### PR TITLE
Fix use_managed_browser page creation

### DIFF
--- a/crawl4ai/browser_manager.py
+++ b/crawl4ai/browser_manager.py
@@ -964,7 +964,10 @@ class BrowserManager:
             pages = context.pages
             page = next((p for p in pages if p.url == crawlerRunConfig.url), None)
             if not page:
-                page = context.pages[0] # await context.new_page()
+                if pages:
+                    page = context.pages[0]
+                else:
+                    page = await context.new_page()
         else:
             # Otherwise, check if we have an existing context for this config
             config_signature = self._make_config_signature(crawlerRunConfig)


### PR DESCRIPTION
## Summary
- fix default context page handling when there are no open pages

## Testing
- `pytest -q --maxfail=1 -vv` *(fails: ModuleNotFoundError: No module named 'test_0')*