### PR TITLE
Fix: safely create a new page if no page exists in persistent context

### DIFF
--- a/crawl4ai/browser_manager.py
+++ b/crawl4ai/browser_manager.py
@@ -964,7 +964,10 @@ class BrowserManager:
             pages = context.pages
             page = next((p for p in pages if p.url == crawlerRunConfig.url), None)
             if not page:
-                page = context.pages[0] # await context.new_page()
+                if pages:
+                        page = pages[0]
+                else:
+                    page = await context.new_page()        
         else:
             # Otherwise, check if we have an existing context for this config
             config_signature = self._make_config_signature(crawlerRunConfig)


### PR DESCRIPTION
Fixes a crash that occurs when using use_managed_browser=True and the context.pages list is empty during concurrent execution.
Previously, context.pages[0] was accessed directly without checking if the list was empty, which led to a list index out of range or context-closed error.
This fix ensures that a new page is created if no pages exist.

Fixes #1198


eg: `Fixes #123` (Tag GitHub issue numbers in this format, so it automatically links the issues with your PR)

crawl4ai/browser_manager.py
→ Updated get_page() method to safely handle the case when no pages exist in a context by checking if context.pages is empty and creating a new page when needed.


Ran the crawler with use_persistent_context=True and multiple URLs using arun_many.

Confirmed that:

No crashes occurred when context.pages was empty.

New pages were created when needed.

Existing pages were reused when possible.



