### PR TITLE
Fix: Prevent select extension when hovering Ask AI button during mouse drag

### DIFF
--- a/docs/md_v2/assets/selection_ask_ai.js
+++ b/docs/md_v2/assets/selection_ask_ai.js
@@ -144,7 +144,11 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     // Mouse selection events (desktop)
-    document.addEventListener('mouseup', handleSelectionEvent);
+    document.addEventListener('mouseup', (event) => {
+    if (askAiButton) askAiButton.classList.remove('no-pointer');
+    handleSelectionEvent(event);
+    });
+
 
     // Touch selection events (mobile)
     document.addEventListener('touchend', handleSelectionEvent);
@@ -160,6 +164,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Hide button on various events
     document.addEventListener('mousedown', (event) => {
+        if (askAiButton) askAiButton.classList.add('no-pointer');
         // Hide if clicking anywhere EXCEPT the button itself
         if (askAiButton && event.target !== askAiButton) {
             hideButton();

--- a/docs/md_v2/assets/styles.css
+++ b/docs/md_v2/assets/styles.css
@@ -260,3 +260,7 @@ div.badges a > img {
 table td, table th {
     border: 1px solid var(--code-bg-color) !important;
 }
+
+.ask-ai-selection-button.no-pointer {
+  pointer-events: none !important;
+}


### PR DESCRIPTION
## Summary

Fixes a bug where, while selecting text and hovering over the Ask AI button (with the mouse button still held down), the browser would incorrectly extend the text selection to include extra content below the selection.  
This PR disables pointer events on the Ask AI button while the mouse is pressed, preventing the browser from expanding the selection during drag.

## List of files changed and why

- **docs/md_v2/assets/style.css**
  - Added `.no-pointer` class to disable pointer events on the Ask AI button while selecting.
- **docs/md_v2/assets/selection_ask_ai.js**
  - Updated mouse event handlers to add/remove the `.no-pointer` class on the Ask AI button during selection drag.

---

## How Has This Been Tested?

- Manually tested by selecting text, dragging over the Ask AI button, and confirming the selection is no longer extended.
- Verified that after releasing the mouse button, the Ask AI button can be clicked as expected.
- Tested in Chrome .

https://github.com/user-attachments/assets/b3cde6e4-9ede-4a3e-8622-b6768417af95
---

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added/updated unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes *(or N/A if no tests)*

