### PR TITLE
feat: Add Azure OpenAI configuration support to crwl config

### DIFF
--- a/crawl4ai/cli.py
+++ b/crawl4ai/cli.py
@@ -60,25 +60,35 @@ def setup_llm_config() -> tuple[str, str]:
     config = get_global_config()
     provider = config.get("DEFAULT_LLM_PROVIDER")
     token = config.get("DEFAULT_LLM_PROVIDER_TOKEN")
-    
+
     if not provider:
         click.echo("\nNo default LLM provider configured.")
         click.echo("Provider format: 'company/model' (e.g., 'openai/gpt-4o', 'anthropic/claude-3-sonnet')")
         click.echo("See available providers at: https://docs.litellm.ai/docs/providers")
         provider = click.prompt("Enter provider")
-        
+
     if not provider.startswith("ollama/"):
         if not token:
             token = click.prompt("Enter API token for " + provider, hide_input=True)
     else:
         token = "no-token"
-    
+
     if not config.get("DEFAULT_LLM_PROVIDER") or not config.get("DEFAULT_LLM_PROVIDER_TOKEN"):
         config["DEFAULT_LLM_PROVIDER"] = provider
         config["DEFAULT_LLM_PROVIDER_TOKEN"] = token
         save_global_config(config)
         click.echo("\nConfiguration saved to ~/.crawl4ai/global.yml")
-    
+
+    # Export Azure-specific environment variables if configured
+    # This allows Azure OpenAI to work without requiring env vars to be set manually
+    azure_api_base = config.get("AZURE_API_BASE")
+    azure_api_version = config.get("AZURE_API_VERSION")
+
+    if azure_api_base:
+        os.environ["AZURE_API_BASE"] = azure_api_base
+    if azure_api_version:
+        os.environ["AZURE_API_VERSION"] = azure_api_version
+
     return provider, token
 
 async def stream_llm_response(url: str, markdown: str, query: str, provider: str, token: str):

--- a/crawl4ai/config.py
+++ b/crawl4ai/config.py
@@ -142,5 +142,15 @@ USER_SETTINGS = {
         "description": "Default user agent mode (default, random, or mobile)",
         "type": "string",
         "options": ["default", "random", "mobile"]
+    },
+    "AZURE_API_BASE": {
+        "default": "",
+        "description": "Azure OpenAI API base URL (e.g., 'https://your-resource.openai.azure.com')",
+        "type": "string"
+    },
+    "AZURE_API_VERSION": {
+        "default": "",
+        "description": "Azure OpenAI API version (e.g., '2024-08-01-preview')",
+        "type": "string"
     }
 }


### PR DESCRIPTION
## Summary

This PR adds support for configuring Azure OpenAI settings through `crwl config`, eliminating the need to manually set environment variables before each command.

## Changes

- Added `AZURE_API_BASE` configuration setting to `USER_SETTINGS` in `config.py`
- Added `AZURE_API_VERSION` configuration setting to `USER_SETTINGS` in `config.py`
- Updated `setup_llm_config()` in `cli.py` to export Azure environment variables from the global configuration

## Motivation

Currently, when using Azure OpenAI with crawl4ai, users must export `AZURE_API_BASE` and `AZURE_API_VERSION` environment variables before running each command:

```bash
AZURE_API_BASE="https://your-resource.openai.azure.com" \
AZURE_API_VERSION="2024-08-01-preview" \
crwl https://example.com -q "What is this about?"
```

This is inconvenient and error-prone. With this PR, users can configure these settings once:

```bash
crwl config set AZURE_API_BASE "https://your-resource.openai.azure.com"
crwl config set AZURE_API_VERSION "2024-08-01-preview"
crwl config set DEFAULT_LLM_PROVIDER "azure/gpt-5"
```

And then use crawl4ai with Azure OpenAI without any environment variables:

```bash
crwl https://example.com -q "What is this about?"
```

## Testing

Tested locally with Azure OpenAI GPT-5 deployment:
- Configured Azure settings via `crwl config set`
- Verified settings are stored in `~/.crawl4ai/global.yml`
- Successfully ran `crwl` commands without setting environment variables
- Confirmed LiteLLM received the Azure environment variables correctly

## Implementation Details

The `setup_llm_config()` function now reads `AZURE_API_BASE` and `AZURE_API_VERSION` from the global configuration and exports them as environment variables before LiteLLM is called. This ensures backward compatibility while providing a better user experience.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>