### PR TITLE
Fix: Local HTML Files crawling bug

### DIFF
--- a/crawl4ai/async_crawler_strategy.py
+++ b/crawl4ai/async_crawler_strategy.py
@@ -440,7 +440,8 @@ class AsyncPlaywrightCrawlerStrategy(AsyncCrawlerStrategy):
         response_headers = {}
         status_code = 200  # Default for local/raw HTML
         screenshot_data = None
-
+        captured_console = []
+        
         if url.startswith(("http://", "https://")):
             return await self._crawl_web(url, config)
 


### PR DESCRIPTION


## Summary
This PR will fix the Issue Fixes #1072  due to which the users are not able to scrape a local html files.


## List of files changed and why
async_crawler_strategy.py -- Because inside the crawl() function on line number 421, there is elif condition on 448 which deals with file:// path url and captured_console variable is reached only when the capture_console_messages is true in the config. However, the capture_console_messages variable is False by default. Due to which the captured_console variable is never reached (unless the sets the capture_console_messages to True). To solve this issue I initialized captured_console = [] on line 443, similar to other functions where captured_console is initialized at the start of function.

## How Has This Been Tested?
Once i applied the fix i tried to test the change by scraping 50-60 different local HTML files using the file:// path url.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added/updated unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
