### PR TITLE
Update screenshot handling to include customizable wait time

### DIFF
--- a/crawl4ai/async_crawler_strategy.py
+++ b/crawl4ai/async_crawler_strategy.py
@@ -352,7 +352,7 @@ class AsyncPlaywrightCrawlerStrategy(AsyncCrawlerStrategy):
             # Check if kwargs has screenshot=True then take screenshot
             screenshot_data = None
             if kwargs.get("screenshot"):
-                screenshot_data = await self.take_screenshot(url)
+                screenshot_data = await self.take_screenshot(url, wait_time=kwargs.get("screenshot_wait_time", 1000))
             
             
             # New code to update image dimensions


### PR DESCRIPTION
This pull request includes a small but important change to the `crawl4ai/async_crawler_strategy.py` file. The change involves modifying the `crawl` method to allow for an optional wait time before taking a screenshot.

* [`crawl4ai/async_crawler_strategy.py`](diffhunk://#diff-ede9fd3357068d6fca3803250d507a6816ed8476e6fa71990948bcedb1c460fbL355-R355): Updated the `crawl` method to accept an optional `screenshot_wait_time` parameter, which specifies the wait time before taking a screenshot.