### PR TITLE
Docs: Wrong parameter name in AsyncWebCrawler.arun docstring

### DIFF
--- a/crawl4ai/async_webcrawler.py
+++ b/crawl4ai/async_webcrawler.py
@@ -225,11 +225,11 @@ class AsyncWebCrawler:
                 screenshot=True,
                 ...
             )
-            result = await crawler.arun(url="https://example.com", crawler_config=config)
+            result = await crawler.arun(url="https://example.com", config=config)
 
         Args:
             url: The URL to crawl (http://, https://, file://, or raw:)
-            crawler_config: Configuration object controlling crawl behavior
+            config: Configuration object controlling crawl behavior
             [other parameters maintained for backwards compatibility]
 
         Returns:


### PR DESCRIPTION
## Summary
There is an error in the docstring of AsyncWebCrawler.arun: the parameter is called `config`, not `crawler_config`.

## List of files changed and why
crawl4ai/async_webcrawler.py - see summary

## How Has This Been Tested?
This is a docstring change, I assume it will work :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Aligned internal crawler invocation to use a standardized configuration parameter for consistency; no behavior or API changes.
* **Documentation**
  * Updated docstrings to reflect current configuration parameter naming and usage.
* **Style**
  * Minor formatting cleanup (newline at end of file).

No user-facing changes or breaking changes in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->