### PR TITLE
fix(screenshot): Correct segment calculation to prevent duplication

### DIFF
--- a/crawl4ai/async_crawler_strategy.py
+++ b/crawl4ai/async_crawler_strategy.py
@@ -1429,7 +1429,7 @@ class AsyncPlaywrightCrawlerStrategy(AsyncCrawlerStrategy):
             viewport_size = page.viewport_size
             viewport_height = viewport_size["height"]
 
-            num_segments = (page_height // viewport_height) + 1
+            num_segments = [(page_height + viewport_height - 1) // viewport_height] 
             for i in range(num_segments):
                 y_offset = i * viewport_height
                 await page.evaluate(f"window.scrollTo(0, {y_offset})")

--- a/crawl4ai/async_crawler_strategy.py
+++ b/crawl4ai/async_crawler_strategy.py
@@ -1429,7 +1429,7 @@ class AsyncPlaywrightCrawlerStrategy(AsyncCrawlerStrategy):
             viewport_size = page.viewport_size
             viewport_height = viewport_size["height"]
 
-            num_segments = [(page_height + viewport_height - 1) // viewport_height] 
+            num_segments = (page_height + viewport_height - 1) // viewport_height 
             for i in range(num_segments):
                 y_offset = i * viewport_height
                 await page.evaluate(f"window.scrollTo(0, {y_offset})")


### PR DESCRIPTION
## Summary

This commit replaces the previous calculation with the correct integer-based ceiling division formula:
`num_segments = (page_height + viewport_height - 1) // viewport_height` [async_crawler_strategy.py#1432](https://github.com/leoric-crown/crawl4ai/blob/09c9f8d5d2fc4ecf87b9c9cbc518fd50feb4573c/crawl4ai/async_crawler_strategy.py#L1432)

Fixes [#1187 ](https://github.com/unclecode/crawl4ai/issues/1187)

## List of files changed and why
[async_crawler_strategy.py](https://github.com/leoric-crown/crawl4ai/blob/09c9f8d5d2fc4ecf87b9c9cbc518fd50feb4573c/crawl4ai/async_crawler_strategy.py#L1432) - Wrong segment calculation was duplicating screenshot content (generating 2 segments of full page screenshots)

## How Has This Been Tested?
Basic testing by updating the offending line and observing results.

## Checklist:

- [x] My code follows the style guidelines of this project (I only edited one line)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (didn't find it necessary since only one line edit)
- [x] I have made corresponding changes to the documentation
- [ ] I have added/updated unit tests that prove my fix is effective or that my feature works - No. Could not figure out how to set up tests, sorry.
- [ ] New and existing unit tests pass locally with my changes - No. Could not figure out how to set up tests, sorry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the accuracy of scrolling and screenshot stitching to ensure full-page captures without unnecessary extra segments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->