### PR TITLE
Fix relative URL joining #570

### DIFF
--- a/crawl4ai/markdown_generation_strategy.py
+++ b/crawl4ai/markdown_generation_strategy.py
@@ -14,11 +14,6 @@ def fast_urljoin(base: str, url: str) -> str:
     """Fast URL joining for common cases."""
     if url.startswith(("http://", "https://", "mailto:", "//")):
         return url
-    if url.startswith("/"):
-        # Handle absolute paths
-        if base.endswith("/"):
-            return base[:-1] + url
-        return base + url
     return urljoin(base, url)
 
 
@@ -103,6 +98,9 @@ class DefaultMarkdownGenerator(MarkdownGenerationStrategy):
             parts.append(markdown[last_end : match.start()])
             text, url, title = match.groups()
 
+            # Strip <> protection if present
+            url = url.strip('<>')
+
             # Use cached URL if available, otherwise compute and cache
             if base_url and not url.startswith(("http://", "https://", "mailto:")):
                 if url not in url_cache:
@@ -115,7 +113,7 @@ class DefaultMarkdownGenerator(MarkdownGenerationStrategy):
                     desc.append(title)
                 if text and text != title:
                     desc.append(text)
-                link_map[url] = (counter, ": " + " - ".join(desc) if desc else "")
+                link_map[url] = (counter, " : " + " - ".join(desc) if desc else "")
                 counter += 1
 
             num = link_map[url][0]
@@ -132,7 +130,7 @@ class DefaultMarkdownGenerator(MarkdownGenerationStrategy):
         # Pre-build reference strings
         references = ["\n\n## References\n\n"]
         references.extend(
-            f"⟨{num}⟩ {url}{desc}\n"
+            f"⟨{num}⟩ {url}{desc}  \n"
             for url, (num, desc) in sorted(link_map.items(), key=lambda x: x[1][0])
         )
 


### PR DESCRIPTION
## Summary
`Fixes #570` 
Relative url joining has been fixed. The issue was due to incorrect usage of link protection using <> tags.

## List of files changed and why
crawl4ai/html2text.py - 
While parsing the "a" tags in handle_tag method, the url in "href" attr was being protected by surrounding with <> in the opening tag, and then in the closing tag it was joined with base_url. To fix this, the protetion with <> is done after the url is joined with the base_url.
The same process has been done in the o() method.

crawl4ai\markdown_generation_strategy.py -  
In the conversion of links to citations for markdown_v2, we remove the <> symbols from the url if it was protected, then we join the url with base_url. 
Also the fast_urljoin method was modified, since it would join a url incorrectly if the base url included a path eg.  https://docs.crawl4ai.com/core/crawler-result/.


## How Has This Been Tested?
It was tested by generating markdown and markdown_v2 of few urls. 
eg. https://docs.crawl4ai.com/, https://docs.crawl4ai.com/core/crawler-result/
The links in the fixed markups were working as expected.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added/updated unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
