### PR TITLE
feat(crawler): add content change detection and timestamp management

### DIFF
--- a/crawl4ai/async_configs.py
+++ b/crawl4ai/async_configs.py
@@ -756,6 +756,12 @@ class CrawlerRunConfig():
                                Default: False.
         shared_data (dict or None): Shared data to be passed between hooks.
                                      Default: None.
+        check_content_changed (bool): If True, check if the content has changed before processing.
+                                      Default: False.
+        head_request_timeout (float): Timeout in seconds for the initial HEAD request.
+                                      Default: 3.0.
+        default_cache_ttl_seconds (int): Default time-to-live for cached responses in seconds.
+                                          Default: None.
 
         # Page Navigation and Timing Parameters
         wait_until (str): The condition to wait for when navigating, e.g. "domcontentloaded".
@@ -900,6 +906,9 @@ class CrawlerRunConfig():
         no_cache_read: bool = False,
         no_cache_write: bool = False,
         shared_data: dict = None,
+        check_content_changed: bool = False,
+        head_request_timeout: float = 3.0,
+        default_cache_ttl_seconds: int = None,
         # Page Navigation and Timing Parameters
         wait_until: str = "domcontentloaded",
         page_timeout: int = PAGE_TIMEOUT,
@@ -995,6 +1004,9 @@ class CrawlerRunConfig():
         self.no_cache_read = no_cache_read
         self.no_cache_write = no_cache_write
         self.shared_data = shared_data
+        self.check_content_changed = check_content_changed 
+        self.head_request_timeout = head_request_timeout
+        self.default_cache_ttl_seconds = default_cache_ttl_seconds
 
         # Page Navigation and Timing Parameters
         self.wait_until = wait_until
@@ -1247,6 +1259,9 @@ class CrawlerRunConfig():
             "no_cache_read": self.no_cache_read,
             "no_cache_write": self.no_cache_write,
             "shared_data": self.shared_data,
+            "check_content_changed": self.check_content_changed,  # Add this line
+            "head_request_timeout": self.head_request_timeout,
+            "default_cache_ttl_seconds": self.default_cache_ttl_seconds,
             "wait_until": self.wait_until,
             "page_timeout": self.page_timeout,
             "wait_for": self.wait_for,

--- a/crawl4ai/async_webcrawler.py
+++ b/crawl4ai/async_webcrawler.py
@@ -255,6 +255,8 @@ class AsyncWebCrawler:
                 # Initialize processing variables
                 async_response: AsyncCrawlResponse = None
                 cached_result: CrawlResult = None
+                html = None
+                content_changed = True
                 screenshot_data = None
                 pdf_data = None
                 extracted_content = None
@@ -264,47 +266,73 @@ class AsyncWebCrawler:
                 if cache_context.should_read():
                     cached_result = await async_db_manager.aget_cached_url(url)
 
+                # Try to get cached result if appropriate
+                if cache_context.should_read():
+                    cached_result = await async_db_manager.aget_cached_url(url)
+
                 if cached_result:
-                    html = sanitize_input_encode(cached_result.html)
-                    extracted_content = sanitize_input_encode(
-                        cached_result.extracted_content or ""
-                    )
-                    extracted_content = (
-                        None
-                        if not extracted_content or extracted_content == "[]"
-                        else extracted_content
-                    )
-                    # If screenshot is requested but its not in cache, then set cache_result to None
-                    screenshot_data = cached_result.screenshot
-                    pdf_data = cached_result.pdf
-                    # if config.screenshot and not screenshot or config.pdf and not pdf:
-                    if config.screenshot and not screenshot_data:
-                        cached_result = None
 
-                    if config.pdf and not pdf_data:
-                        cached_result = None
-
-                    self.logger.url_status(
-                        url=cache_context.display_url,
-                        success=bool(html),
-                        timing=time.perf_counter() - start_time,
-                        tag="FETCH",
-                    )
-
-                # Update proxy configuration from rotation strategy if available
-                if config and config.proxy_rotation_strategy:
-                    next_proxy: ProxyConfig = await config.proxy_rotation_strategy.get_next_proxy()
-                    if next_proxy:
-                        self.logger.info(
-                            message="Switch proxy: {proxy}",
-                            tag="PROXY",
-                            params={"proxy": next_proxy.server}
+                    if config.check_content_changed:
+                        # check if content change
+                        content_changed = await self._check_content_changed(
+                            cached_result, url, config
                         )
-                        config.proxy_config = next_proxy
-                        # config = config.clone(proxy_config=next_proxy)
+                    else:
+                        content_changed = False
+
+                    if not content_changed:
+                        # Content has not changed, use cached version
+                        html = sanitize_input_encode(cached_result.html)
+                        extracted_content = sanitize_input_encode(
+                            cached_result.extracted_content or ""
+                        )
+                        extracted_content = (
+                            None
+                            if not extracted_content or extracted_content == "[]"
+                            else extracted_content
+                        )
+                        screenshot_data = cached_result.screenshot
+                        pdf_data = cached_result.pdf
+
+                        # Check if requested media is missing from cache
+                        if (config.screenshot and not screenshot_data) or (
+                            config.pdf and not pdf_data
+                        ):
+                            cached_result = None
+                            content_changed = True  # Force recrawl for missing media
+                        else:
+                            self.logger.url_status(
+                                url=cache_context.display_url,
+                                success=bool(html),
+                                timing=time.perf_counter() - start_time,
+                                tag="FETCH-CACHED",
+                            )
+
+                    else:
+                        # Content has changed, invalidate cache
+                        await async_db_manager.adelete_data_point(url=url)
+                        
+                        cached_result = None
+                        self.logger.info(
+                            message="Content changed, recrawling",
+                            tag="CACHE",
+                            params={"url": url},
+                        )
+
+                    # Update proxy configuration from rotation strategy if available
+                    if config and config.proxy_rotation_strategy:
+                        next_proxy: ProxyConfig = await config.proxy_rotation_strategy.get_next_proxy()
+                        if next_proxy:
+                            self.logger.info(
+                                message="Switch proxy: {proxy}",
+                                tag="PROXY",
+                                params={"proxy": next_proxy.server}
+                            )
+                            config.proxy_config = next_proxy
+                            # config = config.clone(proxy_config=next_proxy)
 
                 # Fetch fresh content if needed
-                if not cached_result or not html:
+                if (not cached_result or not html) and content_changed:
                     t1 = time.perf_counter()
 
                     if config.user_agent:
@@ -744,3 +772,112 @@ class AsyncWebCrawler:
         else:
             _results = await dispatcher.run_urls(crawler=self, urls=urls, config=config)
             return [transform_result(res) for res in _results]
+
+    async def _check_content_changed(self, cached_result: CrawlResult, url:str, config:CrawlerRunConfig) -> bool:
+        """
+        Determines if the content at a URL has changed since it was last cached.
+        Uses a multi-tiered approach prioritizing low-latency methods.
+        
+        Args:
+            cached_result (CrawlResult): The cached result containing metadata and headers
+            url (str): The URL to check
+            config (CrawlerRunConfig): Configuration object controlling cache behavior
+
+        Returns:
+            bool: True if content has changed (or we can't determine), False if unchanged
+        """
+        # Skip change detection for certain protocols or configurations
+        if url.startswith(("file:", "raw:")) or config.cache_mode == CacheMode.DISABLED:
+            return True
+
+        try:
+            # Extract cached response metadata
+            cached_headers = cached_result.response_headers or {}
+            etag = cached_headers.get("etag")
+            last_modified = cached_headers.get("last-modified")
+            # Get timestamp from metadata
+            cached_time = 0
+            if hasattr(cached_result, "metadata") and cached_result.metadata:
+                cached_time = cached_result.metadata.get("_timestamp", 0)
+
+            # Strategy 1: Use max-age from Cache-Control if available
+            cache_control = cached_headers.get("cache-control", "")
+            if "max-age=" in cache_control:
+                try:
+                    max_age = int(cache_control.split("max-age=")[1].split(",")[0])
+                    current_time = time.time()
+                    if current_time - cached_time < max_age:
+                        self.logger.debug(
+                            message="Content fresh according to max-age",
+                            tag="CACHE",
+                            params={"url": url, "max_age": max_age},
+                        )
+                        return False
+                except (ValueError, IndexError):
+                    pass  # Invalid max-age format, continue to other strategies
+
+            # Strategy 2: Conditional request with ETag/Last-Modified
+            headers = {}
+            if etag:
+                headers["If-None-Match"] = etag
+            if last_modified:
+                headers["If-Modified-Since"] = last_modified
+
+            if headers:
+                # Use HEAD request with a short timeout to minimize latency
+                timeout = aiohttp.ClientTimeout(total=config.head_request_timeout)
+                async with aiohttp.ClientSession(timeout=timeout) as session:
+                    try:
+                        async with session.head(
+                            url, headers=headers, allow_redirects=True
+                        ) as response:
+                            # 304 Not Modified means content is unchanged
+                            if response.status == 304:
+                                self.logger.debug(
+                                    message="Content unchanged (304 Not Modified)",
+                                    tag="CACHE",
+                                    params={"url": url},
+                                )
+                                return False
+
+                            # Check if ETag matches
+                            new_etag = response.headers.get("etag")
+                            if etag and new_etag and etag == new_etag:
+                                self.logger.debug(
+                                    message="Content unchanged (ETag match)",
+                                    tag="CACHE",
+                                    params={"url": url},
+                                )
+                                return False
+                    except Exception as e:
+                        # If HEAD request fails, fallback to using cache
+                        self.logger.warning(
+                            message="HEAD request failed, assuming content unchanged",
+                            tag="CACHE",
+                            params={"url": url, "error": str(e)},
+                        )
+                        return False
+
+            # Strategy 3: Check default cache TTL
+            # If no cache headers or ETag/Last-Modified, check default TTL
+            if config.default_cache_ttl_seconds:
+                current_time = time.time()
+                if current_time - cached_time < config.default_cache_ttl_seconds:
+                    self.logger.debug(
+                        message="Using cached content based on TTL",
+                        tag="CACHE",
+                        params={"url": url, "ttl": config.default_cache_ttl_seconds},
+                    )
+                    return False
+
+            # Default: assume content has changed if we can't prove otherwise
+            return True
+
+        except Exception as e:
+            self.logger.error(
+                message="Error checking content change",
+                tag="CACHE",
+                params={"url": url, "error": str(e)},
+            )
+            # On error, assume content has changed to be safe
+            return True


### PR DESCRIPTION
## Summary
This PR introduces a  new feature for cache management - content change detection. Users can now specify whether they want to check if web content has changed before using a cached version.

When `check_content_changed` is enabled in `CrawlerRunConfig the crawler will use a  multi-tiered approach to determine if content has changed:

1. First, it checks cache-control headers for max-age directives
2. Then, it makes a conditional HEAD request using ETags and Last-Modified headers
3. Finally, it falls back to a configurable default TTL

Previously, the caching system would simply retrieve cached content without checking if the underlying web content had changed. This meant that users might receive stale data without knowing it.

With this new feature, users can now ensure they're always working with fresh content while still benefiting from caching performance. If the content has changed, the crawler automatically invalidates the cache, fetches fresh content, and updates the database.

The implementation is efficient, using low-latency HEAD requests and respecting standard HTTP caching mechanisms, minimizing unnecessary full page retrievals.

This enhancement provides significant value for applications requiring both performance and data freshness, and gives users fine-grained control over their caching strategy.

## List of files changed and why
1.  `async_configs.py` : added the following parameters to enable content change detections:
- `check_content_changed (bool)`: If True, check if the content has changed before processing. Default: False.
                                      
-  `head_request_timeout (float):` Timeout in seconds for the initial HEAD request. Default: 3.0.
                                      
 -  `default_cache_ttl_seconds (int):`  Default time-to-live for cached responses in seconds. Default: None.

2. `async_webcrawler.py`:  added `_check_content_changed`  method to check if the cached content has changed.  Also modified `arun` accordigly. 
3.  `async_database`: Added a new column `timestamp` and a method `adelete_data_point` to delete urls from db. 

## How Has This Been Tested?
Basic Testing:

1. Crawl a URL with `check_content_changed=False` (default behavior)
  - Crawl the same URL again - it should use the cached version
  - Modify the website content (or wait for it to change naturally)
  - Crawl with `check_content_changed=True` - it should detect changes and fetch fresh content


2. Find a URL that returns proper caching headers (Cache-Control, ETag, Last-Modified)
  - Crawl with check_content_changed=True
  - Crawl again immediately - it should use cache (fresh according to headers)
