### PR TITLE
docs: Update return types for arun() and arun_many() to RunManyReturn (#1543)

### DIFF
--- a/docs/md_v2/api/arun_many.md
+++ b/docs/md_v2/api/arun_many.md
@@ -10,7 +10,7 @@ async def arun_many(
     config: Optional[Union[CrawlerRunConfig, List[CrawlerRunConfig]]] = None,
     dispatcher: Optional[BaseDispatcher] = None,
     ...
-) -> Union[List[CrawlResult], AsyncGenerator[CrawlResult, None]]:
+) -> RunManyReturn:
     """
     Crawl multiple URLs concurrently or in batches.
 
@@ -20,16 +20,16 @@ async def arun_many(
         - A list of `CrawlerRunConfig` objects with url_matcher patterns
     :param dispatcher: (Optional) A concurrency controller (e.g. MemoryAdaptiveDispatcher).
     ...
-    :return: Either a list of `CrawlResult` objects, or an async generator if streaming is enabled.
+    :return: RunManyReturn containing either a list of `CrawlResult` objects or an async generator if streaming is enabled.
     """
 ```
 
 ## Differences from `arun()`
 
-1. **Multiple URLs**:  
-   
-   - Instead of crawling a single URL, you pass a list of them (strings or tasks).  
-   - The function returns either a **list** of `CrawlResult` or an **async generator** if streaming is enabled.
+1. **Multiple URLs**:
+
+   - Instead of crawling a single URL, you pass a list of them (strings or tasks).
+   - The function returns `RunManyReturn` which contains either a **list** of `CrawlResult` or an **async generator** if streaming is enabled.
 
 2. **Concurrency & Dispatchers**:  
 
@@ -164,7 +164,7 @@ results = await crawler.arun_many(
 
 ### Return Value
 
-Either a **list** of [`CrawlResult`](./crawl-result.md) objects, or an **async generator** if streaming is enabled. You can iterate to check `result.success` or read each item’s `extracted_content`, `markdown`, or `dispatch_result`.
+Returns a **`RunManyReturn`** object which contains either a **list** of [`CrawlResult`](./crawl-result.md) objects, or an **async generator** if streaming is enabled. You can iterate to check `result.success` or read each item's `extracted_content`, `markdown`, or `dispatch_result`.
 
 ---
 

--- a/docs/md_v2/api/async-webcrawler.md
+++ b/docs/md_v2/api/async-webcrawler.md
@@ -103,7 +103,7 @@ async def arun(
     url: str,
     config: Optional[CrawlerRunConfig] = None,
     # Legacy parameters for backward compatibility...
-) -> CrawlResult:
+) -> RunManyReturn:
     ...
 ```
 
@@ -143,7 +143,7 @@ async def arun_many(
     urls: List[str],
     config: Optional[CrawlerRunConfig] = None,
     # Legacy parameters maintained for backwards compatibility...
-) -> List[CrawlResult]:
+) -> RunManyReturn:
     """
     Process multiple URLs with intelligent rate limiting and resource monitoring.
     """


### PR DESCRIPTION
## 🎯 Summary
Fixes #1543

## 📝 Description
The documentation was incorrectly stating that `arun()` returns `CrawlResult` and `arun_many()` returns `Union[List[CrawlResult], AsyncGenerator[CrawlResult, None]]`. However, both methods actually return `RunManyReturn`, causing issues with IDE auto-completion and type hints.

## 🔧 Changes
- **docs/md_v2/api/async-webcrawler.md**:
  - Changed arun() return type from `CrawlResult` to `RunManyReturn`
  - Changed arun_many() return type from `List[CrawlResult]` to `RunManyReturn`

- **docs/md_v2/api/arun_many.md**:
  - Changed function signature return type from `Union[List[CrawlResult], AsyncGenerator[CrawlResult, None]]` to `RunManyReturn`
  - Updated docstring and descriptions to reflect that `RunManyReturn` contains either a list of results or an async generator

## ✅ Actual Return Types (from source code)
```python
# crawl4ai/async_webcrawler.py:204
async def arun(...) -> RunManyReturn:

# crawl4ai/async_webcrawler.py:665
async def arun_many(...) -> RunManyReturn:
```

Co-Authored-By: Claude <noreply@anthropic.com>