### PR TITLE
Fix #260 prevent pass duplicated kwargs to scrapping_strategy

### DIFF
--- a/crawl4ai/async_webcrawler.py
+++ b/crawl4ai/async_webcrawler.py
@@ -197,8 +197,8 @@ class AsyncWebCrawler:
                 html,
                 word_count_threshold=word_count_threshold,
                 css_selector=css_selector,
-                only_text=kwargs.get("only_text", False),
-                image_description_min_word_threshold=kwargs.get(
+                only_text=kwargs.pop("only_text", False),
+                image_description_min_word_threshold=kwargs.pop(
                     "image_description_min_word_threshold", IMAGE_DESCRIPTION_MIN_WORD_THRESHOLD
                 ),
                 **kwargs,


### PR DESCRIPTION
This pull request includes a change to the `crawl4ai/async_webcrawler.py` file, specifically modifying the `aprocess_html` function to use the `pop` method for extracting keyword arguments instead of the `get` method.

Codebase simplification:

* [`crawl4ai/async_webcrawler.py`](diffhunk://#diff-4615044bdaa338cb6b9bbb86d0ae9831b2695d86d50e65995c43aa2dd49bfddaL200-R201): Changed the `aprocess_html` function to use `kwargs.pop` instead of `kwargs.get` for `only_text` and `image_description_min_word_threshold`. This ensures that these keyword arguments are removed from `kwargs` after being accessed to prevent pass duplicated kwargs to scrapping_strategy.