### PR TITLE
fix: not working long page screenshot

### DIFF
--- a/crawl4ai/async_crawler_strategy.py
+++ b/crawl4ai/async_crawler_strategy.py
@@ -1639,11 +1639,9 @@ class AsyncPlaywrightCrawlerStrategy(AsyncCrawlerStrategy):
         Returns:
             str: The base64-encoded screenshot data
         """
-        dimensions = await self.get_page_dimensions(page)
-        page_height = dimensions['height']        
-        if page_height < kwargs.get(
-            "screenshot_height_threshold", SCREENSHOT_HEIGHT_TRESHOLD
-        ):
+        need_scroll = await self.page_need_scroll(page)
+        
+        if not need_scroll:
             # Page is short enough, just take a screenshot
             return await self.take_screenshot_naive(page)
         else:
@@ -2157,5 +2155,23 @@ class AsyncPlaywrightCrawlerStrategy(AsyncCrawlerStrategy):
             () => {
                 const {scrollWidth, scrollHeight} = document.documentElement;
                 return {width: scrollWidth, height: scrollHeight};
+            }
+        """)
+    
+    async def page_need_scroll(self, page: Page):
+        """
+        Determine whether the page need to scroll
+        
+        Args:
+            page: Playwright page object
+            
+        Returns:
+            page should scroll or not
+        """
+        return await page.evaluate("""
+            () => {
+                const scrollHeight = document.documentElement.scrollHeight;
+                const viewportHeight = window.innerHeight;
+                return scrollHeight > viewportHeight;
             }
         """)


### PR DESCRIPTION
Bug fix for long page screenshot.

**Error:**

The fixed `SCREENSHOT_HEIGHT_TRESHOLD` (default 10000) was too large, preventing scrolling for most pages. This resulted in only single viewport screenshots instead of full-page captures.

**Fix:**

Replaced the threshold check with a comparison of `scrollHeight` and `viewportHeight`. Scrolling now occurs when `scrollHeight` exceeds `viewportHeight`, ensuring full-page screenshots.