### PR TITLE
fix(extraction): llm extraction strategy not overriding response

### DIFF
--- a/crawl4ai/extraction_strategy.py
+++ b/crawl4ai/extraction_strategy.py
@@ -656,11 +656,11 @@ class LLMExtractionStrategy(ExtractionStrategy):
             self.total_usage.total_tokens += usage.total_tokens
 
             try:
-                response = response.choices[0].message.content
+                content = response.choices[0].message.content
                 blocks = None
 
                 if self.force_json_response:
-                    blocks = json.loads(response)
+                    blocks = json.loads(content)
                     if isinstance(blocks, dict):
                         # If it has only one key which calue is list then assign that to blocks, exampled: {"news": [..]}
                         if len(blocks) == 1 and isinstance(list(blocks.values())[0], list):
@@ -673,7 +673,7 @@ class LLMExtractionStrategy(ExtractionStrategy):
                         blocks = blocks
                 else: 
                     # blocks = extract_xml_data(["blocks"], response.choices[0].message.content)["blocks"]
-                    blocks = extract_xml_data(["blocks"], response)["blocks"]
+                    blocks = extract_xml_data(["blocks"], content)["blocks"]
                     blocks = json.loads(blocks)
 
                 for block in blocks:


### PR DESCRIPTION
## Summary

In extract() of LLMExtractionStrategy, `response` is not overridden. Thus if some error is met in later part of this `try`, in `except` we'll get error triggering response.choices[0].message.content: `'str' object has no attribute 'choices'`, as response is now overridden into a string.

https://github.com/unclecode/crawl4ai/blob/main/crawl4ai/extraction_strategy.py#L658-L689

This error occurs occasionally when crawl4ai is used against a list of models include gemini-2.5-pro and gemini-2.5-flash.

## List of files changed and why

In extract() of LLMExtractionStrategy, change `response = response.choices[0].message.content` to `content = ...`, so response is not overriden.

## How Has This Been Tested?

Extract for 200 different webpages after fixing this on my computer.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added/updated unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved internal variable naming for clearer distinction between LLM response objects and their content. No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->