### PR TITLE
fix: corrected formula and precomputed values

### DIFF
--- a/crawl4ai/deep_crawling/scorers.py
+++ b/crawl4ai/deep_crawling/scorers.py
@@ -10,8 +10,8 @@ import ctypes
 import platform
 PLATFORM = platform.system()
 
-# Pre-computed scores for common year differences
-_SCORE_LOOKUP = [1.0, 0.5, 0.3333333333333333, 0.25]
+# Pre-computed scores for path distance differences
+_SCORE_LOOKUP = [0.0, 0.5, 0.6666666666666667, 0.75]
 
 # Pre-computed scores for common year differences
 _FRESHNESS_SCORES = [
@@ -241,8 +241,8 @@ class PathDepthScorer(URLScorer):
         
         if distance < 4:
             return _SCORE_LOOKUP[distance]
-            
-        return 1.0 / (1.0 + distance)                                             
+
+        return 1.0 - 1.0 / (1.0 + distance)                                            
 
 class ContentTypeScorer(URLScorer):
     __slots__ = ('_weight', '_exact_types', '_regex_types')


### PR DESCRIPTION
## Summary
Fixes #1080 

## List of files changed and why
Corrected the scoring function of the `PathDepthScorer` as it was giving a path that has a higher distance to the optimal depth a lower score and a path that is close to the optimal depth a higher score.

Also updated the precomputed values that are only used by the `PathDepthScorer`.

## How Has This Been Tested?
I testet the code before and after this change and it works as expected after the change.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added/updated unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
