### PR TITLE
Fix UnicodeDecodeError by reading README.md with UTF-8 encoding

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     name="Crawl4AI",
     version="0.2.72",
     description="🔥🕷️ Crawl4AI: Open-source LLM Friendly Web Crawler & Scrapper",
-    long_description=open("README.md").read(),
+    long_description=open("README.md", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
     url="https://github.com/unclecode/crawl4ai",
     author="Unclecode",


### PR DESCRIPTION
This PR addresses an installation error where a UnicodeDecodeError is raised when reading the README.md file. The error occurs because the default encoding is not always UTF-8, which causes issues when the file contains special characters.

Changes Made:

Modified the setup.py file to read README.md with UTF-8 encoding to ensure compatibility across different environments.

- Verified the installation process works correctly after making the change by testing it locally.

Linked Issue:
Fixes #36