### PR TITLE
fix: invert URL scores in BestFirstCrawlingStrategy priority queue to…

### DIFF
--- a/crawl4ai/deep_crawling/bff_strategy.py
+++ b/crawl4ai/deep_crawling/bff_strategy.py
@@ -187,7 +187,7 @@ class BestFirstCrawlingStrategy(DeepCrawlStrategy):
                 result.metadata = result.metadata or {}
                 result.metadata["depth"] = depth
                 result.metadata["parent_url"] = parent_url
-                result.metadata["score"] = score
+                result.metadata["score"] = -score #original score as metadata
                 
                 # Count only successful crawls toward max_pages limit
                 if result.success:
@@ -208,7 +208,7 @@ class BestFirstCrawlingStrategy(DeepCrawlStrategy):
                     for new_url, new_parent in new_links:
                         new_depth = depths.get(new_url, depth + 1)
                         new_score = self.url_scorer.score(new_url) if self.url_scorer else 0
-                        await queue.put((new_score, new_depth, new_url, new_parent))
+                        await queue.put((-new_score, new_depth, new_url, new_parent)) # negative of score so as to prioritize higher positive score from min heap
 
         # End of crawl.
 


### PR DESCRIPTION
Fixes the crawling priority logic in BestFirstCrawlingStrategy by inverting URL scores before inserting them into the priority queue. The issue was that the strategy uses a min-priority queue which caused URLs with lower scores to be crawled first, contradicting the intended max-priority behavior where higher scored URLs should be crawled earlier.

This change negates the scores when enqueuing URLs, and negates them back when yielding crawl results. This aligns crawl order with scorer priorities and respects documented behavior for prioritized crawling..

Fixes #1253 

## List of files changed and why
crawl4ai/deep_crawling/bff_strategy.py :
Fixed the priority inversion by inserting URLs with negative scores into the priority queue and restoring positive scores on crawl result metadata.

## How Has This Been Tested?
Manually tested with custom WarrantyPriorityScorer scoring URLs with varying positive scores to verify that URLs with higher scores are crawled before lower scored URLs.
Verified crawling logs show that URLs are processed in descending order of their scorer rank.
Confirmed crawl stops on reaching max_pages as before, with no regression in other crawl behaviors.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added/updated unit tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
