### PR TITLE
Adding save to HF support for async webcrawler

### DIFF
--- a/crawl4ai/async_configs.py
+++ b/crawl4ai/async_configs.py
@@ -8,6 +8,7 @@ from .user_agent_generator import UserAgentGenerator
 from .extraction_strategy import ExtractionStrategy
 from .chunking_strategy import ChunkingStrategy
 from .markdown_generation_strategy import MarkdownGenerationStrategy
+from .data_persistence_strategy import DataPersistenceStrategy, SkipDataPersistenceStrategy
 
 class BrowserConfig:
     """
@@ -188,6 +189,7 @@ class CrawlerRunConfig:
                                                           Default: None (NoExtractionStrategy is used if None).
         chunking_strategy (ChunkingStrategy): Strategy to chunk content before extraction.
                                               Default: RegexChunking().
+        data_persistence_strategy (DataPersistenceStrategy): Strategy for storing the results. Defaults to SkipDataPersistenceStrategy.
         content_filter (RelevantContentFilter or None): Optional filter to prune irrelevant content.
                                                         Default: None.
         cache_mode (CacheMode or None): Defines how caching is handled.
@@ -268,11 +270,12 @@ class CrawlerRunConfig:
     def __init__(
         self,
         word_count_threshold: int =  MIN_WORD_THRESHOLD ,
-        extraction_strategy : ExtractionStrategy=None,  # Will default to NoExtractionStrategy if None
-        chunking_strategy : ChunkingStrategy= None,    # Will default to RegexChunking if None
+        extraction_strategy : ExtractionStrategy = None,  # Will default to NoExtractionStrategy if None
+        chunking_strategy : ChunkingStrategy = None,    # Will default to RegexChunking if None
+        data_persistence_strategy: DataPersistenceStrategy = SkipDataPersistenceStrategy(),
         markdown_generator : MarkdownGenerationStrategy = None,
-        content_filter=None,
-        cache_mode=None,
+        content_filter = None,
+        cache_mode = None,
         session_id: str = None,
         bypass_cache: bool = False,
         disable_cache: bool = False,
@@ -285,7 +288,7 @@ class CrawlerRunConfig:
         only_text: bool = False,
         image_description_min_word_threshold: int = IMAGE_DESCRIPTION_MIN_WORD_THRESHOLD,
         prettiify: bool = False,
-        js_code=None,
+        js_code = None,
         wait_for: str = None,
         js_only: bool = False,
         wait_until: str = "domcontentloaded",
@@ -311,6 +314,7 @@ class CrawlerRunConfig:
         self.word_count_threshold = word_count_threshold
         self.extraction_strategy = extraction_strategy
         self.chunking_strategy = chunking_strategy
+        self.data_persistence_strategy = data_persistence_strategy
         self.markdown_generator = markdown_generator
         self.content_filter = content_filter
         self.cache_mode = cache_mode
@@ -354,7 +358,9 @@ class CrawlerRunConfig:
             raise ValueError("extraction_strategy must be an instance of ExtractionStrategy")
         if self.chunking_strategy is not None and not isinstance(self.chunking_strategy, ChunkingStrategy):
             raise ValueError("chunking_strategy must be an instance of ChunkingStrategy")
-
+        if self.data_persistence_strategy is not None and not isinstance(data_persistence_strategy, DataPersistenceStrategy):
+            raise ValueError("data_persistence_strategy must be an instance of DataPersistenceStrategy")
+            
         # Set default chunking strategy if None
         if self.chunking_strategy is None:
             from .chunking_strategy import RegexChunking
@@ -367,6 +373,7 @@ class CrawlerRunConfig:
             word_count_threshold=kwargs.get("word_count_threshold", 200),
             extraction_strategy=kwargs.get("extraction_strategy"),
             chunking_strategy=kwargs.get("chunking_strategy"),
+            data_persistence_strategy=kwargs.get("data_persistence_strategy"),
             markdown_generator=kwargs.get("markdown_generator"),
             content_filter=kwargs.get("content_filter"),
             cache_mode=kwargs.get("cache_mode"),

--- a/crawl4ai/data_persistence_strategy.py
+++ b/crawl4ai/data_persistence_strategy.py
@@ -1,0 +1,152 @@
+from abc import ABC, abstractmethod
+from .models import CrawlResult
+import json
+import re
+from datasets import Dataset
+from huggingface_hub import DatasetCard
+from typing import Any
+
+
+class DataPersistenceStrategy(ABC):
+    """
+    Abstract base class for implementing data persistence strategies.
+    """
+
+    @abstractmethod
+    def save(self, result: CrawlResult) -> dict[str, Any]:
+        """
+        Save the given crawl result using a specific persistence strategy.
+
+        Args:
+            result (CrawlResult): The crawl result containing data to persist.
+
+        Returns:
+            dict[str, Any]: A dictionary representing the outcome details of the persistence operation.
+        """
+        pass
+
+
+class SkipDataPersistenceStrategy(DataPersistenceStrategy):
+    def save(self, result: CrawlResult) -> dict[str, Any]:
+        return None
+
+
+DATASET_CARD_TEMPLATE = """
+---
+tags:
+- crawl4ai
+- crawl
+---
+
+**Source of the data:**
+
+The dataset was generated using [Crawl4ai](https://crawl4ai.com/mkdocs/) library from {url}.
+
+"""
+
+
+class HFDataPersistenceStrategy(DataPersistenceStrategy):
+    """
+    A persistence strategy for uploading extracted content or markdown from crawl results to the Hugging Face Hub.
+
+    This strategy converts the extracted content or markdown into a Hugging Face Dataset
+    and uploads it to a specified repository on the Hub.
+
+    Args:
+        repo_id (str): The repository ID on the Hugging Face Hub.
+        private (bool): Whether the repository should be private.
+        card (str, optional): The card information for the dataset. Defaults to None.
+        token (str, optional): The authentication token for the Hugging Face Hub. Defaults to None.
+        logger (Logger, optional): Logger instance for logging messages. Defaults to None.
+        **kwargs: Additional keyword arguments.
+    """
+
+    def __init__(
+        self, repo_id: str, private: bool, card: str = None, token=None, **kwargs
+    ):
+        self.repo_id = repo_id
+        self.private = private
+        self.card = card
+        self.verbose = kwargs.get("verbose", False)
+        self.token = token
+
+    def save(self, result: CrawlResult) -> dict[str, Any]:
+        """
+        Uploads extracted content or markdown from the given crawl result to the Hugging Face Hub.
+
+        Args:
+            result (CrawlResult): The crawl result containing extracted content or markdown to upload.
+
+        Returns:
+            dict[str, Any]: A dictionary with the repository ID and dataset split name.
+
+        Raises:
+            ValueError: If neither extracted content nor markdown is present in the result.
+            TypeError: If extracted content or markdown is not a string.
+
+        Notes:
+            - Extracted content should be a JSON string containing a list of dictionaries.
+            - If extracted content is invalid, raw markdown will be used as a fallback.
+            - The repository ID and dataset split name are returned upon successful upload.
+        """
+        if not (result.extracted_content or result.markdown):
+            raise ValueError("No extracted content or markdown present.")
+
+        if result.extracted_content and not isinstance(result.extracted_content, str):
+            raise TypeError("Extracted content must be a string.")
+
+        if result.markdown and not isinstance(result.markdown, str):
+            raise TypeError("Markdown must be a string.")
+
+        records = self._prepare_records(result)
+
+        if self.verbose:
+            print(
+                f"[LOG] 🔄 Successfully converted extracted content to JSON records: {len(records)} records found"
+            )
+
+        ds = Dataset.from_list(records)
+        sanitized_split_name = re.sub(r"[^a-zA-Z0-9_]", "_", result.url)
+        commit_info = ds.push_to_hub(
+            repo_id=self.repo_id,
+            private=self.private,
+            token=self.token,
+            split=sanitized_split_name,
+        )
+
+        repo_id = commit_info.repo_url.repo_id
+        self._push_dataset_card(repo_id, result.url)
+
+        if self.verbose:
+            print(
+                f"[LOG] ✅ Data has been successfully pushed to the Hugging Face Hub. Repository ID: {repo_id}"
+            )
+
+        return {"repo_id": repo_id, "split": sanitized_split_name}
+
+    def _prepare_records(self, result: CrawlResult) -> list[dict[str, Any]]:
+        if result.extracted_content:
+            try:
+                records = json.loads(result.extracted_content)
+                if not isinstance(records, list) or not all(
+                    isinstance(rec, dict) for rec in records
+                ):
+                    raise ValueError(
+                        "Extracted content must be a JSON list of dictionaries."
+                    )
+            except json.JSONDecodeError as e:
+                if self.verbose:
+                    print(f"[LOG] ⚠️ Failed to parse extracted content as JSON: {e}")
+                records = [{"extracted_content": result.extracted_content}]
+        else:
+            records = [{"markdown": result.markdown}]
+
+        return records
+
+    def _push_dataset_card(self, repo_id: str, url: str) -> None:
+        card_content = self.card or DATASET_CARD_TEMPLATE.format(url=url)
+        DatasetCard(content=card_content).push_to_hub(
+            repo_id=repo_id, repo_type="dataset", token=self.token
+        )
+        if self.verbose:
+            print(f"[LOG] 🔄 Dataset card successfully pushed to repository: {repo_id}")

--- a/crawl4ai/models.py
+++ b/crawl4ai/models.py
@@ -34,6 +34,7 @@ class CrawlResult(BaseModel):
     session_id: Optional[str] = None
     response_headers: Optional[dict] = None
     status_code: Optional[int] = None
+    storage_metadata: Optional[dict] = None
     
 class AsyncCrawlResponse(BaseModel):
     html: str

--- a/docs/examples/async_webcrawler_md_to_hf.py
+++ b/docs/examples/async_webcrawler_md_to_hf.py
@@ -1,0 +1,22 @@
+import asyncio
+from crawl4ai import AsyncWebCrawler
+from crawl4ai.data_persistence_strategy import HFDataPersistenceStrategy
+
+
+async def main():
+    async with AsyncWebCrawler(verbose=True) as crawler:
+        persistence_strategy = HFDataPersistenceStrategy(
+            repo_id="crawl4ai_hf_page_md", private=False, verbose=True
+        )
+
+        result = await crawler.arun(
+            url="https://huggingface.co/",
+            data_persistence_strategy=persistence_strategy,
+        )
+
+        print(f"Successfully crawled markdown: {result.markdown}")
+        print(f"Persistence details: {result.storage_metadata}")
+
+
+# Run the async main function
+asyncio.run(main())

--- a/docs/examples/async_webcrawler_structured_to_hf.py
+++ b/docs/examples/async_webcrawler_structured_to_hf.py
@@ -1,0 +1,67 @@
+import os
+import sys
+import asyncio
+from crawl4ai.extraction_strategy import JsonCssExtractionStrategy
+from crawl4ai.data_persistence_strategy import HFDataPersistenceStrategy
+
+# Add the parent directory to the Python path
+parent_dir = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+)
+sys.path.append(parent_dir)
+
+from crawl4ai.async_webcrawler import AsyncWebCrawler
+
+
+async def main():
+    async with AsyncWebCrawler(verbose=True) as crawler:
+        url = "https://www.nbcnews.com/business"
+        schema = {
+            "name": "News Teaser Extractor",
+            "baseSelector": ".wide-tease-item__wrapper",
+            "fields": [
+                {
+                    "name": "category",
+                    "selector": ".unibrow span[data-testid='unibrow-text']",
+                    "type": "text",
+                },
+                {
+                    "name": "headline",
+                    "selector": ".wide-tease-item__headline",
+                    "type": "text",
+                },
+                {
+                    "name": "summary",
+                    "selector": ".wide-tease-item__description",
+                    "type": "text",
+                },
+                {
+                    "name": "link",
+                    "selector": "a[href]",
+                    "type": "attribute",
+                    "attribute": "href",
+                },
+            ],
+        }
+
+        extraction_strategy = JsonCssExtractionStrategy(schema, verbose=True)
+        persistence_strategy = HFDataPersistenceStrategy(
+            repo_id="crawl4ai_nbcnews_structured", private=False, verbose=True
+        )
+
+        result = await crawler.arun(
+            url=url,
+            bypass_cache=True,
+            extraction_strategy=extraction_strategy,
+            data_persistence_strategy=persistence_strategy,
+        )
+        if result.success:
+            print(f"Successfully crawled: {result.url}")
+            print(f"Persistence details: {result.storage_metadata}")
+        else:
+            print(f"Failed to crawl: {result.url}")
+            print(f"Error: {result.error_message}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ aiofiles>=24.1.0
 colorama~=0.4
 snowballstemmer~=2.2
 pydantic>=2.10
+datasets~=3.1.0

--- a/tests/async/test_data_persistance_strategy.py
+++ b/tests/async/test_data_persistance_strategy.py
@@ -1,0 +1,93 @@
+import os
+import sys
+import pytest
+from datasets import load_dataset
+from crawl4ai.extraction_strategy import JsonCssExtractionStrategy
+from crawl4ai.data_persistence_strategy import HFDataPersistenceStrategy
+
+# Add the parent directory to the Python path
+parent_dir = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+)
+sys.path.append(parent_dir)
+
+from crawl4ai.async_webcrawler import AsyncWebCrawler
+
+
+@pytest.mark.asyncio
+async def test_save_with_unsupported_data_persistence_strategy():
+    async with AsyncWebCrawler(verbose=True) as crawler:
+        url = "https://www.nbcnews.com/business"
+        unsupported_data_persistence_strategy = JsonCssExtractionStrategy({})
+
+        result = await crawler.arun(
+            url=url,
+            bypass_cache=True,
+            data_persistence_strategy=unsupported_data_persistence_strategy,
+        )
+        assert not result.success
+        assert result.url == url
+        assert not result.html
+        assert "data_persistence_strategy must be an instance of DataPersistenceStrategy" in result.error_message
+        assert result.storage_metadata is None
+
+
+@pytest.mark.asyncio
+async def test_save_to_hf():
+    async with AsyncWebCrawler(verbose=True) as crawler:
+        url = "https://www.nbcnews.com/business"
+        schema = {
+            "name": "News Teaser Extractor",
+            "baseSelector": ".wide-tease-item__wrapper",
+            "fields": [
+                {
+                    "name": "category",
+                    "selector": ".unibrow span[data-testid='unibrow-text']",
+                    "type": "text",
+                },
+                {
+                    "name": "headline",
+                    "selector": ".wide-tease-item__headline",
+                    "type": "text",
+                },
+                {
+                    "name": "summary",
+                    "selector": ".wide-tease-item__description",
+                    "type": "text",
+                },
+                {
+                    "name": "link",
+                    "selector": "a[href]",
+                    "type": "attribute",
+                    "attribute": "href",
+                },
+            ],
+        }
+
+        extraction_strategy = JsonCssExtractionStrategy(schema, verbose=True)
+        repo_id = "test_repo"
+        data_persistence_strategy = HFDataPersistenceStrategy(
+            repo_id=repo_id, private=False, verbose=True
+        )
+
+        result = await crawler.arun(
+            url=url,
+            bypass_cache=True,
+            extraction_strategy=extraction_strategy,
+            data_persistence_strategy=data_persistence_strategy,
+        )
+        assert result.success
+        assert result.url == url
+        assert result.html
+        assert result.markdown
+        assert result.cleaned_html
+        assert result.storage_metadata
+        assert result.storage_metadata["split"] == "https___www_nbcnews_com_business"
+        created_repo_id = result.storage_metadata["repo_id"]
+        new_dataset = load_dataset(created_repo_id, split="train")
+        assert len(new_dataset) > 0
+
+
+# Entry point for debugging
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
This pull request addresses https://github.com/unclecode/crawl4ai/issues/257. It introduces a persistence strategy layer to the project, allowing for more flexible data storage options.

Key changes:

- Added an abstract `DataPersistenceStrategy` class for defining various persistence strategies.
- Implemented `HFDataPersistenceStrategy`, a concrete strategy for pushing data to a Hugging Face dataset.
With this update, data extracted via the crawl process can now be seamlessly uploaded to the Hugging Face Hub as datasets, enhancing data sharing and accessibility.
Once this PR is adopted by the community, it will be easy to filter all datasets created using the crawl4ai library by visiting https://huggingface.co/datasets?other=crawl4ai