### PR TITLE
(Docs) Fix numbered list end-of-line formatting

### DIFF
--- a/docs/md_v2/advanced/advanced-features.md
+++ b/docs/md_v2/advanced/advanced-features.md
@@ -7,8 +7,8 @@ Crawl4AI offers multiple power-user features that go beyond simple crawling. Thi
 2. **Capturing PDFs & Screenshots**  
 3. **Handling SSL Certificates**  
 4. **Custom Headers**  
-5. **Session Persistence & Local Storage**
-6. **Robots.txt Compliance**
+5. **Session Persistence & Local Storage**  
+6. **Robots.txt Compliance**  
 
 > **Prerequisites**  
 > - You have a basic grasp of [AsyncWebCrawler Basics](../core/simple-crawling.md)  


### PR DESCRIPTION
## Summary
Added the missing "two spaces" to add a line break.

Otherwise, there is no new line in the existing version:
<img width="728" alt="image" src="https://github.com/user-attachments/assets/d54b2f5f-9d6a-400c-b5a4-ece24ca2392f" />

Fixes a small formatting bug, introduced by the commit: d09c611
I didn't create any issues as the bug was too small (and only for documentation).

## How Has This Been Tested?
I checked the "display the rich diff" view below and all looks good.

<img width="779" alt="image" src="https://github.com/user-attachments/assets/f312cbc7-f03b-48c6-afa2-2073a4bc9b7c" />

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation

