### PR TITLE
docs: Add missing CacheMode import in quickstart documentation (#1477)

### DIFF
--- a/docs/md_v2/core/quickstart.md
+++ b/docs/md_v2/core/quickstart.md
@@ -97,7 +97,7 @@ By default, Crawl4AI automatically generates Markdown from each crawled page. Ho
 ### Example: Using a Filter with `DefaultMarkdownGenerator`
 
 ```python
-from crawl4ai import AsyncWebCrawler, CrawlerRunConfig
+from crawl4ai import AsyncWebCrawler, CrawlerRunConfig, CacheMode
 from crawl4ai.content_filter_strategy import PruningContentFilter
 from crawl4ai.markdown_generation_strategy import DefaultMarkdownGenerator
 


### PR DESCRIPTION
## 🎯 Summary
Fixes #1477

## 📝 Description
The code example in "4. Generating Markdown Output" section of the quickstart documentation was using `CacheMode.BYPASS` without importing `CacheMode`, which would cause a `NameError` when users try to run the example.

## 🔧 Changes
- Added `CacheMode` to the imports from `crawl4ai` module in `docs/md_v2/core/quickstart.md`

## ✅ Before
```python
from crawl4ai import AsyncWebCrawler, CrawlerRunConfig
# CacheMode not imported, but used in config
```

## ✅ After
```python
from crawl4ai import AsyncWebCrawler, CrawlerRunConfig, CacheMode
# CacheMode is now properly imported
```

Co-Authored-By: Claude <noreply@anthropic.com>