### PR TITLE
fix requests version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ numpy>=1.26.0,<2.1.1
 pillow==10.4.0
 playwright==1.47.0
 python-dotenv==1.0.1
-requests>=2.26.0,<2.32.3
+requests>=2.26.0,<=2.32.3
 beautifulsoup4==4.12.3


### PR DESCRIPTION
change the `requests>=2.26.0,<2.32.3` to `requests>=2.26.0,<=2.32.3`  in requirements.txt

the previous version of requirements.txt is `requests==2.32.3`, so `<=2.32.3` is more precise?

https://github.com/unclecode/crawl4ai/commit/bccadec887214f33991ddebca9db2c18555c200a#diff-4d7c51b1efe9043e44439a949dfd92e5827321b34082903477fd04876edb7552L9

![image](https://github.com/user-attachments/assets/81df79b7-0c0c-4360-861c-f317ea80e710)
