### PR TITLE
fix: screenshot were not saved into AsyncCrawlResponse

### DIFF
--- a/crawl4ai/async_crawler_strategy.py
+++ b/crawl4ai/async_crawler_strategy.py
@@ -312,7 +312,12 @@ class AsyncPlaywrightCrawlerStrategy(AsyncCrawlerStrategy):
                         "status_code": status_code
                     }, f)
 
-            response = AsyncCrawlResponse(html=html, response_headers=response_headers, status_code=status_code)
+            if kwargs.get("screenshot", False):
+                screenshot_data = await self.take_screenshot(url)
+
+            response = AsyncCrawlResponse(
+                html=html, response_headers=response_headers, status_code=status_code, screenshot=screenshot_data
+            )
             return response
         except Error as e:
             raise Error(f"Failed to crawl {url}: {str(e)}")


### PR DESCRIPTION
### Description
This pull request addresses an issue where the screenshot functionality in AsyncWebCrawler is not working as expected, leading to an assertion error.

### Issue
When using the sample code to run the crawler with screenshot=True, an AssertionError is raised because the result.screenshot is None:

#### Sample Code:
```python
async with AsyncWebCrawler(verbose=False) as crawler:
    result = await crawler.arun(url="https://example.com", screenshot=True, bypass_cache=True)

    assert result.success is True
    assert result.screenshot is not None, "Screenshot is None"
```

#### Output
```python
    assert result.screenshot is not None, "Screenshot is None"
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: Screenshot is None
```