### PR TITLE
enforce auth when jwt is enabled

### DIFF
--- a/deploy/docker/auth.py
+++ b/deploy/docker/auth.py
@@ -32,7 +32,7 @@ def verify_token(credentials: HTTPAuthorizationCredentials = Depends(security)) 
     """Verify the JWT token from the Authorization header."""
 
     if credentials is None:
-        return None
+        raise HTTPException(status_code=401, detail="No credentials provided")
     token = credentials.credentials
     verifying_key = get_jwk_from_secret(SECRET_KEY)
     try:


### PR DESCRIPTION
## Summary
If no credentials are provided, the token gets never verified, even if jwt is enabled. 
This PR throws a 401 exceptions then.


## List of files changed and why
auth.py. Throw exception when token gets verified and no credentials provided

## How Has This Been Tested?
Tested it locally

## Checklist:

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added/updated unit tests that prove my fix is effective or that my feature works
- [x ] New and existing unit tests pass locally with my changes
