### PR TITLE
Add httpx http2 extras

### DIFF
--- a/deploy/docker/requirements.txt
+++ b/deploy/docker/requirements.txt
@@ -14,3 +14,4 @@ anyio==4.9.0
 PyJWT==2.10.1
 mcp>=1.6.0
 websockets>=15.0.1
+httpx[http2]>=0.27.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "rich>=13.9.4",
     "cssselect>=1.2.0",
     "httpx>=0.27.2",
+    "httpx[http2]>=0.27.2",
     "fake-useragent>=2.0.3",
     "click>=8.1.7",
     "pyperclip>=1.8.2",

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ rich>=13.9.4
 cssselect>=1.2.0
 chardet>=5.2.0
 brotli>=1.1.0
+httpx[http2]>=0.27.2


### PR DESCRIPTION
## Summary
- add httpx[http2] extra requirement to core dependencies
- include httpx[http2] in requirements files

## Testing
- `pytest -q tests/async/test_content_filter_bm25.py::test_basic_extraction` *(fails: ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_684542dffd54832d8d791b8d027fe5e9