### PR TITLE
docs: fix wrong words

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -14,7 +14,7 @@ We would like to thank the following people for their contributions to Crawl4AI:
 - [FractalMind](https://github.com/FractalMind) - Created the first official Docker Hub image and fixed Dockerfile errors
 - [ketonkss4](https://github.com/ketonkss4) - Identified Selenium's new capabilities, helping reduce dependencies
 - [jonymusky](https://github.com/jonymusky) - Javascript execution documentation, and wait_for
-- [datehoer](https://github.com/datehoer) - Add browser prxy support
+- [datehoer](https://github.com/datehoer) - Add browser proxy support
 
 ## Pull Requests
 


### PR DESCRIPTION
There are typos in the markdown file. Use this change to correct them.