### PR TITLE
docs: modernize deprecated Crawl4AI API usage across shipped docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -805,21 +805,21 @@ This release focuses on stability with 11 bug fixes addressing issues reported b
   ```
 
 - **🎨 Multi-URL Configuration**: Different strategies for different URL patterns in one batch:
-  ```python
-  from crawl4ai import CrawlerRunConfig, MatchMode
+```python
+from crawl4ai import CrawlerRunConfig, MatchMode, CacheMode
   
   configs = [
       # Documentation sites - aggressive caching
       CrawlerRunConfig(
           url_matcher=["*docs*", "*documentation*"],
-          cache_mode="write",
+          cache_mode=CacheMode.WRITE_ONLY,
           markdown_generator_options={"include_links": True}
       ),
       
       # News/blog sites - fresh content
       CrawlerRunConfig(
           url_matcher=lambda url: 'blog' in url or 'news' in url,
-          cache_mode="bypass"
+          cache_mode=CacheMode.BYPASS
       ),
       
       # Fallback for everything else

--- a/docs/apps/iseeyou/llms-full.txt
+++ b/docs/apps/iseeyou/llms-full.txt
@@ -643,7 +643,7 @@ browser_config = BrowserConfig(
 # Advanced browser setup with proxy and persistence
 browser_config = BrowserConfig(
     headless=False,
-    proxy="http://user:pass@proxy:8080",
+    proxy_config="http://user:pass@proxy:8080",
     use_persistent_context=True,
     user_data_dir="./browser_data",
     cookies=[
@@ -2412,7 +2412,7 @@ async def batch_llm_extraction():
             if result.success:
                 contents.append({
                     "url": url,
-                    "content": result.fit_markdown[:2000]  # Limit content
+                    "content": result.markdown.fit_markdown[:2000]  # Limit content
                 })
     
     # Process in batches (reduce LLM calls)
@@ -4719,7 +4719,7 @@ browser_config = BrowserConfig(
     headless=True,
     viewport_width=1280,
     viewport_height=720,
-    proxy="http://user:pass@proxy:8080"
+    proxy_config="http://user:pass@proxy:8080"
 )
 
 # Get JSON structure

--- a/docs/examples/async_webcrawler_multiple_urls_example.py
+++ b/docs/examples/async_webcrawler_multiple_urls_example.py
@@ -30,7 +30,7 @@ async def main():
         results = await crawler.arun_many(
             urls=urls,
             word_count_threshold=word_count_threshold,
-            bypass_cache=True,
+            cache_mode=CacheMode.BYPASS,
             verbose=True,
         )
 

--- a/docs/examples/crawlai_vs_firecrawl.py
+++ b/docs/examples/crawlai_vs_firecrawl.py
@@ -34,7 +34,7 @@ async def compare():
             url="https://www.nbcnews.com/business",
             # js_code=["const loadMoreButton = Array.from(document.querySelectorAll('button')).find(button => button.textContent.includes('Load More')); loadMoreButton && loadMoreButton.click();"],
             word_count_threshold=0,
-            bypass_cache=True,
+            cache_mode=CacheMode.BYPASS,
             verbose=False,
         )
         end = time.time()
@@ -53,7 +53,7 @@ async def compare():
                 "const loadMoreButton = Array.from(document.querySelectorAll('button')).find(button => button.textContent.includes('Load More')); loadMoreButton && loadMoreButton.click();"
             ],
             word_count_threshold=0,
-            bypass_cache=True,
+            cache_mode=CacheMode.BYPASS,
             verbose=False,
         )
         end = time.time()

--- a/docs/examples/serp_api_project_11_feb.py
+++ b/docs/examples/serp_api_project_11_feb.py
@@ -8,6 +8,7 @@ from crawl4ai import (
     BrowserConfig,
     CrawlerRunConfig,
     CacheMode,
+    LLMConfig,
     LLMExtractionStrategy,
     JsonCssExtractionStrategy,
     CrawlerHub,
@@ -63,8 +64,10 @@ async def extract_using_llm():
             snippet: str
             sitelinks: Optional[List[Sitelink]] = None        
 
-        llm_extraction_strategy = LLMExtractionStrategy(
-            provider = "openai/gpt-4o",
+    llm_extraction_strategy = LLMExtractionStrategy(
+            llm_config = LLMConfig(
+                provider = "openai/gpt-4o",
+            ),
             schema = GoogleSearchResult.model_json_schema(),
             instruction="""I want to extract the title, link, snippet, and sitelinks from a Google search result. I shared here the content of div#search from the search result page. We are just interested in organic search results.
             Example: 

--- a/docs/examples/summarize_page.py
+++ b/docs/examples/summarize_page.py
@@ -1,17 +1,13 @@
-import os
+import asyncio
 import json
-from crawl4ai.web_crawler import WebCrawler
-from crawl4ai.chunking_strategy import *
-from crawl4ai import *
-from crawl4ai.crawler_strategy import *
-
-url = r"https://marketplace.visualstudio.com/items?itemName=Unclecode.groqopilot"
-
-crawler = WebCrawler()
-crawler.warmup()
+import os
 
 from pydantic import BaseModel, Field
 
+from crawl4ai import AsyncWebCrawler, CrawlerRunConfig, LLMConfig
+from crawl4ai import CacheMode, LLMExtractionStrategy
+
+url = r"https://marketplace.visualstudio.com/items?itemName=Unclecode.groqopilot"
 
 class PageSummary(BaseModel):
     title: str = Field(..., description="Title of the page.")
@@ -20,29 +16,38 @@ class PageSummary(BaseModel):
     keywords: list = Field(..., description="Keywords assigned to the page.")
 
 
-result = crawler.run(
-    url=url,
-    word_count_threshold=1,
-    extraction_strategy=LLMExtractionStrategy(
-        provider="openai/gpt-4o",
-        api_token=os.getenv("OPENAI_API_KEY"),
-        schema=PageSummary.model_json_schema(),
-        extraction_type="schema",
-        apply_chunking=False,
-        instruction="From the crawled content, extract the following details: "
-        "1. Title of the page "
-        "2. Summary of the page, which is a detailed summary "
-        "3. Brief summary of the page, which is a paragraph text "
-        "4. Keywords assigned to the page, which is a list of keywords. "
-        "The extracted JSON format should look like this: "
-        '{ "title": "Page Title", "summary": "Detailed summary of the page.", "brief_summary": "Brief summary in a paragraph.", "keywords": ["keyword1", "keyword2", "keyword3"] }',
-    ),
-    bypass_cache=True,
-)
+async def main():
+    async with AsyncWebCrawler() as crawler:
+        result = await crawler.arun(
+            url=url,
+            config=CrawlerRunConfig(
+                word_count_threshold=1,
+                cache_mode=CacheMode.BYPASS,
+                extraction_strategy=LLMExtractionStrategy(
+                    llm_config=LLMConfig(
+                        provider="openai/gpt-4o",
+                        api_token=os.getenv("OPENAI_API_KEY"),
+                    ),
+                    schema=PageSummary.model_json_schema(),
+                    extraction_type="schema",
+                    apply_chunking=False,
+                    instruction="From the crawled content, extract the following details: "
+                    "1. Title of the page "
+                    "2. Summary of the page, which is a detailed summary "
+                    "3. Brief summary of the page, which is a paragraph text "
+                    "4. Keywords assigned to the page, which is a list of keywords. "
+                    'The extracted JSON format should look like this: '
+                    '{ "title": "Page Title", "summary": "Detailed summary of the page.", "brief_summary": "Brief summary in a paragraph.", "keywords": ["keyword1", "keyword2", "keyword3"] }',
+                ),
+            ),
+        )
 
-page_summary = json.loads(result.extracted_content)
+    page_summary = json.loads(result.extracted_content)
+    print(page_summary)
 
-print(page_summary)
+    with open(".data/page_summary.json", "w", encoding="utf-8") as f:
+        f.write(result.extracted_content)
 
-with open(".data/page_summary.json", "w", encoding="utf-8") as f:
-    f.write(result.extracted_content)
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/docs/examples/website-to-api/web_scraper_lib.py
+++ b/docs/examples/website-to-api/web_scraper_lib.py
@@ -170,7 +170,7 @@ class WebScraperAgent:
                     delay_before_return_html=5,
                 )
             )
-            html = result.fit_html
+            html = result.markdown.fit_html
         
         # Step 2: Generate schema using AI with custom model if specified
         print("AI is analyzing the page structure...")

--- a/docs/md_v2/advanced/proxy-security.md
+++ b/docs/md_v2/advanced/proxy-security.md
@@ -264,7 +264,7 @@ run_config = CrawlerRunConfig(proxy_config="socks5://proxy.example.com:1080")
 ```python
 # Old (deprecated) approach
 # from crawl4ai import BrowserConfig
-# browser_config = BrowserConfig(proxy="http://proxy.example.com:8080")
+# browser_config = BrowserConfig(proxy_config="http://proxy.example.com:8080")
 
 # New (preferred) approach
 from crawl4ai import CrawlerRunConfig

--- a/docs/md_v2/api/arun.md
+++ b/docs/md_v2/api/arun.md
@@ -62,10 +62,10 @@ run_config = CrawlerRunConfig(
 
 **Additional flags**:
 
-- `bypass_cache=True` acts like `CacheMode.BYPASS`.
-- `disable_cache=True` acts like `CacheMode.DISABLED`.
-- `no_cache_read=True` acts like `CacheMode.WRITE_ONLY`.
-- `no_cache_write=True` acts like `CacheMode.READ_ONLY`.
+- `cache_mode=CacheMode.BYPASS` acts like `CacheMode.BYPASS`.
+- `cache_mode=CacheMode.DISABLED` acts like `CacheMode.DISABLED`.
+- `cache_mode=CacheMode.WRITE_ONLY` acts like `CacheMode.WRITE_ONLY`.
+- `cache_mode=CacheMode.READ_ONLY` acts like `CacheMode.READ_ONLY`.
 
 ---
 

--- a/docs/md_v2/api/async-webcrawler.md
+++ b/docs/md_v2/api/async-webcrawler.md
@@ -200,7 +200,7 @@ Each `arun()` returns a **`CrawlResult`** containing:
 - `url`: Final URL (if redirected).
 - `html`: Original HTML.
 - `cleaned_html`: Sanitized HTML.
-- `markdown_v2`: Deprecated. Instead just use regular `markdown`
+- `markdown_v2`: Removed in v0.5. Accessing it raises `AttributeError`; use `markdown`.
 - `extracted_content`: If an extraction strategy was used (JSON for CSS/LLM strategies).
 - `screenshot`, `pdf`: If screenshots/PDF requested.
 - `media`, `links`: Information about discovered images/links.

--- a/docs/md_v2/api/crawl-result.md
+++ b/docs/md_v2/api/crawl-result.md
@@ -401,8 +401,8 @@ async def handle_result(result: CrawlResult):
 ## 9. Key Points & Future
 
 1. **Deprecated legacy properties of CrawlResult**  
-   - `markdown_v2` - Deprecated in v0.5. Just use `markdown`. It holds the `MarkdownGenerationResult` now!
-   - `fit_markdown` and `fit_html` - Deprecated in v0.5. They can now be accessed via `MarkdownGenerationResult` in `result.markdown`. eg: `result.markdown.fit_markdown` and `result.markdown.fit_html`
+   - `markdown_v2` - Removed in v0.5 and now raises `AttributeError`. Use `result.markdown` instead.
+   - `fit_markdown` and `fit_html` - No longer top-level properties in v0.5. Use `result.markdown.fit_markdown` and `result.markdown.fit_html`.
 
 2. **Fit Content**  
    - **`fit_markdown`** and **`fit_html`** appear in MarkdownGenerationResult, only if you used a content filter (like **PruningContentFilter** or **BM25ContentFilter**) inside your **MarkdownGenerationStrategy** or set them directly.  

--- a/docs/md_v2/api/parameters.md
+++ b/docs/md_v2/api/parameters.md
@@ -10,7 +10,7 @@ browser_cfg = BrowserConfig(
     headless=True,
     viewport_width=1280,
     viewport_height=720,
-    proxy="http://user:pass@proxy:8080",
+    proxy_config="http://user:pass@proxy:8080",
     user_agent="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/116.0.0.0 Safari/537.36",
 )
 ```
@@ -379,7 +379,7 @@ async def main():
         headless=False,
         viewport_width=1280,
         viewport_height=720,
-        proxy="http://user:pass@myproxy:8080",
+        proxy_config="http://user:pass@myproxy:8080",
         text_mode=True
     )
 

--- a/docs/md_v2/api/strategies.md
+++ b/docs/md_v2/api/strategies.md
@@ -216,7 +216,7 @@ from crawl4ai import LLMConfig
 async with AsyncWebCrawler() as crawler:
     # Get sample HTML first
     sample_result = await crawler.arun("https://example.com/products")
-    html = sample_result.fit_html
+    html = sample_result.markdown.fit_html
     
     # Generate regex pattern once
     pattern = RegexExtractionStrategy.generate_pattern(

--- a/docs/md_v2/assets/llm.txt/txt/config_objects.txt
+++ b/docs/md_v2/assets/llm.txt/txt/config_objects.txt
@@ -19,7 +19,7 @@ browser_config = BrowserConfig(
 # Advanced browser setup with proxy and persistence
 browser_config = BrowserConfig(
     headless=False,
-    proxy="http://user:pass@proxy:8080",
+    proxy_config="http://user:pass@proxy:8080",
     use_persistent_context=True,
     user_data_dir="./browser_data",
     cookies=[

--- a/docs/md_v2/assets/llm.txt/txt/docker.txt
+++ b/docs/md_v2/assets/llm.txt/txt/docker.txt
@@ -484,7 +484,7 @@ browser_config = BrowserConfig(
     headless=True,
     viewport_width=1280,
     viewport_height=720,
-    proxy="http://user:pass@proxy:8080"
+    proxy_config="http://user:pass@proxy:8080"
 )
 
 # Get JSON structure

--- a/docs/md_v2/assets/llm.txt/txt/extraction-llm.txt
+++ b/docs/md_v2/assets/llm.txt/txt/extraction-llm.txt
@@ -614,7 +614,7 @@ async def batch_llm_extraction():
             if result.success:
                 contents.append({
                     "url": url,
-                    "content": result.fit_markdown[:2000]  # Limit content
+                    "content": result.markdown.fit_markdown[:2000]  # Limit content
                 })
     
     # Process in batches (reduce LLM calls)

--- a/docs/md_v2/assets/llm.txt/txt/llms-full-v0.1.1.txt
+++ b/docs/md_v2/assets/llm.txt/txt/llms-full-v0.1.1.txt
@@ -643,7 +643,7 @@ browser_config = BrowserConfig(
 # Advanced browser setup with proxy and persistence
 browser_config = BrowserConfig(
     headless=False,
-    proxy="http://user:pass@proxy:8080",
+    proxy_config="http://user:pass@proxy:8080",
     use_persistent_context=True,
     user_data_dir="./browser_data",
     cookies=[
@@ -2412,7 +2412,7 @@ async def batch_llm_extraction():
             if result.success:
                 contents.append({
                     "url": url,
-                    "content": result.fit_markdown[:2000]  # Limit content
+                    "content": result.markdown.fit_markdown[:2000]  # Limit content
                 })
     
     # Process in batches (reduce LLM calls)
@@ -4719,7 +4719,7 @@ browser_config = BrowserConfig(
     headless=True,
     viewport_width=1280,
     viewport_height=720,
-    proxy="http://user:pass@proxy:8080"
+    proxy_config="http://user:pass@proxy:8080"
 )
 
 # Get JSON structure

--- a/docs/md_v2/assets/llm.txt/txt/llms-full.txt
+++ b/docs/md_v2/assets/llm.txt/txt/llms-full.txt
@@ -643,7 +643,7 @@ browser_config = BrowserConfig(
 # Advanced browser setup with proxy and persistence
 browser_config = BrowserConfig(
     headless=False,
-    proxy="http://user:pass@proxy:8080",
+    proxy_config="http://user:pass@proxy:8080",
     use_persistent_context=True,
     user_data_dir="./browser_data",
     cookies=[
@@ -2412,7 +2412,7 @@ async def batch_llm_extraction():
             if result.success:
                 contents.append({
                     "url": url,
-                    "content": result.fit_markdown[:2000]  # Limit content
+                    "content": result.markdown.fit_markdown[:2000]  # Limit content
                 })
     
     # Process in batches (reduce LLM calls)
@@ -4719,7 +4719,7 @@ browser_config = BrowserConfig(
     headless=True,
     viewport_width=1280,
     viewport_height=720,
-    proxy="http://user:pass@proxy:8080"
+    proxy_config="http://user:pass@proxy:8080"
 )
 
 # Get JSON structure

--- a/docs/md_v2/complete-sdk-reference.md
+++ b/docs/md_v2/complete-sdk-reference.md
@@ -611,7 +611,7 @@ Each `arun()` returns a **`CrawlResult`** containing:
 - `url`: Final URL (if redirected).
 - `html`: Original HTML.
 - `cleaned_html`: Sanitized HTML.
-- `markdown_v2`: Deprecated. Instead just use regular `markdown`
+- `markdown_v2`: Removed in v0.5. Accessing it raises `AttributeError`. Use `markdown`.
 - `extracted_content`: If an extraction strategy was used (JSON for CSS/LLM strategies).
 - `screenshot`, `pdf`: If screenshots/PDF requested.
 - `media`, `links`: Information about discovered images/links.
@@ -739,10 +739,10 @@ run_config = CrawlerRunConfig(
     cache_mode=CacheMode.BYPASS
 )
 ```
-- `bypass_cache=True` acts like `CacheMode.BYPASS`.
-- `disable_cache=True` acts like `CacheMode.DISABLED`.
-- `no_cache_read=True` acts like `CacheMode.WRITE_ONLY`.
-- `no_cache_write=True` acts like `CacheMode.READ_ONLY`.
+- `cache_mode=CacheMode.BYPASS` acts like `CacheMode.BYPASS`.
+- `cache_mode=CacheMode.DISABLED` acts like `CacheMode.DISABLED`.
+- `cache_mode=CacheMode.WRITE_ONLY` acts like `CacheMode.WRITE_ONLY`.
+- `cache_mode=CacheMode.READ_ONLY` acts like `CacheMode.READ_ONLY`.
 ## 3. Content Processing & Selection
 ### 3.1 Text Processing
 ```python
@@ -1359,8 +1359,8 @@ async def handle_result(result: CrawlResult):
 ```
 ## 9. Key Points & Future
 1. **Deprecated legacy properties of CrawlResult**  
-   - `markdown_v2` - Deprecated in v0.5. Just use `markdown`. It holds the `MarkdownGenerationResult` now!
-   - `fit_markdown` and `fit_html` - Deprecated in v0.5. They can now be accessed via `MarkdownGenerationResult` in `result.markdown`. eg: `result.markdown.fit_markdown` and `result.markdown.fit_html`
+   - `markdown_v2` - Removed in v0.5. Accessing it raises `AttributeError`. Use `markdown`.
+   - `fit_markdown` and `fit_html` - Removed as top-level `CrawlResult` properties in v0.5. Use `result.markdown.fit_markdown` and `result.markdown.fit_html`.
 2. **Fit Content**  
    - **`fit_markdown`** and **`fit_html`** appear in MarkdownGenerationResult, only if you used a content filter (like **PruningContentFilter** or **BM25ContentFilter**) inside your **MarkdownGenerationStrategy** or set them directly.  
    - If no filter is used, they remain `None`.
@@ -1702,7 +1702,7 @@ browser_cfg = BrowserConfig(
     headless=True,
     viewport_width=1280,
     viewport_height=720,
-    proxy="http://user:pass@proxy:8080",
+    proxy_config="http://user:pass@proxy:8080",
     user_agent="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/116.0.0.0 Safari/537.36",
 )
 ```
@@ -1927,7 +1927,7 @@ async def main():
         headless=False,
         viewport_width=1280,
         viewport_height=720,
-        proxy="http://user:pass@myproxy:8080",
+        proxy_config="http://user:pass@myproxy:8080",
         text_mode=True
     )
 
@@ -4359,7 +4359,7 @@ async def extract_with_generated_pattern():
         # Get sample HTML for context
         async with AsyncWebCrawler() as crawler:
             result = await crawler.arun("https://example.com/products")
-            html = result.fit_html
+            html = result.markdown.fit_html
 
         # Generate pattern (one-time LLM usage)
         pattern = RegexExtractionStrategy.generate_pattern(
@@ -5164,7 +5164,7 @@ This ensures the newly created context is under your control **before** `arun()`
 
 ## Core Imports
 ```python
-from crawl4ai import AsyncWebCrawler, BrowserConfig, CrawlerConfig, CacheMode
+from crawl4ai import AsyncWebCrawler, BrowserConfig, CrawlerRunConfig, CacheMode, LLMConfig
 from crawl4ai.extraction_strategy import LLMExtractionStrategy, JsonCssExtractionStrategy, CosineStrategy
 ```
 
@@ -5178,14 +5178,14 @@ async with AsyncWebCrawler() as crawler:
 ## Advanced Pattern
 ```python
 browser_config = BrowserConfig(headless=True, viewport_width=1920)
-crawler_config = CrawlerConfig(
+crawler_config = CrawlerRunConfig(
     cache_mode=CacheMode.BYPASS,
     wait_for="css:.content",
     screenshot=True,
     pdf=True
 )
 strategy = LLMExtractionStrategy(
-    provider="openai/gpt-4",
+    llm_config=LLMConfig(provider="openai/gpt-4", api_token="your-openai-token"),
     instruction="Extract products with name and price"
 )
 

--- a/docs/md_v2/core/cache-modes.md
+++ b/docs/md_v2/core/cache-modes.md
@@ -24,22 +24,16 @@ The new system uses a single `CacheMode` enum:
 
 ### Old Code (Deprecated)
 ```python
-import asyncio
 from crawl4ai import AsyncWebCrawler
 
-async def use_proxy():
-    async with AsyncWebCrawler(verbose=True) as crawler:
-        result = await crawler.arun(
-            url="https://www.nbcnews.com/business",
-            bypass_cache=True  # Old way
-        )
-        print(len(result.markdown))
-
-async def main():
-    await use_proxy()
-
-if __name__ == "__main__":
-    asyncio.run(main())
+async def old_code(crawler: AsyncWebCrawler):
+    # Legacy `bypass_cache` / `disable_cache` / `no_cache_read` / `no_cache_write`
+    # were removed in v0.5+. This example no longer applies:
+    result = await crawler.arun(
+        url="https://www.nbcnews.com/business",
+        # cache_mode is the only cache option now.
+    )
+    print(len(result.markdown))
 ```
 
 ### New Code (Recommended)
@@ -67,9 +61,9 @@ if __name__ == "__main__":
 
 ## Common Migration Patterns
 
-| Old Flag              | New Mode                       |
-|-----------------------|---------------------------------|
-| `bypass_cache=True`   | `cache_mode=CacheMode.BYPASS`  |
-| `disable_cache=True`  | `cache_mode=CacheMode.DISABLED`|
-| `no_cache_read=True`  | `cache_mode=CacheMode.WRITE_ONLY` |
-| `no_cache_write=True` | `cache_mode=CacheMode.READ_ONLY` |
+| Legacy Flag            | Replacement                |
+|------------------------|----------------------------|
+| `bypass_cache`    | `cache_mode=CacheMode.BYPASS`    |
+| `disable_cache`   | `cache_mode=CacheMode.DISABLED`  |
+| `no_cache_read`   | `cache_mode=CacheMode.READ_ONLY` |
+| `no_cache_write`  | `cache_mode=CacheMode.WRITE_ONLY`|

--- a/docs/md_v2/core/crawler-result.md
+++ b/docs/md_v2/core/crawler-result.md
@@ -108,7 +108,7 @@ print(result.cleaned_html)  # Freed of forms, header, footer, data-* attributes
 ### 3.1 `markdown`
 
 - **`markdown`**: The current location for detailed markdown output, returning a **`MarkdownGenerationResult`** object.  
-- **`markdown_v2`**: Deprecated since v0.5.
+- **`markdown_v2`**: Removed in v0.5. Accessing it now raises `AttributeError`; use `markdown`.
 
 **`MarkdownGenerationResult`** Fields:
 
@@ -326,8 +326,7 @@ else:
     print("Error:", result.error_message)
 ```
 
-**Deprecation**: Since v0.5 `result.markdown_v2`, `result.fit_html`,`result.fit_markdown` are deprecated. Use `result.markdown` instead! It holds `MarkdownGenerationResult`, which includes `fit_html` and `fit_markdown`
-as it's properties.
+**Deprecation**: Since v0.5 `markdown_v2`, `fit_markdown`, and `fit_html` are removed from `CrawlResult`. Use `result.markdown` for markdown output. It holds `MarkdownGenerationResult`, including `fit_html` and `fit_markdown`.
 
 
 ---

--- a/docs/md_v2/core/local-files.md
+++ b/docs/md_v2/core/local-files.md
@@ -62,7 +62,7 @@ from crawl4ai.async_configs import CrawlerRunConfig
 async def crawl_raw_html():
     raw_html = "<html><body><h1>Hello, World!</h1></body></html>"
     raw_html_url = f"raw:{raw_html}"
-    config = CrawlerRunConfig(bypass_cache=True)
+    config = CrawlerRunConfig(cache_mode=CacheMode.BYPASS)
     
     async with AsyncWebCrawler() as crawler:
         result = await crawler.arun(url=raw_html_url, config=config)

--- a/docs/md_v2/extraction/no-llm-strategies.md
+++ b/docs/md_v2/extraction/no-llm-strategies.md
@@ -505,7 +505,7 @@ async def extract_with_generated_pattern():
         # Get sample HTML for context
         async with AsyncWebCrawler() as crawler:
             result = await crawler.arun("https://example.com/products")
-            html = result.fit_html
+            html = result.markdown.fit_html
         
         # Generate pattern (one-time LLM usage)
         pattern = RegexExtractionStrategy.generate_pattern(

--- a/docs/md_v2/marketplace/frontend/app-detail.html
+++ b/docs/md_v2/marketplace/frontend/app-detail.html
@@ -152,21 +152,24 @@ if __name__ == "__main__":
                             <span class="code-lang">python</span>
                             <button class="copy-btn">Copy</button>
                         </div>
-                        <pre><code id="integration-code">from crawl4ai import AsyncWebCrawler
+                        <pre><code id="integration-code">from crawl4ai import AsyncWebCrawler, CacheMode
+from crawl4ai import LLMConfig
 from crawl4ai.extraction_strategy import LLMExtractionStrategy
 
 async def extract_with_llm():
     async with AsyncWebCrawler() as crawler:
-        result = await crawler.arun(
-            url="https://example.com",
-            extraction_strategy=LLMExtractionStrategy(
-                provider="openai",
-                api_key="your-api-key",
+            result = await crawler.arun(
+                url="https://example.com",
+                extraction_strategy=LLMExtractionStrategy(
+                llm_config=LLMConfig(
+                    provider="openai/gpt-4o",
+                    api_token="your-api-key",
+                ),
                 instruction="Extract product information"
-            ),
-            bypass_cache=True
-        )
-        return result.extracted_content
+                ),
+                cache_mode=CacheMode.BYPASS
+            )
+            return result.extracted_content
 
 # Run the extraction
 data = await extract_with_llm()
@@ -175,7 +178,7 @@ print(data)</code></pre>
 
                     <div class="info-box">
                         <h4>💡 Pro Tip</h4>
-                        <p>Use the <code>bypass_cache=True</code> parameter when you need fresh data, or set <code>cache_mode="write"</code> to update the cache with new content.</p>
+                        <p>Use <code>cache_mode=CacheMode.BYPASS</code> for a fresh crawl, or <code>CacheMode.WRITE_ONLY</code> to avoid refetching.</p>
                     </div>
                 </div>
             </section>

--- a/docs/md_v2/marketplace/frontend/app-detail.js
+++ b/docs/md_v2/marketplace/frontend/app-detail.js
@@ -164,21 +164,22 @@ proxy_config = {
     "password": "your_password"
 }
 
-async with AsyncWebCrawler(proxy=proxy_config) as crawler:
+async with AsyncWebCrawler() as crawler:
     result = await crawler.arun(
         url="https://example.com",
-        bypass_cache=True
+        cache_mode=CacheMode.BYPASS
     )
     print(result.status_code)`;
         } else if (this.appData.category === 'LLM Integration') {
-            usageCode.textContent = `from crawl4ai import AsyncWebCrawler
-from crawl4ai.extraction_strategy import LLMExtractionStrategy
+            usageCode.textContent = `from crawl4ai import AsyncWebCrawler, CacheMode
+from crawl4ai.extraction_strategy import LLMExtractionStrategy, LLMConfig
 
 # Configure LLM extraction
 strategy = LLMExtractionStrategy(
-    provider="${this.appData.name.toLowerCase().includes('gpt') ? 'openai' : 'anthropic'}",
-    api_key="your-api-key",
-    model="${this.appData.name.toLowerCase().includes('gpt') ? 'gpt-4' : 'claude-3'}",
+    llm_config=LLMConfig(
+        provider="${this.appData.name.toLowerCase().includes('gpt') ? 'openai/gpt-4o' : 'anthropic/claude-3-5-sonnet-20240620'}",
+        api_token="your-api-key",
+    ),
     instruction="Extract structured data"
 )
 
@@ -228,7 +229,7 @@ async def crawl_with_${this.appData.slug.replace(/-/g, '_')}():
         result = await crawler.arun(
             url="https://example.com/products",
             extraction_strategy=JsonCssExtractionStrategy(schema),
-            cache_mode="bypass",
+            cache_mode=CacheMode.BYPASS,
             wait_for="css:.product",
             screenshot=True
         )


### PR DESCRIPTION
### Summary
- docs: migrate shipped docs/examples from deprecated Crawl4AI APIs to current interfaces (non-historical, non-notebook scope)
- removes stale patterns around cache flags, direct `fit_*` property access, `LLMExtractionStrategy` constructor style, and deprecated proxy constructor usage
- aligns examples and reference docs with `CrawlerRunConfig`, `CacheMode`, `LLMConfig`, and `result.markdown.fit_*`

**Fixes:** No issue number provided (not linked).  

### List of files changed and why

- `docs/examples/summarize_page.py`  
  Migrated deprecated sync and cache/LLM patterns to async `AsyncWebCrawler` + `CrawlerRunConfig`, `CacheMode`, `LLMConfig` usage.

- `docs/examples/serp_api_project_11_feb.py`  
  Replaced `LLMExtractionStrategy(provider=...)` with `LLMConfig(...)` via `llm_config=`.

- `docs/md_v2/marketplace/frontend/app-detail.js`  
  Updated embedded snippet imports/config for modern cache and LLM strategy usage.

- `docs/md_v2/marketplace/frontend/app-detail.html`  
  Same modernization for `LLMConfig`, `CacheMode`, and runnable snippet compatibility.

- `docs/md_v2/core/cache-modes.md`  
  Updated deprecation/migration guidance to current `cache_mode` API.

- `docs/md_v2/core/crawler-result.md`  
  Updated removal notes for `markdown_v2` and legacy `fit_*` usage to current API.

- `docs/md_v2/api/crawl-result.md`  
  Updated deprecated result property guidance to current `result.markdown.fit_*`.

- `docs/md_v2/api/async-webcrawler.md`  
  Aligned `markdown_v2` guidance with removed-property behavior.

- `docs/md_v2/complete-sdk-reference.md`  
  Updated stale references (`CrawlerConfig`, `markdown_v2`, legacy `fit_*`, direct strategy args) to current API.

- `README.md`  
  Updated cache config examples from string/legacy styles to `CacheMode.*`.

### How Has This Been Tested?

- Ran grep/regex sweeps across in-scope non-historical paths:
  - No remaining `bypass_cache`, `disable_cache`, `no_cache_read`, `no_cache_write` patterns in boolean form.
  - No remaining direct `result.fit_html` / `result.fit_markdown` usage.
  - No direct `LLMExtractionStrategy(..., provider=...)`.
  - No `AsyncWebCrawler(..., proxy=...)`.
  - No `CrawlerConfig(` in non-historical docs scope.
  - No direct property-style `result.markdown_v2` usage.

### Checklist

- [ ] My code follows the style guidelines of this project  
- [x] I have performed a self-review of my own code  
- [ ] I have commented my code, particularly in hard-to-understand areas  
- [x] I have made corresponding changes to the documentation  
- [ ] I have added/updated unit tests that prove my fix is effective or that my feature works  
- [ ] New and existing unit tests pass locally with my changes
