### PR TITLE
Fix: README.md docker image tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ The new Docker implementation includes:
 
 ```bash
 # Pull and run the latest release candidate
-docker pull unclecode/crawl4ai:0.7.0
+docker pull unclecode/crawl4ai:0.7.0-r1
 docker run -d -p 11235:11235 --name crawl4ai --shm-size=1g unclecode/crawl4ai:0.7.0
 
 # Visit the playground at http://localhost:11235/playground


### PR DESCRIPTION
# Fix: README.md docker image tag

## Summary
The previous `README.md` version referenced an **incorrect docker image tag:**
```bash
docker pull unclecode/crawl4ai:0.7.0
```
resulting in the following error:
```bash
Error response from daemon: failed to resolve reference "docker.io/unclecode/crawl4ai:0.7.0": docker.io/unclecode/crawl4ai:0.7.0: not found`
```
This was simply fixed by **changing it to the correct image tag:**
```bash
docker pull unclecode/crawl4ai:0.7.0-r1
```

## List of files changed and why
`README.md` - to provide the correct command in the documentation.

## How Has This Been Tested?
Running the updated command locally and verifying the tag on Docker Hub.

## Checklist:

- [N/A] My code follows the style guidelines of this project
- [N/A] I have performed a self-review of my own code
- [N/A] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to the documentation
- [N/A] I have added/updated unit tests that prove my fix is effective or that my feature works
- [N/A] New and existing unit tests pass locally with my changes
