### PR TITLE
Fix JSONCSSSelector to Handle Sibling CSS Selectors

### DIFF
--- a/crawl4ai/extraction_strategy.py
+++ b/crawl4ai/extraction_strategy.py
@@ -1224,7 +1224,6 @@ class JsonCssExtractionStrategy(JsonElementExtractionStrategy):
         return parsed_html.select(selector)
 
     def _get_elements(self, element, selector: str):
-        print(f"Applying selector: {selector} on element: {element}")
         if selector.startswith('+ '):
             # Remove '+ ' prefix and strip whitespace
             rest = selector[2:].strip()
@@ -1237,11 +1236,9 @@ class JsonCssExtractionStrategy(JsonElementExtractionStrategy):
                 sibling_selector = rest
                 rest_selector = None
             
-            print(f"Sibling Selector: {sibling_selector}, Rest Selector: {rest_selector}")
             
             # Find the next sibling matching the sibling_selector
             sibling = element.find_next_sibling(sibling_selector)
-            print(f"Sibling: {sibling}")
             
             if sibling and rest_selector:
                 # Apply the remaining selector to the sibling

--- a/tests/async/test_extraction_strategy.py
+++ b/tests/async/test_extraction_strategy.py
@@ -1,0 +1,169 @@
+# tests/async/test_extraction_strategy.py
+import pytest
+from bs4 import BeautifulSoup
+from crawl4ai.extraction_strategy import JsonCssExtractionStrategy
+
+# Sample HTML inspired by Hacker News or similar structures
+SAMPLE_HTML = """
+<table>
+    <tbody>
+        <tr class='athing' id='1'>
+            <td class="title">
+                <span class="titleline">
+                    <a href="https://example.com">My Awesome Project</a>
+                </span>
+            </td>
+        </tr>
+        <tr>
+            <td class="subtext">
+                <span class="score" id="score_1">100 points</span>
+                by <a href="user?id=testuser" class="hnuser">testuser</a>
+                <span class="age" title="2023-11-10T12:00:00">
+                    <a href="item?id=1">2 hours ago</a>
+                </span>
+            </td>
+        </tr>
+        <tr class='athing' id='2'>
+            <td class="title">
+                <span class="titleline">
+                    <a href="https://another.com">Another Cool Thing</a>
+                </span>
+            </td>
+        </tr>
+        <tr>
+            <td class="subtext">
+                <span class="score" id="score_2">50 points</span>
+                by <a href="user?id=anotheruser" class="hnuser">anotheruser</a>
+                <span class="age" title="2023-11-10T14:00:00">
+                    <a href="item?id=2">30 minutes ago</a>
+                </span>
+            </td>
+        </tr>
+    </tbody>
+</table>
+"""
+
+class TestJsonCssExtractorStrategy:
+
+    def test_sibling_selector_with_descendant(self):
+        """Tests extracting a descendant from a next sibling."""
+        schema = {
+            "name": "HackerNewsItems",
+            "baseSelector": "tr.athing",
+            "fields": [
+                {
+                    "name": "title",
+                    "selector": ".titleline a",
+                    "type": "text"
+                },
+                {
+                    "name": "points",
+                    "selector": "+ tr .score",
+                    "type": "text"
+                }
+            ]
+        }
+        strategy = JsonCssExtractionStrategy(schema=schema)
+        results = strategy.run(url="http://test.com", sections=[SAMPLE_HTML])
+        
+        assert len(results) == 2
+        assert results[0]['title'] == "My Awesome Project"
+        assert results[0]['points'] == "100 points"
+        assert results[1]['title'] == "Another Cool Thing"
+        assert results[1]['points'] == "50 points"
+
+    def test_sibling_selector_without_descendant(self):
+        """Tests extracting the entire next sibling element."""
+        schema = {
+            "name": "HackerNewsItems",
+            "baseSelector": "tr.athing",
+            "fields": [
+                {
+                    "name": "title",
+                    "selector": ".titleline a",
+                    "type": "text"
+                },
+                {
+                    "name": "metadata_row",
+                    "selector": "+ tr", # Select the whole next sibling <tr>
+                    "type": "html"
+                }
+            ]
+        }
+        strategy = JsonCssExtractionStrategy(schema=schema)
+        results = strategy.run(url="http://test.com", sections=[SAMPLE_HTML])
+        
+        assert len(results) == 2
+        assert results[0]['title'] == "My Awesome Project"
+        assert '<td class="subtext">' in results[0]['metadata_row']
+        assert 'id="score_1"' in results[0]['metadata_row']
+        
+        # Test the second item
+        assert results[1]['title'] == "Another Cool Thing"
+        assert '<td class="subtext">' in results[1]['metadata_row']
+        assert 'id="score_2"' in results[1]['metadata_row']
+        
+
+    def test_sibling_selector_no_match(self):
+        """Tests behavior when no matching sibling is found."""
+        html_with_missing_sibling = """
+        <table>
+            <tbody>
+                <tr class='athing' id='1'>
+                    <td class="title">
+                        <a href="https://example.com">Item with no subtext</a>
+                    </td>
+                </tr>
+                <!-- The sibling tr is missing here -->
+                 <tr class='athing' id='2'>
+                    <td class="title">
+                       <a href="https://another.com">Another item</a>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+        """
+        schema = {
+            "name": "Items",
+            "baseSelector": "tr.athing",
+            "fields": [
+                {"name": "title", "selector": ".title a", "type": "text"},
+                {"name": "points", "selector": "+ tr .score", "type": "text", "default": "N/A"}
+            ]
+        }
+        strategy = JsonCssExtractionStrategy(schema=schema)
+        results = strategy.run(url="http://test.com", sections=[html_with_missing_sibling])
+        
+        assert len(results) == 2
+        assert results[0]['title'] == "Item with no subtext"
+        assert results[0]['points'] == "N/A" # Should use default value
+        assert 'points' not in results[1] or results[1]['points'] == "N/A" # Second one also has no sibling
+
+
+    def test_standard_descendant_selector_regression(self):
+        """Ensures that standard selectors still work correctly."""
+        schema = {
+            "name": "HackerNewsItems",
+            "baseSelector": "tr.athing",
+            "fields": [
+                {
+                    "name": "title",
+                    "selector": ".titleline a", # Standard descendant selector
+                    "type": "text"
+                },
+                {
+                    "name": "link",
+                    "selector": ".titleline a", # Standard descendant selector
+                    "type": "attribute",
+                    "attribute": "href"
+                }
+            ]
+        }
+        strategy = JsonCssExtractionStrategy(schema=schema)
+        results = strategy.run(url="http://test.com", sections=[SAMPLE_HTML])
+        
+        assert len(results) == 2
+        assert results[0]['title'] == "My Awesome Project"
+        assert results[0]['link'] == "https://example.com"
+        assert results[1]['title'] == "Another Cool Thing"
+        assert results[1]['link'] == "https://another.com"


### PR DESCRIPTION
## Summary

This pull request resolves an issue where the `JsonCssExtractorStrategy` in Crawl4AI failed to process adjacent sibling CSS selectors (e.g., `+ tr .score`). The changes enhance the selector parsing logic to correctly interpret these sibling relationships, enabling accurate extraction of elements from non-nested HTML structures.

For example, on sites like Hacker News where an item's metadata is in a separate `<tr>` immediately following the title row, this fix allows for extracting both pieces of data from a single base element.

Fixes #1254 

## List of files changed and why

*   **`crawl4ai/extraction_strategy.py`**: To update the `_get_elements` method within `JsonCssExtractorStrategy`. The new logic detects the `+` combinator, uses `find_next_sibling` to locate the adjacent element, and then applies any further descendant selectors.
*   **`tests/async/test_extraction_strategy.py`**: To add a new test suite that specifically validates the sibling selector functionality. This proves the fix is effective and helps prevent future regressions.
*  **`docs/md_v2/extraction/no-llm-strategies.md`**: To add a new section about the updated functionality

## How Has This Been Tested?

A new test suite has been added in `tests/async/test_extraction_strategy.py` to cover the new functionality with various scenarios:

*   **Sibling Selector with Descendant**: Verified that a selector like `+ tr .score` correctly finds the next sibling `<tr>` and then the `.score` element within it.
*   **Sibling Selector Only**: Confirmed that a selector like `+ tr` correctly returns the entire next sibling element when no descendant selector is provided.
*   **No Matching Sibling**: Ensured that the function returns an empty list and does not raise an error when a matching sibling is not found, allowing for graceful defaults in the schema.
*   **Regression Testing**: Verified that standard descendant selectors (e.g., `.titleline a`) continue to function as expected without the `+` prefix.

All new and existing unit tests pass locally with my changes.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added/updated unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for advanced CSS sibling selectors in extraction strategies, enabling extraction of data from adjacent sibling elements.
* **Documentation**
  * Updated documentation with a new section explaining the sibling combinator feature, including usage examples and practical scenarios.
* **Tests**
  * Introduced new tests to validate extraction using sibling selectors, ensuring correct handling of various selector scenarios and maintaining existing selector behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->