### PR TITLE
fix bs4 warning on text kwarg - switch to string

### DIFF
--- a/crawl4ai/content_filter_strategy.py
+++ b/crawl4ai/content_filter_strategy.py
@@ -656,7 +656,7 @@ class PruningContentFilter(RelevantContentFilter):
 
     def _remove_comments(self, soup):
         """Removes HTML comments"""
-        for element in soup(text=lambda text: isinstance(text, Comment)):
+        for element in soup(string=lambda string: isinstance(string, Comment)):
             element.extract()
 
     def _remove_unwanted_tags(self, soup):


### PR DESCRIPTION
Fix warning as proposed by bs4:
```
  .../bs4/element.py:2253: DeprecationWarning: The 'text' argument to find()-type methods is deprecated. Use 'string' instead.
    return self.find_all(
```

## Summary
Please include a summary of the change and/or which issues are fixed.

eg: `Fixes #123` (Tag GitHub issue numbers in this format, so it automatically links the issues with your PR)

## List of files changed and why
eg: quickstart.py - To update the example as per new changes

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added/updated unit tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
