### PR TITLE
In obtaining cleaned_html, the tag "script" needs to be processed separately.

### DIFF
--- a/crawl4ai/content_scraping_strategy.py
+++ b/crawl4ai/content_scraping_strategy.py
@@ -1668,7 +1668,26 @@ class LXMLWebScrapingStrategy(WebScrapingStrategy):
                 content_element = body
 
             # Remove script and style tags
-            for tag in ["script", "style", "link", "meta", "noscript"]:
+            # Handle script separately
+            for element in body.xpath(f".//script"):
+                parent = element.getparent()
+                if parent is not None:
+                    tail = element.tail  # Get the tail text
+                    if tail:
+                        prev = element.getprevious()  # Get the previous sibling node
+                        if prev is not None:
+                            if prev.tail:
+                                prev.tail += tail 
+                            else:
+                                prev.tail = tail
+                        else:
+                            if parent.text:
+                                parent.text += tail
+                            else:
+                                parent.text = tail
+                    parent.remove(element)  # Delete the element
+
+            for tag in ["style", "link", "meta", "noscript"]:
                 for element in body.xpath(f".//{tag}"):
                     if element.getparent() is not None:
                         element.getparent().remove(element)

--- a/crawl4ai/content_scraping_strategy.py
+++ b/crawl4ai/content_scraping_strategy.py
@@ -1668,6 +1668,11 @@ class LXMLWebScrapingStrategy(WebScrapingStrategy):
                 content_element = body
 
             # Remove script and style tags
+            for tag in ["style", "link", "meta", "noscript"]:
+                for element in body.xpath(f".//{tag}"):
+                    if element.getparent() is not None:
+                        element.getparent().remove(element)
+                        
             # Handle script separately
             for element in body.xpath(f".//script"):
                 parent = element.getparent()
@@ -1687,10 +1692,6 @@ class LXMLWebScrapingStrategy(WebScrapingStrategy):
                                 parent.text = tail
                     parent.remove(element)  # Delete the element
 
-            for tag in ["style", "link", "meta", "noscript"]:
-                for element in body.xpath(f".//{tag}"):
-                    if element.getparent() is not None:
-                        element.getparent().remove(element)
 
             # Handle social media and domain exclusions
             kwargs["exclude_domains"] = set(kwargs.get("exclude_domains", []))


### PR DESCRIPTION
## Summary

In obtaining cleaned_html, the tag <script> needs to be processed separately.

## List of files changed and why

For the crawl4ai/content_scraping_strategy.py:

- When using XPath to delete the <script> element, the tail text of the element (such as 'uwa.edu') will disappear along with the element because tail is the text attached to the position of the element in the parent node.

## How Has This Been Tested?

The test code is as follows:

```python
import asyncio
import requests
from crawl4ai import *

async def main():
    raw_html = '<a>natalie.cordon<span class="email-ta">@</span><script>encryptedA();</script>uwa.edu<span class="email-tod">.</span><script>encryptedDot();</script>au</a>'
    async with AsyncWebCrawler() as crawler:
        result = await crawler.arun(
            url="raw://" + raw_html,        
        )

        print(result.cleaned_html)
        print(result.markdown)

if __name__ == "__main__":
    asyncio.run(main())
```

The source code test result is incorrect:

```
raw_html: <a>natalie.cordon<span class="email-ta">@</span><script>encryptedA();</script>uwa.edu<span class="email-tod">.</span><script>encryptedDot();</script>au</a>

cleaned_html: <html><body><a>natalie.cordon<span>@</span><span>.</span></a></body></html>

markdown: natalie.cordon@.
```

The test result is correct after modifying the code:

```
raw_html: <a>natalie.cordon<span class="email-ta">@</span><script>encryptedA();</script>uwa.edu<span class="email-tod">.</span><script>encryptedDot();</script>au</a>

cleaned_html: <html><body>
<a>natalie.cordon<span>@</span>uwa.edu<span>.</span>au</a></body></html>

markdown: natalie.cordon@uwa.edu.au
```

P.S. I really like your work and thank you for your contributions. Related web pages containing the label: https://research-repository.uwa.edu.au/en/organisations/school-of-allied-health/persons/
