### PR TITLE
fix(crawler): use base_url when href is absolute

### DIFF
--- a/crawl4ai/content_scraping_strategy.py
+++ b/crawl4ai/content_scraping_strategy.py
@@ -638,9 +638,15 @@ class WebScrapingStrategy(ContentScrapingStrategy):
 
                     # url_base = url.split("/")[2]
 
+                    # Handle relative URLs that start with "/"
+                    if href.startswith("/"):
+                        url_base = "/".join(url.split("/")[:3])  # Get https://domain.com part
+                    else:
+                        url_base = url
+
                     # Normalize the URL
                     try:
-                        normalized_href = normalize_url(href, url)
+                        normalized_href = normalize_url(href, url_base)
                     except ValueError:
                         # logging.warning(f"Invalid URL format: {href}, Error: {str(e)}")
                         return False


### PR DESCRIPTION
## Summary

this fixes an issue, when `url` is `http://domain.com/path` and a href on this page is `/path-2` resulting with `http://domain.com/path/path-2` which is wrong