### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -31,7 +31,7 @@ jobs:
           df -h
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Extract version from release or tag
         id: get_version
@@ -67,7 +67,7 @@ jobs:
           password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Build and push Docker images
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 


### PR DESCRIPTION
## Summary  
Updated GitHub Action versions for compatibility with newer releases  

## List of files changed and why  
- `actions/checkout` - Updated from `v4` to `v6` in `.github/workflows/release.yml`  
- `docker/build-push-action` - Updated from `v5` to `v6` in `.github/workflows/docker-release.yml`  
- `actions/setup-python` - Updated from `v5` to `v6` in `.github/workflows/release.yml`  
- `actions/checkout` - Updated from `v4` to `v6` in `.github/workflows/docker-release.yml`  

## How Has This Been Tested?  
Tests will be executed in the CI pipeline of the pull request to verify version compatibility and functionality.  

## Checklist  
- [x] My code follows the style guidelines of this project  
- [x] I have performed a self-review of my own code  
- [ ] I have commented my code, particularly in hard-to-understand areas  
- [ ] I have made corresponding changes to the documentation  
- [ ] I have added/updated unit tests that prove my fix is effective or that my feature works  
- [ ] New and existing unit tests pass locally with my changes