### PR TITLE
Add proxy functionality to AsyncWebCrawler and AsyncPlaywrightCrawler

### DIFF
--- a/crawl4ai/async_crawler_strategy.py
+++ b/crawl4ai/async_crawler_strategy.py
@@ -59,6 +59,7 @@ class AsyncPlaywrightCrawlerStrategy(AsyncCrawlerStrategy):
             'after_goto': None,
             'before_return_html': None
         }
+        self.proxy = kwargs.get("proxy")
 
     async def __aenter__(self):
         await self.start()
@@ -73,7 +74,6 @@ class AsyncPlaywrightCrawlerStrategy(AsyncCrawlerStrategy):
         if self.browser is None:
             browser_args = {
                 "headless": self.headless,
-                # "headless": False,
                 "args": [
                     "--disable-gpu",
                     "--disable-dev-shm-usage",
@@ -84,9 +84,8 @@ class AsyncPlaywrightCrawlerStrategy(AsyncCrawlerStrategy):
             
             # Add proxy settings if a proxy is specified
             if self.proxy:
-                proxy_settings = ProxySettings(server=self.proxy)
+                proxy_settings = {"server": self.proxy}
                 browser_args["proxy"] = proxy_settings
-                
                 
             self.browser = await self.playwright.chromium.launch(**browser_args)
             await self.execute_hook('on_browser_created', self.browser)

--- a/crawl4ai/async_webcrawler.py
+++ b/crawl4ai/async_webcrawler.py
@@ -24,9 +24,12 @@ class AsyncWebCrawler:
         crawler_strategy: Optional[AsyncCrawlerStrategy] = None,
         always_by_pass_cache: bool = False,
         verbose: bool = False,
+        proxy: Optional[str] = None,
     ):
+        self.proxy = proxy  
         self.crawler_strategy = crawler_strategy or AsyncPlaywrightCrawlerStrategy(
-            verbose=verbose
+            verbose=verbose,
+            proxy=self.proxy
         )
         self.always_by_pass_cache = always_by_pass_cache
         self.crawl4ai_folder = os.path.join(Path.home(), ".crawl4ai")


### PR DESCRIPTION
This PR adds proxy functionality to the AsyncWebCrawler and AsyncPlaywrightCrawlerStrategy classes.

Linked Issue: #116 

- Modified AsyncWebCrawler to accept a `proxy` parameter.
- Updated AsyncPlaywrightCrawlerStrategy to handle proxy settings when launching the browser.
- Added usage example in the documentation.

This allows users to specify a proxy server for crawling, which can be useful for accessing content behind firewalls.