### PR TITLE
fix: apply correct dark mode behavior when light_mode=False

### DIFF
--- a/crawl4ai/async_configs.py
+++ b/crawl4ai/async_configs.py
@@ -449,11 +449,13 @@ class BrowserConfig:
         user_agent_mode: str = "",
         user_agent_generator_config: dict = {},
         text_mode: bool = False,
-        light_mode: bool = False,
+        performance_mode: bool = False,
+        dark_mode: bool = False,
         extra_args: list = None,
         debugging_port: int = 9222,
         host: str = "localhost",
         enable_stealth: bool = False,
+        **kwargs,
     ):
         
         self.browser_type = browser_type
@@ -502,7 +504,19 @@ class BrowserConfig:
         self.user_agent_mode = user_agent_mode
         self.user_agent_generator_config = user_agent_generator_config
         self.text_mode = text_mode
-        self.light_mode = light_mode
+        
+        # Handle light_mode for backward compatibility
+        if "light_mode" in kwargs:
+            warnings.warn(
+                "The 'light_mode' parameter is deprecated and will be removed in a future version. "
+                "Use 'performance_mode' instead.",
+                DeprecationWarning
+            )
+            self.performance_mode = kwargs.get("light_mode", performance_mode)
+        else:
+            self.performance_mode = performance_mode
+        self.dark_mode = dark_mode
+        
         self.extra_args = extra_args if extra_args is not None else []
         self.sleep_on_close = sleep_on_close
         self.verbose = verbose
@@ -550,6 +564,18 @@ class BrowserConfig:
 
     @staticmethod
     def from_kwargs(kwargs: dict) -> "BrowserConfig":
+        
+        # Handle light_mode for backward compatibility
+        if "light_mode" in kwargs:
+            warnings.warn(
+                "The 'light_mode' parameter is deprecated and will be removed in a future version. "
+                "Use 'performance_mode' instead.",
+                DeprecationWarning
+            )
+            performance_mode = kwargs.pop("light_mode", False)
+        else:
+            performance_mode = kwargs.get("performance_mode", False)
+
         return BrowserConfig(
             browser_type=kwargs.get("browser_type", "chromium"),
             headless=kwargs.get("headless", True),
@@ -579,7 +605,8 @@ class BrowserConfig:
             user_agent_mode=kwargs.get("user_agent_mode"),
             user_agent_generator_config=kwargs.get("user_agent_generator_config"),
             text_mode=kwargs.get("text_mode", False),
-            light_mode=kwargs.get("light_mode", False),
+            performance_mode=performance_mode,
+            dark_mode=kwargs.get("dark_mode", False),
             extra_args=kwargs.get("extra_args", []),
             debugging_port=kwargs.get("debugging_port", 9222),
             host=kwargs.get("host", "localhost"),
@@ -612,7 +639,8 @@ class BrowserConfig:
             "user_agent_mode": self.user_agent_mode,
             "user_agent_generator_config": self.user_agent_generator_config,
             "text_mode": self.text_mode,
-            "light_mode": self.light_mode,
+            "performance_mode": self.performance_mode,
+            "dark_mode": self.dark_mode,
             "extra_args": self.extra_args,
             "sleep_on_close": self.sleep_on_close,
             "verbose": self.verbose,

--- a/crawl4ai/browser_manager.py
+++ b/crawl4ai/browser_manager.py
@@ -89,7 +89,7 @@ class ManagedBrowser:
             "--mute-audio",
             "--disable-background-timer-throttling",
         ]
-        if config.light_mode:
+        if config.performance_mode:
             flags.extend(BROWSER_DISABLE_OPTIONS)
         if config.text_mode:
             flags.extend([
@@ -730,7 +730,7 @@ class BrowserManager:
             f"--window-size={self.config.viewport_width},{self.config.viewport_height}",
         ]
 
-        if self.config.light_mode:
+        if self.config.performance_mode:
             args.extend(BROWSER_DISABLE_OPTIONS)
 
         if self.config.text_mode:
@@ -944,6 +944,8 @@ class BrowserManager:
             "device_scale_factor": 1.0,
             "java_script_enabled": self.config.java_script_enabled,
         }
+        if self.config.dark_mode:
+            context_settings["color_scheme"] = "dark"
         
         if crawlerRunConfig:
             # Check if there is value for crawlerRunConfig.proxy_config set add that to context


### PR DESCRIPTION
---

## **Summary**

Fixes #1631

This PR fixes the issue where `light_mode=False` did not enable dark mode correctly and instead acted as a performance configuration flag. The browser initially launched in light mode and only switched to dark after opening DevTools. The fix introduces proper dark mode support while maintaining backward compatibility with existing integrations.

---

## **List of files changed and why**

* `BrowserConfig` — Renamed `light_mode` to `performance_mode` and added a new `dark_mode` parameter to accurately control UI theme rendering.
* `browser_manager.py` — Updated browser launch arguments and implemented `color_scheme="dark"` handling within `create_browser_context`.

---

## **How Has This Been Tested?**

Manual verification by launching the browser with:

```python
BrowserConfig(
    dark_mode=True,
    performance_mode=True,
    enable_stealth=True,
    headless=False,
)
```

Dark mode now activates immediately without requiring DevTools.

---

## **Checklist:**

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] I have added/updated unit tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes

---