### PR TITLE
fix: add xvfb to docker image to enable playwright headed crawls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ ENV PYTHONFAULTHANDLER=1 \
     PIP_DEFAULT_TIMEOUT=100 \
     DEBIAN_FRONTEND=noninteractive \
     REDIS_HOST=localhost \
-    REDIS_PORT=6379
+    REDIS_PORT=6379 \
+    DISPLAY=:99
 
 ARG PYTHON_VERSION=3.12
 ARG INSTALL_TYPE=default
@@ -68,6 +69,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libcairo2 \
     libasound2 \
     libatspi2.0-0 \
+    xvfb \
+    xauth \
+    x11-utils \
     && apt-get clean \ 
     && rm -rf /var/lib/apt/lists/*
 

--- a/deploy/docker/supervisord.conf
+++ b/deploy/docker/supervisord.conf
@@ -25,4 +25,14 @@ stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr      ; Redirect gunicorn stderr to container stderr
 stderr_logfile_maxbytes=0
 
+[program:xvfb]
+command=Xvfb :99 -screen 0 1920x1080x24 -ac +extension GLX +render -noreset
+user=appuser
+autorestart=true
+priority=5
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
 # Optional: Add filebeat or other logging agents here if needed


### PR DESCRIPTION
## Summary
Please include a summary of the change and/or which issues are fixed.

Fixes #1485

## List of files changed and why
Dockerfile - Install xvfb for XServer
supervisord.conf - Run xfvb

## How Has This Been Tested?
I've tested this by adding
environment:
      - DISPLAY=:99
volumes:
      - ./supervisord-crawler.conf:/app/supervisord.conf
to my compose file and running crwl https://example.com -b "headless=false" in the container

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added/updated unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Adds built-in headless display support in the container, enabling graphics-dependent features (e.g., screenshots, visual rendering) to run reliably without a physical display.

- Chores
  - Container now starts a virtual display service automatically on boot for improved stability of UI-driven tasks.
  - Environment configured to expose the display to applications; logs are routed to standard output/error for easier monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->