### PR TITLE
[Docs] Fixed the incorrect elapsed calculation and inappropriate output format

### DIFF
--- a/docs/examples/scraping_strategies_performance.py
+++ b/docs/examples/scraping_strategies_performance.py
@@ -1,8 +1,8 @@
-import time, re
-from crawl4ai.content_scraping_strategy import WebScrapingStrategy,  LXMLWebScrapingStrategy
-import time
 import functools
+import time
 from collections import defaultdict
+
+from crawl4ai.content_scraping_strategy import WebScrapingStrategy,  LXMLWebScrapingStrategy
 
 class TimingStats:
     def __init__(self):
@@ -95,7 +95,7 @@ def test_scraping():
     
     # Time the scraping
     print("\nStarting scrape...")
-    start_time = time.time()
+    start_time = time.perf_counter()
     
     kwargs = {
         "url": "http://example.com",
@@ -117,7 +117,7 @@ def test_scraping():
     timing_stats.report()
     
     # Print stats of LXML output
-    print("\Turbo Output:")
+    print("\nTurbo Output:")
     print(f"\nExtracted links: {len(result_selected.links.internal) + len(result_selected.links.external)}")
     print(f"Extracted images: {len(result_selected.media.images)}")
     print(f"Clean HTML size: {len(result_selected.cleaned_html)/1024:.2f} KB")


### PR DESCRIPTION
Fix elpased and improper output format in docs scraping strategies performance

Before fix
![docs_scraping_performance_issues2](https://github.com/user-attachments/assets/4571798a-af7e-4de1-b350-7b62574efcc5)

After fix
![fixed_docs_scraping_performance_issues](https://github.com/user-attachments/assets/ef78a2a1-e8f2-4bd9-a151-67e6dfc32d43)
