### PR TITLE
fix(crawler): use redirected URL in HTML processing

### DIFF
--- a/crawl4ai/async_webcrawler.py
+++ b/crawl4ai/async_webcrawler.py
@@ -450,7 +450,7 @@ class AsyncWebCrawler:
 
                     # Process the HTML content
                     crawl_result : CrawlResult = await self.aprocess_html(
-                        url=url,
+                        url=async_response.redirected_url or url,
                         html=html,
                         extracted_content=extracted_content,
                         config=config,  # Pass the config object instead of individual parameters
@@ -461,6 +461,7 @@ class AsyncWebCrawler:
                         **kwargs,
                     )
 
+                    crawl_result.url = url
                     crawl_result.status_code = async_response.status_code
                     crawl_result.redirected_url = async_response.redirected_url or url
                     crawl_result.response_headers = async_response.response_headers


### PR DESCRIPTION
## Summary
Use redirected URL in HTML processing

Fixes #733

## List of files changed and why
* async_webcrawler.py - To pass the redirected_url (if available) to `aprocess_html)

## How Has This Been Tested?

I used the code snippet from the Issue description and compared the output with and without changes.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added/updated unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
