### PR TITLE
Fix the missing base directory

### DIFF
--- a/crawl4ai/docs_manager.py
+++ b/crawl4ai/docs_manager.py
@@ -1,3 +1,4 @@
+import os
 import requests
 import shutil
 from pathlib import Path
@@ -6,7 +7,9 @@ from crawl4ai.llmtxt import AsyncLLMTextManager
 
 class DocsManager:
     def __init__(self, logger=None):
-        self.docs_dir = Path.home() / ".crawl4ai" / "docs"
+        base_dir = os.getenv("CRAWL4_AI_BASE_DIRECTORY")
+        home_dir = Path(base_dir) if base_dir else Path.home() / ".crawl4ai"
+        self.docs_dir = home_dir / "docs"
         self.local_docs = Path(__file__).parent.parent / "docs" / "llm.txt"
         self.docs_dir.mkdir(parents=True, exist_ok=True)
         self.logger = logger or AsyncLogger(verbose=True)

--- a/crawl4ai/migrations.py
+++ b/crawl4ai/migrations.py
@@ -141,7 +141,7 @@ async def backup_database(db_path: str) -> str:
 async def run_migration(db_path: Optional[str] = None):
     """Run database migration"""
     if db_path is None:
-        db_path = os.path.join(Path.home(), ".crawl4ai", "crawl4ai.db")
+        db_path = os.path.join(os.getenv("CRAWL4_AI_BASE_DIRECTORY", Path.home()), ".crawl4ai", "crawl4ai.db")
     
     if not os.path.exists(db_path):
         logger.info("No existing database found. Skipping migration.", tag="INIT")

--- a/crawl4ai/version_manager.py
+++ b/crawl4ai/version_manager.py
@@ -6,7 +6,8 @@ from . import __version__
 
 class VersionManager:
     def __init__(self):
-        self.home_dir = Path.home() / ".crawl4ai"
+        base_dir = os.getenv("CRAWL4_AI_BASE_DIRECTORY")
+        self.home_dir = Path(base_dir) if base_dir else Path.home() / ".crawl4ai"
         self.version_file = self.home_dir / "version.txt"
         
     def get_installed_version(self):


### PR DESCRIPTION
Missing the base directory in some places causes issue when using custom CRAWL4_AI_BASE_DIRECTORY. For example it failed to create migrations, get the version or get correct docs directory.