### PR TITLE
fix VersionManager not using CRAWL4_AI_BASE_DIRECTORY

### DIFF
--- a/crawl4ai/utils.py
+++ b/crawl4ai/utils.py
@@ -226,7 +226,7 @@ def merge_chunks(
 
 class VersionManager:
     def __init__(self):
-        self.home_dir = Path.home() / ".crawl4ai"
+        self.home_dir = Path(os.getenv("CRAWL4_AI_BASE_DIRECTORY", Path.home()))
         self.version_file = self.home_dir / "version.txt"
 
     def get_installed_version(self):


### PR DESCRIPTION
## Summary

`VersionManager` did not do an eval of `CRAWL4_AI_BASE_DIRECTORY` env variable unlike actual database manager,  
so it caused split-brain scenario where database was written in folder specified by env variable,  
followed by failure to write `version.txt` since that was force-attempted in users home folder.

## List of files changed and why

utils.py:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added/updated unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
