### PR TITLE
Feat: added stateless streamable_http transport for MCP at /mcp/http

### DIFF
--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -257,10 +257,11 @@ MCP is an open protocol that standardizes how applications provide context to LL
 
 ### Connecting via MCP
 
-The Crawl4AI server exposes two MCP endpoints:
+The Crawl4AI server exposes three MCP endpoints:
 
 - **Server-Sent Events (SSE)**: `http://localhost:11235/mcp/sse`
 - **WebSocket**: `ws://localhost:11235/mcp/ws`
+- **Streamable_http**: `http://localhost:11235/mcp/http`
 
 ### Using with Claude Code
 
@@ -295,6 +296,13 @@ You can test the MCP WebSocket connection using the test file included in the re
 ```bash
 # From the repository root
 python tests/mcp/test_mcp_socket.py
+```
+
+You can test the MCP streamable_http connection using the test file included in the repository:
+
+```bash
+# From the repository root
+python tests/mcp/test_mcp_http.py
 ```
 
 ### MCP Schemas

--- a/deploy/docker/mcp_bridge.py
+++ b/deploy/docker/mcp_bridge.py
@@ -279,7 +279,7 @@ def attach_mcp(
                 print("Application shutting down...")
 
     app.router.mount(
-        "{base}/http",
+        f"{base}/http",
         app=handle_streamable_http,
     )
 

--- a/deploy/docker/server.py
+++ b/deploy/docker/server.py
@@ -7,7 +7,6 @@ Crawl4AI FastAPI entry‑point
 """
 
 # ── stdlib & 3rd‑party imports ───────────────────────────────
-import contextlib
 from crawler_pool import get_crawler, close_all, janitor
 from crawl4ai import AsyncWebCrawler, BrowserConfig, CrawlerRunConfig
 from auth import create_access_token, get_token_dependency, TokenRequest

--- a/deploy/docker/server.py
+++ b/deploy/docker/server.py
@@ -40,8 +40,7 @@ import os
 import sys
 import time
 import asyncio
-from typing import List
-from contextlib import _AsyncGeneratorContextManager, asynccontextmanager, AsyncExitStack
+from contextlib import asynccontextmanager
 import pathlib
 
 from fastapi import (

--- a/deploy/docker/utils.py
+++ b/deploy/docker/utils.py
@@ -1,3 +1,4 @@
+import contextlib
 import dns.resolver
 import logging
 import yaml
@@ -64,3 +65,21 @@ def verify_email_domain(email: str) -> bool:
         return True if records else False
     except Exception as e:
         return False
+
+   
+def combine_lifespans(*lifespans):
+    @contextlib.asynccontextmanager
+    async def combined(app):
+        # Nest the lifespans like contextlib.ExitStack does for async
+        stack = contextlib.AsyncExitStack()
+        await stack.__aenter__()
+
+        try:
+            for lifespan in lifespans:
+
+                await stack.enter_async_context(lifespan(app))
+            yield
+        finally:
+            await stack.__aexit__(None, None, None)
+
+    return combined

--- a/docs/md_v2/core/docker-deployment.md
+++ b/docs/md_v2/core/docker-deployment.md
@@ -257,10 +257,11 @@ MCP is an open protocol that standardizes how applications provide context to LL
 
 ### Connecting via MCP
 
-The Crawl4AI server exposes two MCP endpoints:
+The Crawl4AI server exposes three MCP endpoints:
 
 - **Server-Sent Events (SSE)**: `http://localhost:11235/mcp/sse`
 - **WebSocket**: `ws://localhost:11235/mcp/ws`
+- **Streamable_http**: `http://localhost:11235/mcp/http`
 
 ### Using with Claude Code
 
@@ -295,6 +296,13 @@ You can test the MCP WebSocket connection using the test file included in the re
 ```bash
 # From the repository root
 python tests/mcp/test_mcp_socket.py
+```
+
+You can test the MCP streamable_http connection using the test file included in the repository:
+
+```bash
+# From the repository root
+python tests/mcp/test_mcp_http.py
 ```
 
 ### MCP Schemas

--- a/tests/mcp/test_mcp_http.py
+++ b/tests/mcp/test_mcp_http.py
@@ -1,0 +1,11 @@
+from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.session import ClientSession
+
+async def main():
+    async with streamablehttp_client("http://0.0.0.0:11234/mcp/http") as (r,s,_):
+        async with ClientSession(r,s) as sess:
+            print(await sess.list_tools())      
+            
+if __name__ == "__main__":
+    import asyncio
+    asyncio.run(main())


### PR DESCRIPTION
## Summary

added stateless streamable_http endpoint for MCP at /mcp/http

Ref:  https://github.com/unclecode/crawl4ai/discussions/1158


## List of files changed and why
- deploy/docker/mcp_bridge.py - To mount the endpoint and app for streamable http as well in attach_mcp function and now returning the lifespan required for the same. [Official example](https://github.com/modelcontextprotocol/python-sdk/blob/29c69e6a47d0104d0afcea6ac35e7ab02fde809a/src/mcp/server/streamable_http.py)
- deploy/docker/utils.py - added a utility that takes all lifespans and combine it into single lifespan function for fastapi app
- deploy/docker/server.py - combined and added the lifespan of attach_mcp with existing one 
- tests/mcp/test_mcp_http.py - Added test similar to test_mcp_sse.py for http server
- docs/md_v2/core/docker-deployment.md - Updated documentation to add url and testing instruction
- deploy/docker/README.md - Updated documentation to add url and testing instruction


## How Has This Been Tested?
Tested all the tools of mcp server via postman and also added tests/mcp/test_mcp_http.py with test to list all tools

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added/updated unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a streamable HTTP endpoint for MCP, allowing interaction with the server via HTTP in addition to existing WebSocket support.
- **Documentation**
  - Updated deployment and usage guides to include information and testing instructions for the new MCP HTTP endpoint.
- **Tests**
  - Introduced a new test script to verify the functionality of the MCP HTTP endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->