### PR TITLE
fix: Respect <base> tag for relative link resolution in html2text (#1680)

### DIFF
--- a/crawl4ai/html2text/__init__.py
+++ b/crawl4ai/html2text/__init__.py
@@ -316,6 +316,12 @@ class HTML2Text(html.parser.HTMLParser):
             if self.tag_callback(self, tag, attrs, start) is True:
                 return
 
+        # Handle <base> tag to update base URL for relative links
+        if tag == "base" and start:
+            href = attrs.get("href")
+            if href:
+                self.baseurl = href
+
         # first thing inside the anchor tag is another tag
         # that produces some output
         if (
@@ -1069,6 +1075,15 @@ class CustomHTML2Text(HTML2Text):
                 setattr(self, key, value)
 
     def handle_tag(self, tag, attrs, start):
+        # Handle <base> tag to update base URL for relative links
+        # Must be handled before preserved tags since <base> is in <head>
+        if tag == "base" and start:
+            href = attrs.get("href") if attrs else None
+            if href:
+                self.baseurl = href
+            # Also let parent class handle it
+            return super().handle_tag(tag, attrs, start)
+
         # Handle preserved tags
         if tag in self.preserve_tags:
             if start:


### PR DESCRIPTION
## Summary
- Added <base> tag handling in HTML2Text and CustomHTML2Text
- Updates baseurl when <base href=\"...\"> is encountered
- Fixes relative link resolution to follow HTML standards

## Fixes
Fixes #1680

## Details
The HTML2Text class was ignoring the `<base>` tag, causing relative links
to be resolved against the initial page URL instead of the base URL
specified in the HTML document.

According to HTML standards, the `<base>` element specifies the base URL
for all relative URLs in a document. This is commonly used in:
- Content Management Systems (CMS)
- Single Page Applications (SPA)
- Documentation sites
- Sites with complex URL structures

### Changes
1. **HTML2Text.handle_tag()**: Added `<base>` tag detection and baseurl update
2. **CustomHTML2Text.handle_tag()**: Added same handling before preserved tags processing

### Example
Before:
- Page URL: `https://example.com/index.php/page.html`
- Base tag: `<base href="https://example.com/">`
- Relative link: `files/document.pdf`
- **Resolved to**: `https://example.com/index.php/files/document.pdf` ❌

After:
- **Resolved to**: `https://example.com/files/document.pdf` ✅

## Test plan
- [x] Code review confirms <base> tag is properly handled
- [x] Both HTML2Text and CustomHTML2Text updated
- [x] baseurl is updated when <base> tag is encountered
- [x] Follows HTML standard behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)