### PR TITLE
Replace Chinese comment with English in nullcontext method

### DIFF
--- a/crawl4ai/async_webcrawler.py
+++ b/crawl4ai/async_webcrawler.py
@@ -198,7 +198,7 @@ class AsyncWebCrawler:
 
     @asynccontextmanager
     async def nullcontext(self):
-        """异步空上下文管理器"""
+        """Async null context manager that yields nothing."""
         yield
 
     async def arun(

--- a/deploy/docker/c4ai-code-context.md
+++ b/deploy/docker/c4ai-code-context.md
@@ -1548,7 +1548,7 @@ class AsyncWebCrawler:
 
     @asynccontextmanager
     async def nullcontext(self):
-        """异步空上下文管理器"""
+        """Async null context manager that yields nothing."""
         yield
 
     async def arun(


### PR DESCRIPTION
## Summary
- Replaced Chinese docstring `异步空上下文管理器` with English `Async null context manager that yields nothing.`
- Updated both the source file (`crawl4ai/async_webcrawler.py`) and the documentation (`deploy/docker/c4ai-code-context.md`)

## Details
The `nullcontext` method in `AsyncWebCrawler` had a Chinese comment that should be in English for consistency with the rest of the codebase.

## Test plan
- [x] Verified no other Chinese comments exist in source code (test files with Chinese test data were intentionally left unchanged)
- [x] Linting passes
- [x] Tests pass