### PR TITLE
chore: add py.typed file

### DIFF
--- a/crawl4ai/py.typed
+++ b/crawl4ai/py.typed
@@ -1,0 +1,1 @@
+# PEP-0561 typing sentinel, see: https://peps.python.org/pep-0561/

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     license="MIT",
     packages=find_packages(),
     package_data={
-        'crawl4ai': ['js_snippet/*.js']
+        'crawl4ai': ['js_snippet/*.js', 'py.typed']
     },
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
This PR adds the missing `py.typed` file. Without this file the library is considered untyped by type checkers.