### PR TITLE
Remove inline styling tags and merge their contents into their parent elements

### DIFF
--- a/crawl4ai/utils.py
+++ b/crawl4ai/utils.py
@@ -250,6 +250,15 @@ def get_content_of_website(url, html, word_count_threshold = MIN_WORD_THRESHOLD,
         # Replace all "pre" tags with their inner text
         body = replace_pre_tags_with_text(body)
 
+
+        # List of inline styling tags
+        inline_styling_tags = ['b', 'i', 'u', 'span', 'del', 'ins', 'sub', 'sup', 'strong', 'em', 'code', 'kbd', 'var', 's', 'q', 'abbr', 'cite', 'dfn', 'time', 'small', 'mark']
+        # Iterate over each tag and unwrap it
+        for tag in inline_styling_tags:
+            for match in soup.find_all(tag):
+                match.unwrap()
+                
+
         # Recursively remove empty elements, their parent elements, and elements with word count below threshold
         def remove_empty_and_low_word_count_elements(node, word_count_threshold):
             for child in node.contents:


### PR DESCRIPTION
Ref: https://github.com/unclecode/crawl4ai/issues/20

It's a common practice to add inline style tags to text to bold, italicize or change colour of certain words in a paragraph to emphasise them to human readers of a site. However, this is not of any relevance to LLMs, since the words are already in their context.

In crawl4ai `remove_empty_and_low_word_count_elements` is removing these tags altogether and some valuable data is being lost. Therefore we should merge the contents of these tags into their parent elements before this step.