### PR TITLE
fix: Allow local embeddings by removing OpenAI fallback (#1658)

### DIFF
--- a/crawl4ai/adaptive_crawler.py
+++ b/crawl4ai/adaptive_crawler.py
@@ -630,18 +630,15 @@ class EmbeddingStrategy(CrawlStrategy):
         self._validation_embeddings_cache = None  # Cache validation query embeddings
         self._kb_similarity_threshold = 0.95  # Threshold for deduplication
     
-    def _get_embedding_llm_config_dict(self) -> Dict:
-        """Get embedding LLM config as dict with fallback to default."""
+    def _get_embedding_llm_config_dict(self) -> Optional[Dict]:
+        """Get embedding LLM config as dict, or None for local embeddings."""
         if hasattr(self, 'config') and self.config:
             config_dict = self.config._embedding_llm_config_dict
             if config_dict:
                 return config_dict
-        
-        # Fallback to default if no config provided
-        return {
-            'provider': 'openai/text-embedding-3-small',
-            'api_token': os.getenv('OPENAI_API_KEY')
-        }
+
+        # Return None to use local sentence-transformers embeddings
+        return None
         
     async def _get_embeddings(self, texts: List[str]) -> Any:
         """Get embeddings using configured method"""


### PR DESCRIPTION
## 🎯 Summary
Fixes #1658

## 📝 Description
The `_get_embedding_llm_config_dict` method in `EmbeddingStrategy` was returning a fallback OpenAI config when `embedding_llm_config` was None. This prevented users from using local `sentence-transformers` embeddings, as the `get_text_embeddings` utility never saw `None` and always used remote embeddings.

## 🔧 Changes
**crawl4ai/adaptive_crawler.py**:
- Changed return type from `Dict` to `Optional[Dict]`
- Removed fallback OpenAI config, now returns `None` when no config is provided
- Updated docstring to clarify behavior

## ✅ Before
```python
def _get_embedding_llm_config_dict(self) -> Dict:
    # Always returns a dict, even when user wants local embeddings
    return {
        'provider': 'openai/text-embedding-3-small',
        'api_token': os.getenv('OPENAI_API_KEY')
    }
```

## ✅ After
```python
def _get_embedding_llm_config_dict(self) -> Optional[Dict]:
    # Returns None to allow local sentence-transformers
    return None
```

## 🎯 Impact
Users can now use local embeddings by configuring `AdaptiveCrawler` without `embedding_llm_config`:
```python
config = AdaptiveConfig(strategy="embedding", embedding_llm_config=None)
```

Co-Authored-By: Claude <noreply@anthropic.com>