### PR TITLE
feat: add content-type to URL Seeder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -179,10 +179,6 @@ RUN chown -R appuser:appuser ${APP_HOME}
 # give permissions to redis persistence dirs if used
 RUN mkdir -p /var/lib/redis /var/log/redis && chown -R appuser:appuser /var/lib/redis /var/log/redis
 
-# Create cache directory for url_seeder with proper permissions
-RUN mkdir -p /home/appuser/.cache/url_seeder && chown -R appuser:appuser /home/appuser/.cache/url_seeder
-
-
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD bash -c '\
     MEM=$(free -m | awk "/^Mem:/{print \$2}"); \

--- a/Dockerfile
+++ b/Dockerfile
@@ -179,6 +179,10 @@ RUN chown -R appuser:appuser ${APP_HOME}
 # give permissions to redis persistence dirs if used
 RUN mkdir -p /var/lib/redis /var/log/redis && chown -R appuser:appuser /var/lib/redis /var/log/redis
 
+# Create cache directory for url_seeder with proper permissions
+RUN mkdir -p /home/appuser/.cache/url_seeder && chown -R appuser:appuser /home/appuser/.cache/url_seeder
+
+
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD bash -c '\
     MEM=$(free -m | awk "/^Mem:/{print \$2}"); \

--- a/crawl4ai/async_url_seeder.py
+++ b/crawl4ai/async_url_seeder.py
@@ -981,12 +981,13 @@ class AsyncUrlSeeder:
         if extract:
             self._log("debug", "Fetching head for {url}", params={
                       "url": url}, tag="URL_SEED")
-            ok, html, final = await self._fetch_head(url, timeout)
+            ok, html, final, content_type = await self._fetch_head(url, timeout)
             status = "valid" if ok else "not_valid"
             self._log("info" if ok else "warning", "HEAD {status} for {final_url}",
                       params={"status": status.upper(), "final_url": final or url}, tag="URL_SEED")
             # head_data = _parse_head(html) if ok else {}
             head_data = await asyncio.to_thread(_parse_head, html) if ok else {}
+            head_data["content_type"] = content_type
             entry = {
                 "url": final or url,
                 "status": status,
@@ -1071,13 +1072,21 @@ class AsyncUrlSeeder:
                         self._log("warning", "Non-success status {status_code} when fetching head for {url}",
                                   params={"status_code": r.status_code, "url": r.url}, tag="URL_SEED")
                         return False, "", str(r.url)
+                    
+                    # Capture content-type header
+                    content_type = r.headers.get("Content-Type", "")
+
 
                     buf = bytearray()
                     async for chunk in r.aiter_bytes(chunk_size):
                         buf.extend(chunk)
                         low = buf.lower()
                         if b"</head>" in low or len(buf) >= max_bytes:
-                            await r.aclose()
+                            try:
+                                await r.aclose()
+                            except httpx.RemoteProtocolError:
+                                # Server sent STREAM_RESET after we got what we needed - this is fine
+                                pass
                             break
 
                     enc = r.headers.get("Content-Encoding", "").lower()
@@ -1127,17 +1136,17 @@ class AsyncUrlSeeder:
                         html = html_bytes.decode("latin-1", "replace")
 
                     # Return the actual URL after redirects
-                    return True, html, str(r.url)
+                    return True, html, str(r.url), content_type
 
             except httpx.RequestError as e:
                 self._log("debug", "Fetch head network error for {url}: {error}",
                           params={"url": url, "error": str(e)}, tag="URL_SEED")
-                return False, "", url
+                return False, "", url, None
 
         # If loop finishes without returning (e.g. too many redirects)
         self._log("warning", "Exceeded max redirects ({max_redirects}) for {url}",
                   params={"max_redirects": max_redirects, "url": url}, tag="URL_SEED")
-        return False, "", url
+        return False, "", url, None
 
     # ─────────────────────────────── BM25 scoring helpers
     def _extract_text_context(self, head_data: Dict[str, Any]) -> str:


### PR DESCRIPTION
## Summary
* It's handy to have the content-type returned from the URL seeder
* Also fixed an issue with the seeder where an error was raised if the HTTP2 stream was cancelled even if we received the header data.

eg: `Fixes #123` (Tag GitHub issue numbers in this format, so it automatically links the issues with your PR)

## List of files changed and why
* crawl4ai/async_url_seeder.py- add content-type to the head_data

