### PR TITLE
Fix: html2text ignores base tag when resolving relative links (#1680)

### DIFF
--- a/crawl4ai/html2text/__init__.py
+++ b/crawl4ai/html2text/__init__.py
@@ -312,6 +312,14 @@ class HTML2Text(html.parser.HTMLParser):
     ) -> None:
         self.current_tag = tag
 
+        if tag == "base" and start and attrs.get("href"):
+            href = attrs["href"]
+            if self.baseurl:
+                self.baseurl = urlparse.urljoin(self.baseurl, href)
+            else:
+                self.baseurl = href
+            return
+
         if self.tag_callback is not None:
             if self.tag_callback(self, tag, attrs, start) is True:
                 return


### PR DESCRIPTION
## Summary
Fixes #1680

The `html2text` module was previously ignoring the HTML `<base>` tag. This caused relative links to be resolved incorrectly (relative to the page URL instead of the base URL) when a `<base>` tag was present in the document head. This PR adds logic to detect and respect the `<base>` tag during parsing.

## List of files changed and why
* `crawl4ai/html2text/__init__.py` - Updated the `handle_tag` method to check for the `base` tag and update `self.baseurl` with the provided `href`. This ensures all subsequent relative links in the document are resolved against this new base URL.

## How Has This Been Tested?
I verified this change using a local reproduction script with the following test case:

**Test Scenario:**
*   **Page URL:** `https://example.com/subfolder/page.html`
*   **Input HTML:**
    ```html
    <html>
    <head>
        <base href="https://example.com/">
    </head>
    <body>
        <a href="files/document.pdf">Link</a>
    </body>
    </html>
    ```
*   **Behavior Before Fix:** The link resolved relative to the page URL: `https://example.com/subfolder/files/document.pdf`
*   **Behavior After Fix:** The link correctly resolves relative to the base tag: `https://example.com/files/document.pdf`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added/updated unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes