### PR TITLE
fix: Initialize default logger in AsyncPlaywrightCrawlerStrategy (#1704)

### DIFF
--- a/crawl4ai/async_crawler_strategy.py
+++ b/crawl4ai/async_crawler_strategy.py
@@ -87,7 +87,8 @@ class AsyncPlaywrightCrawlerStrategy(AsyncCrawlerStrategy):
         """
         # Initialize browser config, either from provided object or kwargs
         self.browser_config = browser_config or BrowserConfig.from_kwargs(kwargs)
-        self.logger = logger
+        # Initialize with default logger if none provided to prevent NoneType errors
+        self.logger = logger if logger is not None else AsyncLogger(verbose=False)
         
         # Initialize browser adapter
         self.adapter = browser_adapter or PlaywrightAdapter()


### PR DESCRIPTION
## Summary
- Initialize default AsyncLogger when no logger is provided to AsyncPlaywrightCrawlerStrategy
- Prevents NoneType errors when using custom crawler strategies with screenshots/PDFs

## Fixes
Fixes #1704

## Details
When users directly instantiate `AsyncPlaywrightCrawlerStrategy` without passing a logger, `self.logger` remains `None`. This causes crashes when the strategy attempts to log events, particularly during:
- Screenshot export
- PDF generation
- MHTML export

The fix initializes a default `AsyncLogger(verbose=False)` when no logger is provided, ensuring all logger calls succeed.

## Root Cause
From the issue analysis:
- Users passing custom strategies to `AsyncWebCrawler` don't always provide loggers
- 47 places in the codebase call logger methods without null checks
- Only 8 places have null checks

## Test plan
- [x] Code review confirms the fix prevents NoneType errors
- [x] Default logger is silent (verbose=False) to avoid unwanted output
- [x] Existing behavior is preserved when logger is explicitly provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)