### PR TITLE
Fix BrowserConfig proxy_config serialization

### DIFF
--- a/crawl4ai/async_configs.py
+++ b/crawl4ai/async_configs.py
@@ -598,7 +598,7 @@ class BrowserConfig:
             "chrome_channel": self.chrome_channel,
             "channel": self.channel,
             "proxy": self.proxy,
-            "proxy_config": self.proxy_config,
+            "proxy_config": self.proxy_config.to_dict() if self.proxy_config else None,
             "viewport_width": self.viewport_width,
             "viewport_height": self.viewport_height,
             "accept_downloads": self.accept_downloads,


### PR DESCRIPTION
## Summary
Summary
Ensures `BrowserConfig.to_dict()` emits JSON-safe data by converting nested ProxyConfig objects into dictionaries.

Prevents `TypeError: Object of type ProxyConfig is not JSON serializable` in environments (like Docker) that hash browser configs via json.dumps.

Fixes #1629

## List of files changed and why
`crawl4ai/async_configs.py` - updated BrowserConfig.to_dict() so proxy_config is serialized to a plain dict when present

## How Has This Been Tested?
Tested by using proxy config in docker environment and python library.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added/updated unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
