### PR TITLE
fix: "config" for arun_many() is not passing to arun()

### DIFF
--- a/crawl4ai/async_webcrawler.py
+++ b/crawl4ai/async_webcrawler.py
@@ -788,7 +788,7 @@ class AsyncWebCrawler:
                 async with semaphore:
                     return await self.arun(
                         url,
-                        crawler_config=config,  # Pass the entire config object
+                        config=config,  # Pass the entire config object
                         user_agent=user_agent  # Maintain user_agent override capability
                     )
 


### PR DESCRIPTION
I found that the "config" for arun_many() doesn't affect the crawler results.
Then I realized the calling of arun() at arun_many() use the wrong parameter name of "config" to deliver CrawlerRunConfig. 

