### PR TITLE
Adding a parameter to disable SSL verification during crawling

### DIFF
--- a/crawl4ai/async_crawler_strategy.py
+++ b/crawl4ai/async_crawler_strategy.py
@@ -43,6 +43,7 @@ class AsyncPlaywrightCrawlerStrategy(AsyncCrawlerStrategy):
         self.use_cached_html = use_cached_html
         self.user_agent = kwargs.get("user_agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36")
         self.proxy = kwargs.get("proxy")
+        self.ignore_https_errors = kwargs.get("ignore_https_errors", False)
         self.headless = kwargs.get("headless", True)
         self.headers = {}
         self.sessions = {}
@@ -174,6 +175,7 @@ class AsyncPlaywrightCrawlerStrategy(AsyncCrawlerStrategy):
             if not context:
                 context = await self.browser.new_context(
                     user_agent=self.user_agent,
+                    ignore_https_errors=True if self.ignore_https_errors else False,
                     proxy={"server": self.proxy} if self.proxy else None
                 )
                 await context.set_extra_http_headers(self.headers)
@@ -182,6 +184,7 @@ class AsyncPlaywrightCrawlerStrategy(AsyncCrawlerStrategy):
         else:
             context = await self.browser.new_context(
                     user_agent=self.user_agent,
+                    ignore_https_errors=True if self.ignore_https_errors else False,
                     proxy={"server": self.proxy} if self.proxy else None
             )
             await context.set_extra_http_headers(self.headers)
@@ -353,7 +356,7 @@ class AsyncPlaywrightCrawlerStrategy(AsyncCrawlerStrategy):
         return [result if not isinstance(result, Exception) else str(result) for result in results]
 
     async def take_screenshot(self, url: str) -> str:
-        async with await self.browser.new_context(user_agent=self.user_agent) as context:
+        async with await self.browser.new_context(user_agent=self.user_agent, ignore_https_errors=True if self.ignore_https_errors else False) as context:
             page = await context.new_page()
             try:
                 await page.goto(url, wait_until="domcontentloaded")

--- a/tests/async/test_crawler_strategy.py
+++ b/tests/async/test_crawler_strategy.py
@@ -21,6 +21,18 @@ async def test_custom_user_agent():
         assert custom_user_agent in result.html
 
 @pytest.mark.asyncio
+async def test_disabled_ssl_verification():
+    crawler_strategy = AsyncPlaywrightCrawlerStrategy(verbose=True, ignore_https_errors=True)
+    async with AsyncWebCrawler(verbose=True, crawler_strategy=crawler_strategy) as crawler:
+        url = "https://expired.badssl.com/"
+        result = await crawler.arun(url=url, bypass_cache=True)
+        assert result.success
+        assert result.url == url
+        assert result.html
+        assert result.markdown
+        assert result.cleaned_html
+
+@pytest.mark.asyncio
 async def test_custom_headers():
     async with AsyncWebCrawler(verbose=True) as crawler:
         custom_headers = {"X-Test-Header": "TestValue"}


### PR DESCRIPTION
Dears, while building a tool with your wonderful library, I realized there was no support for disabling SSL verification for websites that either use HTTP only or use HTTPS with an invalid certificate. So I added this option in the "AsyncPlaywrightCrawlerStrategy" class. I think this change could benefit a lot of people and prevent breaking certain scripts. I also added a test. Let me know if I should modify anything