### PR TITLE
issue #1329: Docs are not detected due to triplequotes not being first line 

### DIFF
--- a/crawl4ai/async_configs.py
+++ b/crawl4ai/async_configs.py
@@ -813,12 +813,6 @@ class HTTPCrawlerConfig:
         return HTTPCrawlerConfig.from_kwargs(config)
 
 class CrawlerRunConfig():
-    _UNWANTED_PROPS = {
-        'disable_cache' : 'Instead, use cache_mode=CacheMode.DISABLED',
-        'bypass_cache' : 'Instead, use cache_mode=CacheMode.BYPASS',
-        'no_cache_read' : 'Instead, use cache_mode=CacheMode.WRITE_ONLY',
-        'no_cache_write' : 'Instead, use cache_mode=CacheMode.READ_ONLY',
-    }
 
     """
     Configuration class for controlling how the crawler runs each crawl operation.
@@ -1023,6 +1017,12 @@ class CrawlerRunConfig():
 
         url: str = None  # This is not a compulsory parameter
     """
+    _UNWANTED_PROPS = {
+        'disable_cache' : 'Instead, use cache_mode=CacheMode.DISABLED',
+        'bypass_cache' : 'Instead, use cache_mode=CacheMode.BYPASS',
+        'no_cache_read' : 'Instead, use cache_mode=CacheMode.WRITE_ONLY',
+        'no_cache_write' : 'Instead, use cache_mode=CacheMode.READ_ONLY',
+    }
 
     def __init__(
         self,


### PR DESCRIPTION
## Summary
docstring didnt recognize due to not being on the first statement inside the class. I move the _UNWANTED_PROPS = block right after the entire docstring. 

eg: `Fixes issue #1329 ` 

## List of files changed and why

1. async_configs.py - the file that contains the docstring documentation


eg: quickstart.py - To update the example as per new changes

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes.

First, i tried using pylance extension in vs code and hover on the CrawlerRunConfig to see the properties. But the docstring description is missing.
I tried adding the  Pylance json into the settings.json on my prefereneces: open settings (JSON). But still when i hover it shows no docstring.

My second method i tried verify it using python build-in function help() inside a test script. 

this is the code that i ran:

# repl.py
from crawl4ai import CrawlerRunConfig

# Print the docstring attached to the class
print(CrawlerRunConfig.__doc__)


the result return the entire docstring, which python now recognizes that part is a docstring.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added/updated unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Updated internal snapshot to track a newer subproject revision, aligning with the latest upstream state. No functional impact.

* Refactor
  * Reorganized internal configuration attributes for clarity and maintainability. No changes to behavior or public APIs; existing settings and workflows continue to operate as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->