### PR TITLE
fix: Handle markdown-wrapped JSON in LLM schema generation (#1663)

### DIFF
--- a/crawl4ai/extraction_strategy.py
+++ b/crawl4ai/extraction_strategy.py
@@ -1380,7 +1380,15 @@ In this scenario, use your best judgment to generate the schema. You need to exa
             )
             
             # Extract and return schema
-            return json.loads(response.choices[0].message.content)
+            # Clean markdown code blocks that LLMs sometimes wrap JSON in
+            content = response.choices[0].message.content
+            # Remove markdown code block markers if present
+            if "```json" in content:
+                content = content.replace("```json\n", "").replace("\n```", "")
+            elif "```" in content:
+                content = content.replace("```\n", "").replace("\n```", "")
+            content = content.strip()
+            return json.loads(content)
             
         except Exception as e:
             raise Exception(f"Failed to generate schema: {str(e)}")


### PR DESCRIPTION
## Summary
- Strip markdown code block markers from LLM responses before JSON parsing
- Fixes JSONDecodeError when LLMs return JSON wrapped in \`\`\`json...\`\`\`

## Fixes
Fixes #1663

## Details
Claude Sonnet and other LLMs sometimes return valid JSON wrapped in markdown
code blocks, even when JSON mode is enabled. This causes `json.loads()` to fail
with:

\`\`\`
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
\`\`\`

The fix pre-processes the LLM response to remove common markdown patterns:
- \`\`\`json\\n...\\n\`\`\`
- \`\`\`\\n...\\n\`\`\`

Before attempting JSON parsing in `JsonCssExtractionStrategy.generate_schema()`.

## Test plan
- [x] Code review confirms the fix handles common markdown wrapping patterns
- [x] Preserves valid JSON responses without markdown
- [x] Maintains backward compatibility with existing behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)