### PR TITLE
fix(main): UnicodeDecodeError

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,4 @@ requirements0.txt
 a.txt
 
 *.sh
+.idea

--- a/main.py
+++ b/main.py
@@ -66,7 +66,7 @@ async def read_index(request: Request):
 
     for filename in os.listdir(partials_dir):
         if filename.endswith(".html"):
-            with open(os.path.join(partials_dir, filename), "r") as file:
+            with open(os.path.join(partials_dir, filename), "r", encoding="utf8") as file:
                 partials[filename[:-5]] = file.read()
 
     return templates.TemplateResponse("index.html", {"request": request, **partials})


### PR DESCRIPTION
Origin: `zh-CN`. Requires `utf-8` to render a page

```markdown
 File "T:\_GitHubProjects\Forks\crawl4ai\main.py", line 70, in read_index
    partials[filename[:-5]] = file.read()

UnicodeDecodeError: 'gbk' codec can't decode byte 0xa4 in position 149: illegal multibyte sequence
```

as below:

```diff
- with open(path, "r") as file:
+ with open(path, "r", encoding="utf8") as file:
```

I'm troubleshooting the same problem elsewhere.