### PR TITLE
Update README.md with latest docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,9 +304,9 @@ The new Docker implementation includes:
 ### Getting Started
 
 ```bash
-# Pull and run the latest release candidate
-docker pull unclecode/crawl4ai:0.7.0
-docker run -d -p 11235:11235 --name crawl4ai --shm-size=1g unclecode/crawl4ai:0.7.0
+# Pull and run the latest release version
+docker pull unclecode/crawl4ai:latest
+docker run -d -p 11235:11235 --name crawl4ai --shm-size=1g unclecode/crawl4ai:latest
 
 # Visit the playground at http://localhost:11235/playground
 ```


### PR DESCRIPTION

## Summary
The outdated documentation suggested pulling 0.7.0 which is not available. Proposing to always pull latest.

## List of files changed and why
README.md - Update docker example with latest image

## How Has This Been Tested?
Locally, seems to run fine

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
