### PR TITLE
fix get title bug in amazon example

### DIFF
--- a/docs/examples/amazon_product_extraction_direct_url.py
+++ b/docs/examples/amazon_product_extraction_direct_url.py
@@ -27,7 +27,7 @@ async def extract_amazon_products():
                         "type": "attribute",
                         "attribute": "data-asin",
                     },
-                    {"name": "title", "selector": "h2 a span", "type": "text"},
+                    {"name": "title", "selector": "a h2 span", "type": "text"},
                     {
                         "name": "url",
                         "selector": "h2 a",


### PR DESCRIPTION
## Summary
![image](https://github.com/user-attachments/assets/4d2c5ce3-0a80-405e-bfc1-c8ef95e1fc10)
product tiltle in search result is in `<a><h2><span>xxx</span></h2></a>` 


## List of files changed and why
amazon_product_extraction_direct_url.py

## How Has This Been Tested?
before:
![image](https://github.com/user-attachments/assets/62852617-4bdd-4ee4-b043-882063e304ed)

after:
![image](https://github.com/user-attachments/assets/2fa13663-b667-4efb-9d47-efaa7a8a5f9b)



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added/updated unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
