### PR TITLE
fix: run blocking chardet.detect in thread executor #1751

### DIFF
--- a/crawl4ai/async_crawler_strategy.py
+++ b/crawl4ai/async_crawler_strategy.py
@@ -2448,7 +2448,8 @@ class AsyncHTTPCrawlerStrategy(AsyncCrawlerStrategy):
                     
                     encoding = response.charset
                     if not encoding:
-                        encoding = chardet.detect(content.tobytes())['encoding'] or 'utf-8'                    
+                        detection_result = await asyncio.to_thread(chardet.detect, content.tobytes())
+                        encoding = detection_result['encoding'] or 'utf-8'                    
                     
                     result = AsyncCrawlResponse(
                         html=content.tobytes().decode(encoding, errors='replace'),


### PR DESCRIPTION
Fixes #1751
The Bug:
chardet.detect is CPU-bound and was blocking the main asyncio event loop in _handle_http, causing lags of 1+ seconds on large pages.
The Fix:
Wrapped the detection in asyncio.to_thread to offload it to a worker thread.
Verification:
Verified locally with a reproduction script; the event loop heartbeat remained active during detection.