### PR TITLE
fix(#911): css_selector is not working properly

### DIFF
--- a/crawl4ai/async_crawler_strategy.py
+++ b/crawl4ai/async_crawler_strategy.py
@@ -820,7 +820,11 @@ class AsyncPlaywrightCrawlerStrategy(AsyncCrawlerStrategy):
                     
                     for selector in selectors:
                         try:
-                            content = await page.evaluate(f"document.querySelector('{selector}')?.outerHTML || ''")
+                            content = await page.evaluate(
+                                f"""Array.from(document.querySelectorAll("{selector}"))
+                                    .map(el => el.outerHTML)
+                                    .join('')"""
+                            )
                             html_parts.append(content)
                         except Error as e:
                             print(f"Warning: Could not get content for selector '{selector}': {str(e)}")


### PR DESCRIPTION
## Summary

Fixes #911

## List of files changed and why

- `async_crawler_strategy.py`
   - Use `querySelectorAll` to get all elements matching the selector.
   - Use double quotes to wrap the selector, so the single quotes inside it won't cause problems. Keep the behavior consistent with the previous version.

## How Has This Been Tested?

Tested with following snippets, basically, it's the "Using css_selector" example, with the addition of `b[class='hnname']`.

```py
import asyncio
from crawl4ai import AsyncWebCrawler, CrawlerRunConfig

async def main():
    config = CrawlerRunConfig(
        # e.g., bold title text and first 30 items from Hacker News
        css_selector="b[class='hnname'],.athing:nth-child(-n+30)"
    )
    async with AsyncWebCrawler() as crawler:
        result = await crawler.arun(
            url="https://news.ycombinator.com/newest", 
            config=config
        )
        print("Partial HTML length:", len(result.cleaned_html))
        print(result.cleaned_html)

if __name__ == "__main__":
    asyncio.run(main())
```


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added/updated unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
