### PR TITLE
feat: add force viewport screenshot

### DIFF
--- a/crawl4ai/async_configs.py
+++ b/crawl4ai/async_configs.py
@@ -1081,6 +1081,9 @@ class CrawlerRunConfig():
                                              Default: None.
         screenshot_height_threshold (int): Threshold for page height to decide screenshot strategy.
                                            Default: SCREENSHOT_HEIGHT_TRESHOLD (from config, e.g. 20000).
+        force_viewport_screenshot (bool): If True, always take viewport-only screenshots regardless of page height.
+                                          When False, uses automatic decision (viewport for short pages, full-page for long pages).
+                                          Default: False.
         pdf (bool): Whether to generate a PDF of the page.
                     Default: False.
         image_description_min_word_threshold (int): Minimum words for image description extraction.
@@ -1220,6 +1223,7 @@ class CrawlerRunConfig():
         screenshot: bool = False,
         screenshot_wait_for: float = None,
         screenshot_height_threshold: int = SCREENSHOT_HEIGHT_TRESHOLD,
+        force_viewport_screenshot: bool = False,
         pdf: bool = False,
         capture_mhtml: bool = False,
         image_description_min_word_threshold: int = IMAGE_DESCRIPTION_MIN_WORD_THRESHOLD,
@@ -1336,6 +1340,7 @@ class CrawlerRunConfig():
         self.screenshot = screenshot
         self.screenshot_wait_for = screenshot_wait_for
         self.screenshot_height_threshold = screenshot_height_threshold
+        self.force_viewport_screenshot = force_viewport_screenshot
         self.pdf = pdf
         self.capture_mhtml = capture_mhtml
         self.image_description_min_word_threshold = image_description_min_word_threshold

--- a/crawl4ai/async_crawler_strategy.py
+++ b/crawl4ai/async_crawler_strategy.py
@@ -998,7 +998,9 @@ class AsyncPlaywrightCrawlerStrategy(AsyncCrawlerStrategy):
                 if config.screenshot_wait_for:
                     await asyncio.sleep(config.screenshot_wait_for)
                 screenshot_data = await self.take_screenshot(
-                    page, screenshot_height_threshold=config.screenshot_height_threshold
+                    page,
+                    screenshot_height_threshold=config.screenshot_height_threshold,
+                    force_viewport_screenshot=config.force_viewport_screenshot
                 )
 
             if screenshot_data or pdf_data or mhtml_data:
@@ -1536,6 +1538,13 @@ class AsyncPlaywrightCrawlerStrategy(AsyncCrawlerStrategy):
         Returns:
             str: The base64-encoded screenshot data
         """
+        # Check if viewport-only screenshot is forced
+        force_viewport = kwargs.get('force_viewport_screenshot', False)
+
+        if force_viewport:
+            # Use viewport-only screenshot
+            return await self.take_screenshot_naive(page)
+
         need_scroll = await self.page_need_scroll(page)
 
         if not need_scroll:


### PR DESCRIPTION
## Summary
At the moment, the crawler only supports full-page screenshots. In some cases, users only need a viewport screenshot, which is significantly smaller and faster to capture, especially for long pages. This change introduces optional viewport-only screenshots to address that use case.

## List of files changed and why
- `crawl4ai/async_configs.py`  
  Adds a new configuration option to enable capturing screenshots limited to the viewport.
- `crawl4ai/async_crawler_strategy.py`  
  Implements the logic for capturing viewport-only screenshots (no scrolling, naive).

## How Has This Been Tested?
I tested the feature by capturing screenshots with the viewport option set to both `True` and `False` on short and long pages, verifying that the correct screenshot type is produced in each case.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added/updated unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
