### PR TITLE
Fixed #774 ; Missing End Mark (```) in the Documentation 

### DIFF
--- a/docs/md_v2/api/parameters.md
+++ b/docs/md_v2/api/parameters.md
@@ -267,6 +267,7 @@ async def main():
 
 if __name__ == "__main__":
     asyncio.run(main())
+```
 
 ## 2.4 Compliance & Ethics
 


### PR DESCRIPTION
## Summary
Added the End Mark (```) in the Documentation to fix the Bug 

Fixes: #774 

## List of files changed and why
docs/md_v2/api/parameters.md - To update the Documentation added the End mark (```)

## How Has This Been Tested?
Locally tested with Changes and Working fine 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation