### PR TITLE
Fix chunk splitting utilities

### DIFF
--- a/crawl4ai/utils.py
+++ b/crawl4ai/utils.py
@@ -150,7 +150,7 @@ def merge_chunks(
     total_tokens = 0
     
     for doc in docs:
-        tokens = doc.split()
+        tokens = splitter(doc)
         count = int(len(tokens) * word_token_ratio)
         if count:  # Skip empty docs
             token_counts.append(count)
@@ -1196,8 +1196,6 @@ def get_content_of_website_optimized(
                         return None
                 except InvalidSchema:
                     return None
-                finally:
-                    return
 
             image_height = img.get("height")
             height_value, height_unit = parse_dimension(image_height)


### PR DESCRIPTION
## Summary
- ensure `merge_chunks` uses the provided splitter
- remove `finally: return` that made `fetch_image_file_size` always return None

## Testing
- `python -m py_compile crawl4ai/utils.py`
- `pip install pytest` *(fails: no network access)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue ensuring accurate retrieval of image file sizes.
- **Refactor**
  - Enhanced document chunk merging with customizable token splitting for improved flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->