### PR TITLE
Fix cascading context crash under concurrent crawl load

### DIFF
--- a/crawl4ai/async_crawler_strategy.py
+++ b/crawl4ai/async_crawler_strategy.py
@@ -579,11 +579,19 @@ class AsyncPlaywrightCrawlerStrategy(AsyncCrawlerStrategy):
             #     [{"name": "cookiesEnabled", "value": "true", "url": url}]
             # )
 
-            # NOTE: navigator_overrider and shadow-DOM init scripts are
-            # already injected once per context in BrowserManager.setup_context().
-            # Do NOT call context.add_init_script() here — it mutates the
-            # shared context from concurrent tasks and causes cascading
-            # "Target page, context or browser has been closed" failures.
+            # Handle navigator overrides (page-scoped to avoid mutating
+            # the shared context from concurrent tasks)
+            if config.override_navigator or config.simulate_user or config.magic:
+                await page.add_init_script(load_js_script("navigator_overrider"))
+
+            # Force-open closed shadow roots when flatten_shadow_dom is enabled
+            if config.flatten_shadow_dom:
+                await page.add_init_script("""
+                    const _origAttachShadow = Element.prototype.attachShadow;
+                    Element.prototype.attachShadow = function(init) {
+                        return _origAttachShadow.call(this, {...init, mode: 'open'});
+                    };
+                """)
 
             # Call hook after page creation
             await self.execute_hook("on_page_context_created", page, context=context, config=config)

--- a/crawl4ai/browser_manager.py
+++ b/crawl4ai/browser_manager.py
@@ -1211,23 +1211,9 @@ class BrowserManager:
                 ]
             )
 
-        # Handle navigator overrides
-        if crawlerRunConfig:
-            if (
-                crawlerRunConfig.override_navigator
-                or crawlerRunConfig.simulate_user
-                or crawlerRunConfig.magic
-            ):
-                await context.add_init_script(load_js_script("navigator_overrider"))
-
-        # Force-open closed shadow roots when flatten_shadow_dom is enabled
-        if crawlerRunConfig and crawlerRunConfig.flatten_shadow_dom:
-            await context.add_init_script("""
-                const _origAttachShadow = Element.prototype.attachShadow;
-                Element.prototype.attachShadow = function(init) {
-                    return _origAttachShadow.call(this, {...init, mode: 'open'});
-                };
-            """)
+        # NOTE: navigator_overrider and shadow-DOM init scripts are now
+        # injected per-page in _crawl_web() via page.add_init_script()
+        # to avoid mutating the shared context under concurrent load.
 
         # Apply custom init_scripts from BrowserConfig (for stealth evasions, etc.)
         if self.config.init_scripts:


### PR DESCRIPTION
### Problem

When multiple URLs are crawled concurrently and share a BrowserContext (same config signature), all crawls may fail with:
```
BrowserContext.add_init_script: Target page, context or browser has been closed
```
…due to only one URL (e.g. a slow/timing-out site) which was problematic.

Example failure logs — 10 concurrent crawls, all failing within seconds of each other:
```
[ERROR] Error in crawl: BrowserContext.add_init_script: Target page, context or browser has been closed
[ERROR] Error in crawl: BrowserContext.add_init_script: Target page, context or browser has been closed
[ERROR] Error in crawl: BrowserContext.add_init_script: Target page, context or browser has been closed
... (repeated for all concurrent URLs)
```
See detailed logs: [logs.log](https://github.com/user-attachments/files/25454637/logs.log)

### Root cause

`_crawl_web()` in `async_crawler_strategy.py` called `context.add_init_script()` on every crawl for the `override_navigator`, `simulate_user` or `magic` and `shadow dom`. These same scripts are already injected once per context in `BrowserManager.setup_context()`.

The issue is that `add_init_script` is append-only, Playwright has not API to dedup or replace scripts. This causes:

1. Script accumulation: With N concurrent crawls on one context, 2 + 2N init scripts pile up (2 from setup_context + 2 per `_crawl_web` call). On context reuse across batches, this grows unbounded.
2. Memory/CPU pressure: Every new page or frame in the context must execute all accumulated scripts. With 10+ renderer processes each running dozens of duplicate scripts, Chromium hits internal resource limits.
3. Silent context death: Chromium kills the overloaded context without a graceful error. Any concurrent page on that context, including ones that were crawling perfectly fine, immediately gets "Target page, context or browser has been closed".
4. Cascading failure: Because `add_init_script()` is the first context-level operation in `_crawl_web()`, it's the first call to discover the context is dead, producing the distinctive error message across all concurrent tasks.

Removing the add_init_script per scrape fixes the issue has tested using the same script as in https://github.com/unclecode/crawl4ai/pull/1640 (link to direct message https://github.com/unclecode/crawl4ai/pull/1640#issuecomment-3873561529).