### PR TITLE
fix: Include GoogleSearchCrawler script.js in package distribution (#1711)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ crwl = "crawl4ai.cli:main"
 packages = {find = {where = ["."], include = ["crawl4ai*"]}}
 
 [tool.setuptools.package-data]
-crawl4ai = ["js_snippet/*.js"]
+crawl4ai = ["js_snippet/*.js", "crawlers/google_search/*.js"]
 
 [tool.setuptools.dynamic]
 version = {attr = "crawl4ai.__version__.__version__"}


### PR DESCRIPTION
## Summary
- Added GoogleSearchCrawler's script.js to package distribution
- Fixes FileNotFoundError when using GoogleSearchCrawler from installed package

## Fixes
Fixes #1711

## Details
The `crawl4ai/crawlers/google_search/script.js` file was not included in the
Python package distribution, causing this error when using GoogleSearchCrawler:

\`\`\`
FileNotFoundError: '/tmp/windmill/cache/python_3_12/crawl4ai==0.7.8/crawl4ai/crawlers/google_search/script.js'
\`\`\`

Fixed by adding `crawl4ai/crawlers/google_search/*.js` to the setuptools
package-data configuration in pyproject.toml.

## Test plan
- [x] Verified script.js exists in the source tree
- [x] Added to package-data pattern in pyproject.toml
- [x] File will now be included in wheel distributions

🤖 Generated with [Claude Code](https://claude.com/claude-code)