### PR TITLE
Created a new hook called "on_page_created" which allows the user to inspect raw HTTP requests/responses, and more

### DIFF
--- a/crawl4ai/async_crawler_strategy.py
+++ b/crawl4ai/async_crawler_strategy.py
@@ -53,6 +53,7 @@ class AsyncPlaywrightCrawlerStrategy(AsyncCrawlerStrategy):
         self.browser = None
         self.hooks = {
             'on_browser_created': None,
+            'on_page_created': None,
             'on_user_agent_updated': None,
             'on_execution_started': None,
             'before_goto': None,
@@ -178,6 +179,7 @@ class AsyncPlaywrightCrawlerStrategy(AsyncCrawlerStrategy):
                 )
                 await context.set_extra_http_headers(self.headers)
                 page = await context.new_page()
+                page = await self.execute_hook('on_page_created', page)
                 self.sessions[session_id] = (context, page, time.time())
         else:
             context = await self.browser.new_context(
@@ -186,6 +188,7 @@ class AsyncPlaywrightCrawlerStrategy(AsyncCrawlerStrategy):
             )
             await context.set_extra_http_headers(self.headers)
             page = await context.new_page()
+            page = await self.execute_hook('on_page_created', page)
 
         try:
             if self.verbose:
@@ -355,6 +358,7 @@ class AsyncPlaywrightCrawlerStrategy(AsyncCrawlerStrategy):
     async def take_screenshot(self, url: str) -> str:
         async with await self.browser.new_context(user_agent=self.user_agent) as context:
             page = await context.new_page()
+            page = await self.execute_hook('on_page_created', page)
             try:
                 await page.goto(url, wait_until="domcontentloaded")
                 screenshot = await page.screenshot(full_page=True)


### PR DESCRIPTION
Dears, while using your library, I needed to access the raw content of requests being sent when a page is crawled (for instance, requests made to other APIs or files, etc.), the responses, and the associated headers. I realized that the easiest way to do this would be to leverage the existing Playwright hook on "Page" objects by using "Page.on()". Thus, I added a hook in the AsyncCrawlerStragegy class to achieve that.

Please let me know if this is actually useless and there is an easier/native way to do this with your library, but I haven't found any.

Cheers