### PR TITLE
Fix #1758: Fix Screenshot MCP Tool

### DIFF
--- a/crawl4ai/async_crawler_strategy.py
+++ b/crawl4ai/async_crawler_strategy.py
@@ -1744,7 +1744,7 @@ class AsyncPlaywrightCrawlerStrategy(AsyncCrawlerStrategy):
 
             buffered = BytesIO()
             stitched = stitched.convert("RGB")
-            stitched.save(buffered, format="BMP", quality=85)
+            stitched.save(buffered, format="PNG")
             encoded = base64.b64encode(buffered.getvalue()).decode("utf-8")
 
             return encoded

--- a/deploy/docker/server.py
+++ b/deploy/docker/server.py
@@ -382,9 +382,10 @@ async def generate_screenshot(
     _td: Dict = Depends(token_dep),
 ):
     """
-    Capture a full-page PNG screenshot of the specified URL, waiting an optional delay before capture,
-    Use when you need an image snapshot of the rendered page. Its recommened to provide an output path to save the screenshot.
-    Then in result instead of the screenshot you will get a path to the saved file.
+    Capture a full-page PNG screenshot of the specified URL, waiting an optional delay before capture.
+    Use when you need an image snapshot of the rendered page.
+    Returns a base64-encoded PNG screenshot. If output_path is provided, the server will also
+    attempt to save the file locally (useful for non-Docker deployments).
     """
     validate_url_scheme(body.url)
     from crawler_pool import get_crawler
@@ -395,13 +396,17 @@ async def generate_screenshot(
         if not results[0].success:
             raise HTTPException(500, detail=results[0].error_message or "Crawl failed")
         screenshot_data = results[0].screenshot
+        saved_path = None
         if body.output_path:
-            abs_path = os.path.abspath(body.output_path)
-            os.makedirs(os.path.dirname(abs_path), exist_ok=True)
-            with open(abs_path, "wb") as f:
-                f.write(base64.b64decode(screenshot_data))
-            return {"success": True, "path": abs_path}
-        return {"success": True, "screenshot": screenshot_data}
+            try:
+                abs_path = os.path.abspath(body.output_path)
+                os.makedirs(os.path.dirname(abs_path), exist_ok=True)
+                with open(abs_path, "wb") as f:
+                    f.write(base64.b64decode(screenshot_data))
+                saved_path = abs_path
+            except Exception:
+                pass  # File save is best-effort; screenshot data is always returned
+        return {"success": True, "screenshot": screenshot_data, **({"path": saved_path} if saved_path else {})}
     except Exception as e:
         raise HTTPException(500, detail=str(e))
 


### PR DESCRIPTION
## Summary
Fix Screenshot MCP Tool saving screenshots only to the Docker filesystem instead of returning PNG data, and correct screenshot encoding format from BMP to PNG.

Fixes #1758

This PR ensures that screenshots are always returned as base64-encoded PNG data in the API response, making them accessible to remote MCP clients. It also fixes an incorrect image format encoding that caused scrollable screenshots to be returned as BMP instead of the documented PNG format.

## List of files changed and why

**crawl4ai/async_crawler_strategy.py**  
- Updated `take_screenshot_scroller` to save stitched screenshots in PNG format instead of BMP.  
- Previously, `"BMP"` was explicitly specified, causing scrollable screenshots to return BMP-encoded data instead of PNG.  
- This change ensures consistency with documentation and expected client behavior.

**deploy/docker/server.py**  
- Modified the `/screenshot` endpoint to always include base64-encoded screenshot data in the response.  
- Previously, when `output_path` was provided, only a filesystem path inside the Docker container was returned, which is inaccessible to MCP clients.  
- File saving is now best-effort, and the response always includes the `screenshot` field.  
- Ensures remote MCP clients can reliably access screenshot data regardless of filesystem access.

## How Has This Been Tested?

- Verified existing tests (`test_6_multi_endpoint.py`, `run_security_tests.py`) continue to pass without modification.
- Confirmed MCP bridge (`mcp_bridge.py`) correctly serializes the updated response using generic `json.dumps`, with no dependency on specific response keys.
- Validated response compatibility:
  - Without `output_path`: response shape remains unchanged.
  - With `output_path`: response now includes additional `screenshot` field while preserving existing behavior.
- Manually verified scrollable screenshots are now encoded and returned as PNG instead of BMP.
- Confirmed screenshots are accessible remotely via API response even when file saving is enabled.

**Note:**  
No existing unit tests specifically covered:
- BMP vs PNG encoding correctness
- Screenshot accessibility when `output_path` is provided  

New tests should be added in future to cover these cases.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added/updated unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
