### PR TITLE
docs-fix: resolve conflict

### DIFF
--- a/docs/md_v2/core/examples.md
+++ b/docs/md_v2/core/examples.md
@@ -28,11 +28,8 @@ This page provides a comprehensive list of example scripts that demonstrate vari
 | Example | Description | Link |
 |---------|-------------|------|
 | Deep Crawling | An extensive tutorial on deep crawling capabilities, demonstrating BFS and BestFirst strategies, stream vs. non-stream execution, filters, scorers, and advanced configurations. | [View Code](https://github.com/unclecode/crawl4ai/blob/main/docs/examples/deepcrawl_example.py) |
-<<<<<<< HEAD
 | Virtual Scroll | Comprehensive examples for handling virtualized scrolling on sites like Twitter, Instagram. Demonstrates different scrolling scenarios with local test server. | [View Code](https://github.com/unclecode/crawl4ai/blob/main/docs/examples/virtual_scroll_example.py) |
-=======
 | Adaptive Crawling | Demonstrates intelligent crawling that automatically determines when sufficient information has been gathered. | [View Code](https://github.com/unclecode/crawl4ai/blob/main/docs/examples/adaptive_crawling/) |
->>>>>>> feature/progressive-crawling
 | Dispatcher | Shows how to use the crawl dispatcher for advanced workload management. | [View Code](https://github.com/unclecode/crawl4ai/blob/main/docs/examples/dispatcher_example.py) |
 | Storage State | Tutorial on managing browser storage state for persistence. | [View Guide](https://github.com/unclecode/crawl4ai/blob/main/docs/examples/storage_state_tutorial.md) |
 | Network Console Capture | Demonstrates how to capture and analyze network requests and console logs. | [View Code](https://github.com/unclecode/crawl4ai/blob/main/docs/examples/network_console_capture_example.py) |


### PR DESCRIPTION
## Summary
Resolved a merge conflict in docs/md_v2/core/examples.md that was preventing the documentation from rendering correctly due to leftover conflict markers.

## List of files changed and why
1. docs/md_v2/core/examples.md
Resolved leftover Git conflict markers (<<<<<<<, =======, >>>>>>>) that were introduced during a previous merge. These markers were preventing the documentation from rendering correctly. The conflict has been manually reviewed and fixed to restore proper formatting.

## How Has This Been Tested?
1. Verified that the Markdown file (examples.md) renders correctly in the documentation viewer without any syntax errors or visible conflict markers.

2. Confirmed that the fixed section displays the intended content and structure.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added/updated unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<img width="897" height="496" alt="Screenshot 2025-07-29 223212" src="https://github.com/user-attachments/assets/e12e6968-c56f-43e5-a0fc-a103b04bbfad" />
