### PR TITLE
Fix: Avoid Common Crawl calls for sitemap-only URL seeding

### DIFF
--- a/crawl4ai/async_url_seeder.py
+++ b/crawl4ai/async_url_seeder.py
@@ -400,17 +400,19 @@ class AsyncUrlSeeder:
         if self.logger and hasattr(self.logger, 'verbose') and config.verbose is not None:
             self.logger.verbose = config.verbose
 
-        # ensure we have the latest CC collection id
-        if self.index_id is None:
-            self.index_id = await self._latest_index()
-
         # Parse source parameter - split by '+' to get list of sources
-        sources = source.split('+')
+        sources = [s.strip().lower() for s in source.split("+") if s.strip()]
+
         valid_sources = {"cc", "sitemap"}
         for s in sources:
             if s not in valid_sources:
                 raise ValueError(
                     f"Invalid source '{s}'. Valid sources are: {', '.join(valid_sources)}")
+
+            # ensure we have the latest CC collection id when the source is cc
+            if s == "cc" and self.index_id is None:
+                self.index_id = await self._latest_index()
+
 
         if hits_per_sec:
             if hits_per_sec <= 0:

--- a/tests/general/test_url_seeder_for_only_sitemap.py
+++ b/tests/general/test_url_seeder_for_only_sitemap.py
@@ -1,0 +1,30 @@
+import asyncio
+from crawl4ai import AsyncLogger, AsyncUrlSeeder, SeedingConfig
+from pathlib import Path
+import httpx
+
+
+async def test_sitemap_source_does_not_hit_commoncrawl():
+    config = SeedingConfig(
+        source="sitemap",
+        live_check=False,
+        extract_head=False,
+        max_urls=50,
+        verbose=True,
+        force=False
+    )
+
+    async with AsyncUrlSeeder(logger=AsyncLogger(verbose=True)) as seeder:
+        async def boom(*args, **kwargs):
+            print("DEBUG: _latest_index called")
+            raise httpx.ConnectTimeout("Simulated CommonCrawl outage")
+
+        seeder._latest_index = boom
+        try:
+            await seeder.urls("https://docs.crawl4ai.com/", config)
+            print("PASS: _latest_index was NOT called (expected after fix).")
+        except httpx.ConnectTimeout:
+            print("FAIL: _latest_index WAS called even though source='sitemap'.")
+
+if __name__ == "__main__":
+    asyncio.run(test_sitemap_source_does_not_hit_commoncrawl())


### PR DESCRIPTION
## Summary
Fixes the issue #1747.
Fixes an issue where **AsyncUrlSeeder** initialized the Common Crawl index even when **source="sitemap"** was specified. This caused unnecessary requests to Common Crawl and **ConnectTimeout** failures in environments where Common Crawl is unreachable. The change ensures Common Crawl is only initialized when explicitly requested and normalizes the **source** string to be case-insensitive. The ability to perform URL seeding using sitemap only should not depend on the availability of the Common Crawl indexes.

## List of files changed and why
**async_url_seeder.py** – Updated source parsing logic to normalize and validate the source value, and to initialize the Common Crawl index only when "cc" is explicitly included. This prevents unintended Common Crawl calls during sitemap-only seeding.
Since the sources are matched using string matching, I've added normalization of the source tokens (case-insensitive, trimmed) to ensure values like "CC" or "cc + sitemap" or " cc" or " CC + sitemap  " are handled correctly.

## How Has This Been Tested?
- Added a regression test that simulates a Common Crawl outage by overriding **_latest_index()** to raise a **ConnectTimeout**.
- Verified that sitemap-only seeding no longer invokes Common Crawl and completes successfully.
- Confirmed that Common Crawl is still initialized when **source** includes **"cc"** (e.g. "cc" or "cc+sitemap").

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added/updated unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
