### PR TITLE
docs: make example of using a Filter with `DefaultMarkdownGenerator` directly runnable

### DIFF
--- a/deploy/docker/c4ai-doc-context.md
+++ b/deploy/docker/c4ai-doc-context.md
@@ -4877,23 +4877,29 @@ By default, Crawl4AI automatically generates Markdown from each crawled page. Ho
 ### Example: Using a Filter with `DefaultMarkdownGenerator`
 
 ```python
-from crawl4ai import AsyncWebCrawler, CrawlerRunConfig
+import asyncio
+from crawl4ai import AsyncWebCrawler, CrawlerRunConfig, CacheMode
 from crawl4ai.content_filter_strategy import PruningContentFilter
 from crawl4ai.markdown_generation_strategy import DefaultMarkdownGenerator
 
-md_generator = DefaultMarkdownGenerator(
-    content_filter=PruningContentFilter(threshold=0.4, threshold_type="fixed")
-)
+async def main():
+    md_generator = DefaultMarkdownGenerator(
+        content_filter=PruningContentFilter(threshold=0.4, threshold_type="fixed")
+    )
 
-config = CrawlerRunConfig(
-    cache_mode=CacheMode.BYPASS,
-    markdown_generator=md_generator
-)
+    config = CrawlerRunConfig(
+        cache_mode=CacheMode.BYPASS,
+        markdown_generator=md_generator
+    )
 
-async with AsyncWebCrawler() as crawler:
-    result = await crawler.arun("https://news.ycombinator.com", config=config)
-    print("Raw Markdown length:", len(result.markdown.raw_markdown))
-    print("Fit Markdown length:", len(result.markdown.fit_markdown))
+    async with AsyncWebCrawler() as crawler:
+        result = await crawler.arun("https://news.ycombinator.com", config=config)
+        print("Raw Markdown length:", len(result.markdown.raw_markdown))
+        print("Fit Markdown length:", len(result.markdown.fit_markdown))
+        
+if __name__ == "__main__":
+    asyncio.run(main())
+
 ```
 
 **Note**: If you do **not** specify a content filter or markdown generator, you’ll typically see only the raw Markdown. `PruningContentFilter` may adds around `50ms` in processing time. We’ll dive deeper into these strategies in a dedicated **Markdown Generation** tutorial.

--- a/docs/md_v2/core/quickstart.md
+++ b/docs/md_v2/core/quickstart.md
@@ -97,23 +97,28 @@ By default, Crawl4AI automatically generates Markdown from each crawled page. Ho
 ### Example: Using a Filter with `DefaultMarkdownGenerator`
 
 ```python
-from crawl4ai import AsyncWebCrawler, CrawlerRunConfig
+import asyncio
+from crawl4ai import AsyncWebCrawler, CrawlerRunConfig, CacheMode
 from crawl4ai.content_filter_strategy import PruningContentFilter
 from crawl4ai.markdown_generation_strategy import DefaultMarkdownGenerator
 
-md_generator = DefaultMarkdownGenerator(
-    content_filter=PruningContentFilter(threshold=0.4, threshold_type="fixed")
-)
+async def main():
+    md_generator = DefaultMarkdownGenerator(
+        content_filter=PruningContentFilter(threshold=0.4, threshold_type="fixed")
+    )
 
-config = CrawlerRunConfig(
-    cache_mode=CacheMode.BYPASS,
-    markdown_generator=md_generator
-)
+    config = CrawlerRunConfig(
+        cache_mode=CacheMode.BYPASS,
+        markdown_generator=md_generator
+    )
 
-async with AsyncWebCrawler() as crawler:
-    result = await crawler.arun("https://news.ycombinator.com", config=config)
-    print("Raw Markdown length:", len(result.markdown.raw_markdown))
-    print("Fit Markdown length:", len(result.markdown.fit_markdown))
+    async with AsyncWebCrawler() as crawler:
+        result = await crawler.arun("https://news.ycombinator.com", config=config)
+        print("Raw Markdown length:", len(result.markdown.raw_markdown))
+        print("Fit Markdown length:", len(result.markdown.fit_markdown))
+        
+if __name__ == "__main__":
+    asyncio.run(main())
 ```
 
 **Note**: If you do **not** specify a content filter or markdown generator, you’ll typically see only the raw Markdown. `PruningContentFilter` may adds around `50ms` in processing time. We’ll dive deeper into these strategies in a dedicated **Markdown Generation** tutorial.


### PR DESCRIPTION
## Summary
Update the example of using a Filter with `DefaultMarkdownGenerator`  so it can be copy-pasted and run directly.
Previously, the snippet was missing `import asyncio` and `asyncio.run(main())`.

## List of files changed and why

* `deploy/docker/c4ai-doc-context.md` – fixed example by wrapping in `main()` function and adding `asyncio.run(main())` to make it runnable.
* `docs/md_v2/core/quickstart.md` – same as above

## How Has This Been Tested?

* Ran the updated snippet locally with `python example.py`.
* Verified that it successfully crawls Hacker News and prints raw/fit Markdown lengths.

## Checklist:

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [ ] I have commented my code (N/A – documentation only)
* [x] I have made corresponding changes to the documentation
* [ ] I have added/updated unit tests (N/A – documentation only)
* [x] New and existing unit tests pass locally with my changes (not applicable for docs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Updated examples to use an asynchronous main coroutine with asyncio.run for clearer execution flow.
  * Demonstrated configuring cache behavior via a public enum in the sample configuration.
  * Consolidated creation of the markdown generator and crawler config inside the async function.
  * Showed async context usage for the crawler and updated invocation pattern.
  * Added sample output of Raw Markdown and Fit Markdown lengths.
  * No changes to public APIs; improvements are example-only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->