### PR TITLE
Fix Markdown Incorrect Spacing #599

### DIFF
--- a/crawl4ai/html2text/__init__.py
+++ b/crawl4ai/html2text/__init__.py
@@ -610,13 +610,22 @@ class HTML2Text(html.parser.HTMLParser):
                         self.o("[" + str(a_props.count) + "]")
 
         if tag == "dl" and start:
-            self.p()
-        if tag == "dt" and not start:
-            self.pbr()
-        if tag == "dd" and start:
-            self.o("    ")
-        if tag == "dd" and not start:
-            self.pbr()
+            self.p()  # Add paragraph break before list starts
+            self.p_p = 0  # Reset paragraph state
+        
+        elif tag == "dt" and start:
+            if self.p_p == 0:  # If not first term
+                self.o("\n\n")  # Add spacing before new term-definition pair
+            self.p_p = 0  # Reset paragraph state
+        
+        elif tag == "dt" and not start:
+            self.o("\n")  # Single newline between term and definition
+        
+        elif tag == "dd" and start:
+            self.o("    ")  # Indent definition
+        
+        elif tag == "dd" and not start:
+            self.p_p = 0
 
         if tag in ["ol", "ul"]:
             # Google Docs create sub lists as top level lists


### PR DESCRIPTION
## Summary
This PR fixes the spacing issues in description lists (dl/dt/dd tags) while preserving anchor link handling and list functionality. The changes improve readability of scraped content by:
- Adding proper paragraph breaks between term-definition pairs
- Maintaining consistent indentation for definitions
- Using paragraph state counter for spacing control

Fixes #599 

## List of files changed and why
- `/crawl4ai/crawl4ai/html2text/__init__.py`
  - Updated description list tag handling to improve spacing and readability
  - Added clarifying comments
  - Preserved existing anchor and list functionality

## How Has This Been Tested?
- Tested with sample Blender documentation page
- Verified proper spacing between term-definition pairs
- Confirmed anchor links still work correctly
- Checked list formatting remains intact

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added/updated unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
