### PR TITLE
fix: Add newline before pre codeblock start

### DIFF
--- a/crawl4ai/html2text/__init__.py
+++ b/crawl4ai/html2text/__init__.py
@@ -1083,7 +1083,7 @@ class CustomHTML2Text(HTML2Text):
         # Handle pre tags
         if tag == 'pre':
             if start:
-                self.o('```\n')  # Markdown code block start
+                self.o('\n```\n')  # Markdown code block start
                 self.inside_pre = True
             else:
                 self.o('\n```\n')  # Markdown code block end


### PR DESCRIPTION
Sometimes there is additional text before the 'pre' code block begins : 
<img width="649" alt="image" src="https://github.com/user-attachments/assets/36f0dfdd-1878-4f46-8541-6e768740d660" />

This results in a malformed generated markdown: 
<img width="1833" alt="image" src="https://github.com/user-attachments/assets/46e1e463-3dfa-4a08-bfae-2331e8f26d60" />

This just adds a newline before the start of the code block, should be fairly inconsequential. 

New result: 
<img width="1814" alt="image" src="https://github.com/user-attachments/assets/388fe7b7-b020-474d-bdc3-b003b1cde7d9" />

There's another issue with handling whitespaces that are defined like: `<span class="w"> </span>`, seems like the parser is sending the entire content to `handle_data` if the code block is something like 
``` 
<code>
    "python"
    <span class="w"> </span>
    "main.py"
</code>
```
the html will be parsed with `handle_data("pythonmain.py")`, so the whitespace is not preserved. That seems like it would require updating the underlying HTMLParser logic or overriding it so I didn't try to address it myself. Just wanted to raise it in case it wasn't known. 
example: 
<img width="749" alt="image" src="https://github.com/user-attachments/assets/43496b01-8d24-4abc-9488-ea59c1c6c77d" />


