### PR TITLE
Fixed the error that the variable css_selector was originally assigned to list

### DIFF
--- a/docs/md_v2/assets/llm.txt/txt/config_objects.txt
+++ b/docs/md_v2/assets/llm.txt/txt/config_objects.txt
@@ -442,7 +442,7 @@ config = CrawlerRunConfig(
 
 # Hierarchical content selection
 config = CrawlerRunConfig(
-    css_selector=["#main-content", ".article-wrapper"],  # Top-level extraction
+    css_selector="#main-content, .article-wrapper",       # Top-level extraction
     target_elements=[                                     # Subset for processing
         ".article-title",
         ".article-body", 

--- a/docs/md_v2/assets/llm.txt/txt/llms-full-v0.1.1.txt
+++ b/docs/md_v2/assets/llm.txt/txt/llms-full-v0.1.1.txt
@@ -1066,7 +1066,7 @@ config = CrawlerRunConfig(
 
 # Hierarchical content selection
 config = CrawlerRunConfig(
-    css_selector=["#main-content", ".article-wrapper"],  # Top-level extraction
+    css_selector="#main-content, .article-wrapper",       # Top-level extraction
     target_elements=[                                     # Subset for processing
         ".article-title",
         ".article-body", 

--- a/docs/md_v2/assets/llm.txt/txt/llms-full.txt
+++ b/docs/md_v2/assets/llm.txt/txt/llms-full.txt
@@ -1066,7 +1066,7 @@ config = CrawlerRunConfig(
 
 # Hierarchical content selection
 config = CrawlerRunConfig(
-    css_selector=["#main-content", ".article-wrapper"],  # Top-level extraction
+    css_selector="#main-content, .article-wrapper",       # Top-level extraction
     target_elements=[                                     # Subset for processing
         ".article-title",
         ".article-body", 


### PR DESCRIPTION
## Summary
In CrawlerRunConfig, the css_selector is string, and will be split. but these files in doc css_selector is assigned an initial value of list type.

## List of files changed and why
eg: quickstart.py - To update the example as per new changes
docs\md_v2\assets\llm.txt\txt\config_objects.txt - To change css_selector's value
docs\md_v2\assets\llm.txt\txt\llms-full.txt  - To change css_selector's value
docs\md_v2\assets\llm.txt\txt\llms-full-v0.1.1.txt  - To change css_selector's value


