### PR TITLE
docs: fixed css_selector for example

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ async def main():
         result = await crawler.arun(
             url="https://www.nbcnews.com/business",
             js_code=js_code,
-            css_selector="article.tease-card",
+            css_selector=".wide-tease-item__description",
             bypass_cache=True
         )
         print(result.extracted_content)


### PR DESCRIPTION
# Fix CSS selector in README example

## Description
This pull request updates the CSS selector in the Advanced Usage example in the README.md file. The change fixes a non-functioning example and ensures that the crawler can successfully extract content from the NBC News business page.

The previous selector `"article.tease-card"` was not functioning correctly and failed to extract any data from the NBC News business page. The new selector `.wide-tease-item__description` successfully targets the description text of the news articles, allowing the crawler to extract the intended content.

## Changes
- Updated the `css_selector` parameter in the `crawler.arun()` method from `"article.tease-card"` to `".wide-tease-item__description"`.