### PR TITLE
fix cleanup warning when no process listening on debug port

### DIFF
--- a/crawl4ai/browser_manager.py
+++ b/crawl4ai/browser_manager.py
@@ -214,7 +214,7 @@ class ManagedBrowser:
             else:  # macOS / Linux
                 # kill any process listening on the same debugging port
                 pids = (
-                    subprocess.check_output(shlex.split(f"lsof -t -i:{self.debugging_port}"))
+                    subprocess.check_output(shlex.split(f"lsof -Q -t -i:{self.debugging_port}"))
                     .decode()
                     .strip()
                     .splitlines()


### PR DESCRIPTION
## Summary

The following warning is raised on Linux when using `use_persistent_context=True` without any existing process listening to the debugging port:

> [BROWSER]. ℹ pre-launch cleanup failed: Command '[['lsof', '-t', '-i:9222']]' 

Can be seen at line 2 in the Error logs of https://github.com/unclecode/crawl4ai/issues/1138#issue-3077595076

This is caused by `lsof ` returning an error on empty search result, since no process is listening.

## List of files changed and why

The fix changes `crawl4ai.browser_manager.ManagedBrowser.start` to pass `-Q` to `lsof`:

> -Q       ignore failed search terms. […] lsof will return  an  error  if  any of the search results are empty. The -Q option will change this behavior so that lsof will instead return a successful exit code

## How Has This Been Tested?

### Current behavior when no process is listening:

https://github.com/unclecode/crawl4ai/blob/897e0173618d20fea5d8952ccdbcdad0febc0fee/crawl4ai/browser_manager.py#L217-L220

```shell
>>> subprocess.check_output(shlex.split("lsof -t -i:1234")).decode().strip().splitlines()
Traceback (most recent call last):
  File "<python-input-5>", line 1, in <module>
    subprocess.check_output(shlex.split("lsof -t -i:1234")).decode().strip().splitlines()
    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.13/subprocess.py", line 472, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
           ~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
               **kwargs).stdout
               ^^^^^^^^^
  File "/usr/lib64/python3.13/subprocess.py", line 577, in run
    raise CalledProcessError(retcode, process.args,
                             output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['lsof', '-t', '-i:1234']' returned non-zero exit status 1.
```

### New behavior 

```shell
>>> subprocess.check_output(shlex.split("lsof -Q -t -i:1234")).decode().strip().splitlines()
[]
>>> subprocess.check_output(shlex.split("lsof -Q -t -i:9222")).decode().strip().splitlines()
['76965', '76973']
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added/updated unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
