### PR TITLE
fix: Add docstring to MCP tool 'md' endpoint

### DIFF
--- a/deploy/docker/server.py
+++ b/deploy/docker/server.py
@@ -308,6 +308,17 @@ async def get_markdown(
     body: MarkdownRequest,
     _td: Dict = Depends(token_dep),
 ):
+    """
+    Convert a web page into Markdown format.
+
+    Supports multiple extraction modes:
+    - fit (default): Readability-based extraction for clean content
+    - raw: Direct DOM to Markdown conversion
+    - bm25: BM25 relevance ranking with optional query
+    - llm: LLM-based summarization with optional query
+
+    Use this tool when you need clean, readable text from web pages.
+    """
     if not body.url.startswith(("http://", "https://")) and not body.url.startswith(("raw:", "raw://")):
         raise HTTPException(
             400, "Invalid URL format. Must start with http://, https://, or for raw HTML (raw:, raw://)")


### PR DESCRIPTION
## Summary
Fixes #1652

The `get_markdown` function in `deploy/docker/server.py` was missing a docstring, which caused the MCP tool 'md' to have no description when exposed via `_list_tools()`.

## List of files changed and why
- `deploy/docker/server.py` - Added docstring to `get_markdown` function to provide description for MCP tool listing

## How Has This Been Tested?
The fix adds a docstring that is properly picked up by `inspect.getdoc()` in the `_list_tools()` function. The docstring describes:
- The tool's purpose (converting web pages to Markdown)
- Supported extraction modes (fit, raw, bm25, llm)
- Usage guidance for LLMs and developers

## Checklist:
- [x] My code follows the style guidelines of this project (follows existing docstring format in `generate_html`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (N/A - docstring is documentation)
- [ ] I have added/updated unit tests that prove my fix is effective or that my feature works (N/A - simple docstring addition)
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)