### PR TITLE
fixed arun_many for AsyncHTTPCrawlerStrategy when url list contains m…

### DIFF
--- a/crawl4ai/async_crawler_strategy.py
+++ b/crawl4ai/async_crawler_strategy.py
@@ -28,7 +28,6 @@ import cchardet
 from aiohttp.client import ClientTimeout
 from urllib.parse import urlparse
 from types import MappingProxyType
-import contextlib
 from functools import partial
 
 class AsyncCrawlerStrategy(ABC):
@@ -1678,15 +1677,6 @@ class AsyncHTTPCrawlerStrategy(AsyncCrawlerStrategy):
     async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
         await self.close()
 
-    @contextlib.asynccontextmanager
-    async def _session_context(self):
-        try:
-            if not self._session:
-                await self.start()
-            yield self._session
-        finally:
-            await self.close()
-
     def set_hook(self, hook_type: str, hook_func: Callable) -> None:
         if hook_type in self.hooks:
             self.hooks[hook_type] = partial(self._execute_hook, hook_type, hook_func)
@@ -1763,75 +1753,74 @@ class AsyncHTTPCrawlerStrategy(AsyncCrawlerStrategy):
         url: str, 
         config: CrawlerRunConfig
     ) -> AsyncCrawlResponse:
-        async with self._session_context() as session:
-            timeout = ClientTimeout(
-                total=config.page_timeout or self.DEFAULT_TIMEOUT,
-                connect=10,
-                sock_read=30
-            )
+        timeout = ClientTimeout(
+            total=config.page_timeout or self.DEFAULT_TIMEOUT,
+            connect=10,
+            sock_read=30
+        )
             
-            headers = dict(self._BASE_HEADERS)
-            if self.browser_config.headers:
-                headers.update(self.browser_config.headers)
+        headers = dict(self._BASE_HEADERS)
+        if self.browser_config.headers:
+            headers.update(self.browser_config.headers)
 
-            request_kwargs = {
-                'timeout': timeout,
-                'allow_redirects': self.browser_config.follow_redirects,
-                'ssl': self.browser_config.verify_ssl,
-                'headers': headers
-            }
+        request_kwargs = {
+            'timeout': timeout,
+            'allow_redirects': self.browser_config.follow_redirects,
+            'ssl': self.browser_config.verify_ssl,
+            'headers': headers
+        }
 
-            if self.browser_config.method == "POST":
-                if self.browser_config.data:
-                    request_kwargs['data'] = self.browser_config.data
-                if self.browser_config.json:
-                    request_kwargs['json'] = self.browser_config.json
+        if self.browser_config.method == "POST":
+            if self.browser_config.data:
+                request_kwargs['data'] = self.browser_config.data
+            if self.browser_config.json:
+                request_kwargs['json'] = self.browser_config.json
 
-            await self.hooks['before_request'](url, request_kwargs)
+        await self.hooks['before_request'](url, request_kwargs)
 
-            try:
-                async with session.request(self.browser_config.method, url, **request_kwargs) as response:
-                    content = memoryview(await response.read())
+        try:
+            async with self._session.request(self.browser_config.method, url, **request_kwargs) as response:
+                content = memoryview(await response.read())
                     
-                    if not (200 <= response.status < 300):
-                        raise HTTPStatusError(
-                            response.status,
-                            f"Unexpected status code for {url}"
-                        )
-                    
-                    encoding = response.charset
-                    if not encoding:
-                        encoding = cchardet.detect(content.tobytes())['encoding'] or 'utf-8'                    
-                    
-                    result = AsyncCrawlResponse(
-                        html=content.tobytes().decode(encoding, errors='replace'),
-                        response_headers=dict(response.headers),
-                        status_code=response.status,
-                        redirected_url=str(response.url)
+                if not (200 <= response.status < 300):
+                    raise HTTPStatusError(
+                        response.status,
+                        f"Unexpected status code for {url}"
                     )
                     
-                    await self.hooks['after_request'](result)
-                    return result
+                encoding = response.charset
+                if not encoding:
+                    encoding = cchardet.detect(content.tobytes())['encoding'] or 'utf-8'                    
+                    
+                result = AsyncCrawlResponse(
+                    html=content.tobytes().decode(encoding, errors='replace'),
+                    response_headers=dict(response.headers),
+                    status_code=response.status,
+                    redirected_url=str(response.url)
+                )
+                    
+                await self.hooks['after_request'](result)
+                return result
 
-            except aiohttp.ServerTimeoutError as e:
-                await self.hooks['on_error'](e)
-                raise ConnectionTimeoutError(f"Request timed out: {str(e)}")
+        except aiohttp.ServerTimeoutError as e:
+            await self.hooks['on_error'](e)
+            raise ConnectionTimeoutError(f"Request timed out: {str(e)}")
                 
-            except aiohttp.ClientConnectorError as e:
-                await self.hooks['on_error'](e)
-                raise ConnectionError(f"Connection failed: {str(e)}")
+        except aiohttp.ClientConnectorError as e:
+            await self.hooks['on_error'](e)
+            raise ConnectionError(f"Connection failed: {str(e)}")
                 
-            except aiohttp.ClientError as e:
-                await self.hooks['on_error'](e)
-                raise HTTPCrawlerError(f"HTTP client error: {str(e)}")
+        except aiohttp.ClientError as e:
+            await self.hooks['on_error'](e)
+            raise HTTPCrawlerError(f"HTTP client error: {str(e)}")
             
-            except asyncio.exceptions.TimeoutError as e:
-                await self.hooks['on_error'](e)
-                raise ConnectionTimeoutError(f"Request timed out: {str(e)}")
+        except asyncio.exceptions.TimeoutError as e:
+            await self.hooks['on_error'](e)
+            raise ConnectionTimeoutError(f"Request timed out: {str(e)}")
             
-            except Exception as e:
-                await self.hooks['on_error'](e)
-                raise HTTPCrawlerError(f"HTTP request failed: {str(e)}")
+        except Exception as e:
+            await self.hooks['on_error'](e)
+            raise HTTPCrawlerError(f"HTTP request failed: {str(e)}")
 
     async def crawl(
         self, 

--- a/tests/20241401/test_http_crawler_strategy.py
+++ b/tests/20241401/test_http_crawler_strategy.py
@@ -15,6 +15,7 @@ async def main():
         browser_config=HTTPCrawlerConfig(),
         logger=logger
     )
+    await crawler.start()
     # Test 1: Basic HTTP GET
     print("\n=== Test 1: Basic HTTP GET ===")
     result = await crawler.crawl("https://example.com")

--- a/tests/test_http_crawler.py
+++ b/tests/test_http_crawler.py
@@ -1,0 +1,38 @@
+import asyncio
+import unittest
+from crawl4ai import AsyncWebCrawler, CrawlerRunConfig, HTTPCrawlerConfig
+from crawl4ai.async_crawler_strategy import AsyncHTTPCrawlerStrategy
+
+class TestHttpCrawler(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        http_crawler_config = HTTPCrawlerConfig(
+            method="GET",
+            headers={"User-Agent": "MyCustomBot/1.0"},
+            follow_redirects=True,
+            verify_ssl=True,
+        )
+        self._crawler = AsyncWebCrawler(
+            crawler_strategy=AsyncHTTPCrawlerStrategy(
+                browser_config=http_crawler_config
+            )
+        )
+        await self._crawler.start()
+
+    async def asyncTearDown(self):
+        await self._crawler.close()
+        await asyncio.sleep(0.250)
+
+    async def test_run_many_without_stream(self):
+        config = CrawlerRunConfig(stream=False)
+        results = await self._crawler.arun_many(["https://example.com"] * 3, config=config)
+        for result in results:
+            self.assertTrue(result.success)
+
+    async def test_run_many_with_stream(self):
+        config = CrawlerRunConfig(stream=True)
+        async for result in await self._crawler.arun_many(["https://example.com"] * 3, config=config):
+            self.assertTrue(result.success)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Fixes #794

## List of files changed and why
async_crawler_strategy.py - removed the http client session context manager (only used in _handle_http method) which caused the problem when trying to crawl more than one url with more than one session allowed from the dispatcher (max_session_permit attribute). The problem occured when the context manager closed the session after completing a given task and another task was using this session to do its http request. The http client session lifecycle is already managed by the web crawler using its context manager or using explicit lifecycle management.

## How Has This Been Tested?
Unit tests have been added in a new file 'test_http_crawler.py' to test:

- scenario given in #794 (stream mode off).
- scenario when stream mode is enabled

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added/updated unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
