### PR TITLE
fix: access downloads_path through browser_config in _handle_download…

### DIFF
--- a/crawl4ai/async_crawler_strategy.py
+++ b/crawl4ai/async_crawler_strategy.py
@@ -1718,7 +1718,7 @@ class AsyncPlaywrightCrawlerStrategy(AsyncCrawlerStrategy):
         """
         try:
             suggested_filename = download.suggested_filename
-            download_path = os.path.join(self.downloads_path, suggested_filename)
+            download_path = os.path.join(self.browser_config.downloads_path, suggested_filename)
 
             self.logger.info(
                 message="Downloading {filename} to {path}",


### PR DESCRIPTION
… method - Fixes #585

## Summary
This PR fixes issue #585 where the AsyncPlaywrightCrawlerStrategy was trying to access downloads_path directly instead of through browser_config. The fix ensures that the downloads_path is properly accessed through the browser configuration object.

Fixes #585

## List of files changed and why
- `crawl4ai/async_crawler_strategy.py` - Changed `self.downloads_path` to `self.browser_config.downloads_path` in `_handle_download` method to fix the attribute access error and maintain proper configuration hierarchy

## How Has This Been Tested?
The fix has been tested with the following scenarios:
1. File downloads with explicitly specified downloads_path in BrowserConfig
2. File downloads with default downloads_path (when not specified in BrowserConfig)
3. Verified that downloaded files are correctly saved to the configured path
4. Tested that the download functionality works end-to-end with the example from the issue:


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (N/A - bug fix with no API changes)
- [x] I have added/updated unit tests that prove my fix is effective or that my feature works (N/A - existing tests cover this functionality)
- [x] New and existing unit tests pass locally with my changes
