### PR TITLE
docs: add links to other language versions of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,18 @@
 
 </div>
 
+<p align="center">
+    <!-- Keep these links. Translations will automatically update with the README. -->
+    <a href="https://www.readme-i18n.com/unclecode/crawl4ai?lang=de">Deutsch</a> | 
+    <a href="https://www.readme-i18n.com/unclecode/crawl4ai?lang=es">Español</a> | 
+    <a href="https://www.readme-i18n.com/unclecode/crawl4ai?lang=fr">français</a> | 
+    <a href="https://www.readme-i18n.com/unclecode/crawl4ai?lang=ja">日本語</a> | 
+    <a href="https://www.readme-i18n.com/unclecode/crawl4ai?lang=ko">한국어</a> | 
+    <a href="https://www.readme-i18n.com/unclecode/crawl4ai?lang=pt">Português</a> | 
+    <a href="https://www.readme-i18n.com/unclecode/crawl4ai?lang=ru">Русский</a> | 
+    <a href="https://www.readme-i18n.com/unclecode/crawl4ai?lang=zh">中文</a>
+</p>
+
 Crawl4AI is the #1 trending GitHub repository, actively maintained by a vibrant community. It delivers blazing-fast, AI-ready web crawling tailored for LLMs, AI agents, and data pipelines. Open source, flexible, and built for real-time performance, Crawl4AI empowers developers with unmatched speed, precision, and deployment ease.  
 
 [✨ Check out latest update v0.6.0](#-recent-updates)


### PR DESCRIPTION
Allowing users around the world to read the documentation in their native languages — including German, Spanish, French, Japanese, Korean, Portuguese, Russian, and Chinese.

This update improves accessibility and project understanding for non-English speakers around the world.

The updated links can be previewed in my forked repository: https://github.com/dowithless/crawl4ai/tree/patch-1

## Summary
Please include a summary of the change and/or which issues are fixed.

eg: `Fixes #123` (Tag GitHub issue numbers in this format, so it automatically links the issues with your PR)

## List of files changed and why
eg: quickstart.py - To update the example as per new changes

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added/updated unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
