### PR TITLE
Allow OPENAI_BASE_URL to be used to control the base_url for the LLM

### DIFF
--- a/crawl4ai/extraction_strategy.py
+++ b/crawl4ai/extraction_strategy.py
@@ -44,7 +44,7 @@ import numpy as np
 import re
 from bs4 import BeautifulSoup
 from lxml import html, etree
-
+import os
 
 class ExtractionStrategy(ABC):
     """

--- a/crawl4ai/utils.py
+++ b/crawl4ai/utils.py
@@ -1638,9 +1638,15 @@ def perform_completion_with_backoff(
     Returns:
         dict: The API response or an error message after all retries.
     """
-
+    import os
     from litellm import completion
     from litellm.exceptions import RateLimitError
+
+    # Allow base_url and provider to be set via environment variables if not provided
+    if base_url is None:
+        base_url = os.environ.get("OPENAI_BASE_URL", None)
+    if not provider:
+        provider = os.environ.get("OPENAI_MODEL", None)
 
     max_attempts = 3
     base_delay = 2  # Base delay in seconds, you can adjust this based on your needs
@@ -1657,6 +1663,8 @@ def perform_completion_with_backoff(
             response = completion(
                 model=provider,
                 messages=[{"role": "user", "content": prompt_with_variables}],
+                api_key=api_token,
+                base_url=base_url,
                 **extra_args,
             )
             return response  # Return the successful response
@@ -2809,4 +2817,4 @@ def preprocess_html_for_schema(html_content, text_threshold=100, attr_value_thre
     except Exception as e:
         # Fallback for parsing errors
         return html_content[:max_size] if len(html_content) > max_size else html_content
-    
+

--- a/deploy/docker/.llm.env.example
+++ b/deploy/docker/.llm.env.example
@@ -1,5 +1,6 @@
 # LLM Provider Keys
 OPENAI_API_KEY=your_openai_key_here
+# OPENAI_BASE_URL=https://your.openai.base.url
 DEEPSEEK_API_KEY=your_deepseek_key_here
 ANTHROPIC_API_KEY=your_anthropic_key_here
 GROQ_API_KEY=your_groq_key_here


### PR DESCRIPTION
## Summary
Checks OPENAI_BASE_URL for an override

Fixes #1219

## List of files changed and why

crawl4ai/utils.py - This is where it sends the request to the LLM
deploy/docker/.llm.env.example - Update the example config
crawl4ai/extraction_strategy.py - Unrelated bug, but missing `import os`

## How Has This Been Tested?
Yes

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added/updated unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
