### PR TITLE
Update utils.py fix get_title

### DIFF
--- a/crawl4ai/utils.py
+++ b/crawl4ai/utils.py
@@ -2662,7 +2662,7 @@ class HeadPeekr:
         return meta_tags
 
     def get_title(head_content: str):
-        title_match = re.search(r'<title>(.*?)</title>', head_content, re.IGNORECASE | re.DOTALL)
+        title_match = re.search(r'<title\b[^>]*>(.*?)</title>', head_content, re.IGNORECASE | re.DOTALL)
         return title_match.group(1) if title_match else None
 
 def preprocess_html_for_schema(html_content, text_threshold=100, attr_value_threshold=200, max_size=100000):


### PR DESCRIPTION
<title data-rh="true">Models &amp; Pricing | DeepSeek API Docs</title>

The above html code does not get the title

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved extraction of page titles from HTML to handle cases where the `<title>` tag has attributes, ensuring more reliable display of page titles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->