### PR TITLE
Fixed docker deployment guide URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ task_id = response.json()["task_id"]
 result = requests.get(f"http://localhost:11235/task/{task_id}")
 ```
 
-For more examples, see our [Docker Examples](https://github.com/unclecode/crawl4ai/blob/main/docs/examples/docker_example.py). For advanced configuration, environment variables, and usage examples, see our [Docker Deployment Guide](https://docs.crawl4ai.com/basic/docker-deployment/).
+For more examples, see our [Docker Examples](https://github.com/unclecode/crawl4ai/blob/main/docs/examples/docker_example.py). For advanced configuration, environment variables, and usage examples, see our [Docker Deployment Guide](https://docs.crawl4ai.com/core/docker-deployment/).
 
 </details>
 


### PR DESCRIPTION
Previously: https://docs.crawl4ai.com/basic/docker-deployment/
New: https://docs.crawl4ai.com/core/docker-deployment/

## Summary
Previous Docker deployment guide URL: https://docs.crawl4ai.com/basic/docker-deployment/
New Docker deployment guide URL: https://docs.crawl4ai.com/core/docker-deployment/

## List of files changed and why
- README.md (404 link)

## How Has This Been Tested?
I tested the new URL

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added/updated unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
