### PR TITLE
Add Google Search crawler JavaScript files to package data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ crwl = "crawl4ai.cli:main"
 packages = {find = {where = ["."], include = ["crawl4ai*"]}}
 
 [tool.setuptools.package-data]
-crawl4ai = ["js_snippet/*.js"]
+crawl4ai = ["js_snippet/*.js", "crawlers/google_search/*.js"]
 
 [tool.setuptools.dynamic]
 version = {attr = "crawl4ai.__version__.__version__"}


### PR DESCRIPTION
Fix packaging issue in the Crawl4AI repository. The `script.js` file is not included in the package distribution.

## Summary
The `script.js` file is not included in the package distribution. Looking at the packaging configuration:

- `pyproject.toml` only includes `js_snippet/*.js` in package data [pyproject.toml:88-89](https://github.com/unclecode/crawl4ai/blob/c85f56b085a1d5b62779774d48887345e566869b/pyproject.toml#L88)
- `setup.py` also only specifies `js_snippet/*.js` [setup.py:54](https://github.com/unclecode/crawl4ai/blob/c85f56b085a1d5b62779774d48887345e566869b/setup.py#L54)
- `GoogleSearchCrawler` expects `script.js` in its own directory [crawler.py:21-22](https://github.com/unclecode/crawl4ai/blob/c85f56b085a1d5b62779774d48887345e566869b/crawl4ai/crawlers/google_search/crawler.py#L21) .

## List of files changed
updated `pyproject.toml` as follows:
```
[tool.setuptools.package-data]  
crawl4ai = ["js_snippet/*.js", "crawlers/google_search/*.js"]
```