### PR TITLE
fix: completion backoff ratelimit

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,20 @@
+import pytest
+from litellm.exceptions import RateLimitError
+
+from crawl4ai.utils import perform_completion_with_backoff
+
+
+def test_perform_completion_with_backoff_rate_limit():
+    with pytest.raises(RateLimitError):
+        perform_completion_with_backoff(
+            provider="openai/gpt-4o",
+            prompt_with_variables="Test prompt",
+            api_token="test_token",
+            extra_args={  # Force the rate limit error.
+                "mock_response": RateLimitError(
+                    message="Rate limit exceeded",
+                    llm_provider="openai",
+                    model="gpt-4o",
+                ),
+            },
+        )


### PR DESCRIPTION
Re-raise RateLimitError if retries are exhausted in perform_completion_with_backoff, which fixes issues with callers requesting usage information when the model is rate limited.

Also eliminate unnecessary catch of Exception and clean up the flow of the function.

Fixes: #989

## How Has This Been Tested?
Added a new test and ran against full suite pending on #891

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added/updated unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
