### PR TITLE
Feature: Support catch ssl certificate on crawling For #368

### DIFF
--- a/crawl4ai/async_configs.py
+++ b/crawl4ai/async_configs.py
@@ -208,6 +208,8 @@ class CrawlerRunConfig:
                                Default: False.
         css_selector (str or None): CSS selector to extract a specific portion of the page.
                                     Default: None.
+        catch_ssl_certificate (bool): Whether to take the ssl certificate on crawling.
+                           Default: False.
         screenshot (bool): Whether to take a screenshot after crawling.
                            Default: False.
         pdf (bool): Whether to generate a PDF of the page.
@@ -279,6 +281,7 @@ class CrawlerRunConfig:
         no_cache_read: bool = False,
         no_cache_write: bool = False,
         css_selector: str = None,
+        catch_ssl_certificate: bool = False,
         screenshot: bool = False,
         pdf: bool = False,
         verbose: bool = True,
@@ -320,6 +323,7 @@ class CrawlerRunConfig:
         self.no_cache_read = no_cache_read
         self.no_cache_write = no_cache_write
         self.css_selector = css_selector
+        self.catch_ssl_certificate = catch_ssl_certificate
         self.screenshot = screenshot
         self.pdf = pdf
         self.verbose = verbose
@@ -376,6 +380,7 @@ class CrawlerRunConfig:
             no_cache_read=kwargs.get("no_cache_read", False),
             no_cache_write=kwargs.get("no_cache_write", False),
             css_selector=kwargs.get("css_selector"),
+            catch_ssl_certificate=kwargs.get("catch_ssl_certificate", False),
             screenshot=kwargs.get("screenshot", False),
             pdf=kwargs.get("pdf", False),
             verbose=kwargs.get("verbose", True),

--- a/crawl4ai/async_crawler_strategy.py
+++ b/crawl4ai/async_crawler_strategy.py
@@ -731,6 +731,7 @@ class AsyncPlaywrightCrawlerStrategy(AsyncCrawlerStrategy):
             AsyncCrawlResponse: The response containing HTML, headers, status code, and optional data
         """
         response_headers = {}
+        ssl_certificate = None
         status_code = None
         
         # Reset downloaded files list for new crawl
@@ -791,9 +792,12 @@ class AsyncPlaywrightCrawlerStrategy(AsyncCrawlerStrategy):
                 
                 status_code = response.status
                 response_headers = response.headers
+                if config.catch_ssl_certificate:
+                    ssl_certificate = await response.security_details()
             else:
                 status_code = 200
                 response_headers = {}
+                ssl_certificate = None
 
             # Wait for body element and visibility
             try:
@@ -969,6 +973,7 @@ class AsyncPlaywrightCrawlerStrategy(AsyncCrawlerStrategy):
             return AsyncCrawlResponse(
                 html=html,
                 response_headers=response_headers,
+                ssl_certificate=ssl_certificate,
                 status_code=status_code,
                 screenshot=screenshot_data,
                 pdf_data=pdf_data,

--- a/crawl4ai/async_webcrawler.py
+++ b/crawl4ai/async_webcrawler.py
@@ -328,6 +328,7 @@ class AsyncWebCrawler:
                     if async_response:
                         crawl_result.status_code = async_response.status_code
                         crawl_result.response_headers = async_response.response_headers
+                        crawl_result.ssl_certificate = async_response.ssl_certificate
                         crawl_result.downloaded_files = async_response.downloaded_files
                     else:
                         crawl_result.status_code = 200

--- a/crawl4ai/models.py
+++ b/crawl4ai/models.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel, HttpUrl
 from typing import List, Dict, Optional, Callable, Awaitable, Union
+from typing_extensions import TypedDict
 
 
 
@@ -13,6 +14,13 @@ class MarkdownGenerationResult(BaseModel):
     references_markdown: str
     fit_markdown: Optional[str] = None
     fit_html: Optional[str] = None
+
+class SecurityDetails(TypedDict):
+    issuer: Optional[str]
+    protocol: Optional[str]
+    subjectName: Optional[str]
+    validFrom: Optional[float]
+    validTo: Optional[float]
 
 class CrawlResult(BaseModel):
     url: str
@@ -33,12 +41,15 @@ class CrawlResult(BaseModel):
     error_message: Optional[str] = None
     session_id: Optional[str] = None
     response_headers: Optional[dict] = None
+    ssl_certificate: Optional[SecurityDetails] = None
     status_code: Optional[int] = None
-    
+
+
 class AsyncCrawlResponse(BaseModel):
     html: str
     response_headers: Dict[str, str]
     status_code: int
+    ssl_certificate: Optional[SecurityDetails] = None
     screenshot: Optional[str] = None
     pdf_data: Optional[bytes] = None
     get_delayed_content: Optional[Callable[[Optional[float]], Awaitable[str]]] = None


### PR DESCRIPTION
relative issue: #368 

Supports setting the `catch_ssl_certificate` parameter to determine whether or not to obtain an ssl certificate.
```
def get_sync_result(url):
    # Submit a crawl job
    response = requests.post(
        "http://127.0.0.1:11235/crawl_direct",
        headers= {
                "Authorization": "Bearer test_api_code"
        },
        json={
                "urls": url,
                "priority": 10,
                "magic": True,
                "extra": {
                        "page_timeout": 10000,
                        "scan_full_page": True,
                        # catch the ssl certificate
                        "catch_ssl_certificate": True,
                        },
                "cache_mode": "disabled",
                }
    )
    if response.status_code == 200:
        return response.json()
    else:
        print(response.status_code, response.text)
        return None
```
The response is as follows
```
...
'ssl_certificate': {'issuer': 'Amazon RSA 2048 M02', 'protocol': 'TLS 1.2', 'subjectName': 'httpbin.org', 'validFrom': 1724112000.0, 'validTo': 1758153599.0},
...
```