### PR TITLE
Fix `raw://` URL parsing logic

### DIFF
--- a/crawl4ai/async_crawler_strategy.py
+++ b/crawl4ai/async_crawler_strategy.py
@@ -1231,9 +1231,9 @@ class AsyncPlaywrightCrawlerStrategy(AsyncCrawlerStrategy):
                 get_delayed_content=None,
             )
 
-        elif url.startswith("raw:") or url.startswith("raw://"):
+        elif url.startswith("raw:"):
             # Process raw HTML content
-            raw_html = url[4:] if url[:4] == "raw:" else url[7:]
+            raw_html = url[6:] if url.startswith("raw://") else url[4:]
             html = raw_html
             if config.screenshot:
                 screenshot_data = await self._generate_screenshot_from_html(html)

--- a/tests/20241401/test_async_crawler_strategy.py
+++ b/tests/20241401/test_async_crawler_strategy.py
@@ -15,6 +15,24 @@ CRAWL4AI_HOME_DIR = Path(os.path.expanduser("~")).joinpath(".crawl4ai")
 if not CRAWL4AI_HOME_DIR.joinpath("profiles", "test_profile").exists():
     CRAWL4AI_HOME_DIR.joinpath("profiles", "test_profile").mkdir(parents=True)
 
+@pytest.fixture
+def basic_html():
+    return """
+    <html lang="en">
+    <head>
+        <title>Basic HTML</title>
+    </head>
+    <body>
+        <h1>Main Heading</h1>
+        <main>
+            <div class="container">
+                <p>Basic HTML document for testing purposes.</p>
+            </div>
+        </main>
+    </body>
+    </html>
+    """
+
 # Test Config Files
 @pytest.fixture
 def basic_browser_config():
@@ -324,6 +342,13 @@ async def test_stealth_mode(crawler_strategy):
         config
     )
     assert response.status_code == 200
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("prefix", ("raw:", "raw://"))
+async def test_raw_urls(crawler_strategy, basic_html, prefix):
+    url = f"{prefix}{basic_html}"
+    response = await crawler_strategy.crawl(url, CrawlerRunConfig())
+    assert response.html == basic_html
 
 # Error Handling Tests  
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes https://github.com/unclecode/crawl4ai/issues/686

## List of files changed and why

* crawl4ai/async_crawler_strategy.py - To fix the logic that converts raw URLs to raw HTML
* tests/20241401/test_async_crawler_strategy.py - To test the fix

## How Has This Been Tested?

By implementing a parametrized test that calls [AsyncPlaywrightCrawlerStrategy.crawl](https://github.com/unclecode/crawl4ai/blob/main/crawl4ai/async_crawler_strategy.py#L1191-L1250) with a "raw:" and "raw://" URL and checks that the resulting HTML is correct.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added/updated unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
