### PR TITLE
fix(docker): Remove environment variable overrides in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,15 +6,16 @@ x-base-config: &base-config
     - "11235:11235"  # Gunicorn port
   env_file:
     - .llm.env       # API keys (create from .llm.env.example)
-  environment:
-    - OPENAI_API_KEY=${OPENAI_API_KEY:-}
-    - DEEPSEEK_API_KEY=${DEEPSEEK_API_KEY:-}
-    - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
-    - GROQ_API_KEY=${GROQ_API_KEY:-}
-    - TOGETHER_API_KEY=${TOGETHER_API_KEY:-}
-    - MISTRAL_API_KEY=${MISTRAL_API_KEY:-}
-    - GEMINI_API_TOKEN=${GEMINI_API_TOKEN:-}
-    - LLM_PROVIDER=${LLM_PROVIDER:-}  # Optional: Override default provider (e.g., "anthropic/claude-3-opus")
+  # Uncomment to set default environment variables (will overwrite .llm.env)
+  # environment:
+  #   - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+  #   - DEEPSEEK_API_KEY=${DEEPSEEK_API_KEY:-}
+  #   - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+  #   - GROQ_API_KEY=${GROQ_API_KEY:-}
+  #   - TOGETHER_API_KEY=${TOGETHER_API_KEY:-}
+  #   - MISTRAL_API_KEY=${MISTRAL_API_KEY:-}
+  #   - GEMINI_API_KEY=${GEMINI_API_KEY:-}
+  #   - LLM_PROVIDER=${LLM_PROVIDER:-}  # Optional: Override default provider (e.g., "anthropic/claude-3-opus")
   volumes:
     - /dev/shm:/dev/shm  # Chromium performance
   deploy:


### PR DESCRIPTION
## Summary

Fixes #1411 - Docker Compose configuration was overriding `.llm.env` values with empty strings, causing LLM authentication failures.

**Root Cause:** The `environment:` section in `docker-compose.yml` used variable substitution syntax (`${VAR:-}`) that checks the shell environment and `.env` file (not `.llm.env`) for values. When variables weren't found, Docker Compose substituted empty strings, which then overwrote the values from `.llm.env` due to Docker Compose's precedence rules (`environment:` has higher precedence than `env_file:`).

**Solution:** Commented out the `environment:` section to allow `.llm.env` values to load directly into the container without being overwritten. This makes the Docker Compose behavior consistent with `docker run --env-file .llm.env` as documented.

## List of files changed and why

- **`docker-compose.yml`** - Commented out the `environment:` section (lines 10-18) that was overriding `.llm.env` values with empty strings. Added a warning comment explaining that uncommenting will cause `.llm.env` to be overwritten.

## How Has This Been Tested?

**Test Environment:**
- Docker Compose v2.x
- Created `.llm.env` with `GEMINI_API_KEY` and `LLM_PROVIDER=gemini/gemini-2.5-flash`

**Test Steps:**
1. **Before fix (environment section uncommented):**
   ```bash
   docker compose up -d
   docker exec crawl4ai-crawl4ai-1 env | grep -E "(GEMINI_API_KEY|LLM_PROVIDER)"
   # Result: GEMINI_API_KEY, LLM_PROVIDER was empty
   curl "http://localhost:11235/llm/https://example.com/?q=test"
   # Result: Authentication error - tried to use OpenAI without key (defaulted to openai provided as mentioned in config.yml)
   ```

2. **After fix (environment section commented):**
   ```bash
   docker compose down && docker compose up -d
   docker exec crawl4ai-crawl4ai-1 env | grep -E "(GEMINI_API_KEY|LLM_PROVIDER)"
   # Result: Both GEMINI_API_KEY and LLM_PROVIDER properly loaded ✅
   curl "http://localhost:11235/llm/https://example.com/?q=test"
   # Result: {"answer":"..."} - Works with Gemini! ✅
   ```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added/updated unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

**Note:** Unit tests for Docker Compose configuration behavior would require Docker-in-Docker setup. The fix has been manually tested and verified to work as documented. The configuration change is a simplification (removal) rather than new code, making it inherently less error-prone.

## References

- [Docker Compose Environment Variables Precedence](https://docs.docker.com/compose/how-tos/environment-variables/envvars-precedence/)