### PR TITLE
Fix AttributeError in FilterChain.add_filter (Tuple Immutability) #1753

### DIFF
--- a/crawl4ai/deep_crawling/filters.py
+++ b/crawl4ai/deep_crawling/filters.py
@@ -85,7 +85,7 @@ class FilterChain:
 
     def add_filter(self, filter_: URLFilter) -> "FilterChain":
         """Add a filter to the chain"""
-        self.filters.append(filter_)
+        self.filters = self.filters + (filter_,)
         return self  # Enable method chaining
 
     async def apply(self, url: str) -> bool:


### PR DESCRIPTION
## Description
Fixes #1753

The `FilterChain` class initializes `self.filters` as a tuple for immutability, but the `add_filter` method was attempting to use `.append()`, which is a list method, causing an `AttributeError`.

## Changes
- Modified `add_filter` to create a new tuple `self.filters + (filter_,)` instead of mutating the existing one.
- This preserves the design intent (immutability) while fixing the crash.

## Verification
- Reproduced the crash with a script.
- Verified that `add_filter` now correctly adds a filter to the chain without raising an error.