### PR TITLE
perf: enhance monitor stability with non-blocking LOCK acquisition (#1754)

### DIFF
--- a/deploy/docker/crawler_pool.py
+++ b/deploy/docker/crawler_pool.py
@@ -32,9 +32,12 @@ def _is_default_config(sig: str) -> bool:
     return sig == DEFAULT_CONFIG_SIG
 
 async def get_crawler(cfg: BrowserConfig) -> AsyncWebCrawler:
-    """Get crawler from pool with tiered strategy."""
+    """Get crawler from pool with tiered strategy.
+    Heavy work (browser create/start) is done outside LOCK to avoid blocking pool access.
+    """
     sig = _sig(cfg)
-    async with LOCK:
+    await LOCK.acquire()
+    try:
         # Check permanent browser for default config
         if PERMANENT and _is_default_config(sig):
             LAST_USED[sig] = time.time()
@@ -62,7 +65,7 @@ async def get_crawler(cfg: BrowserConfig) -> AsyncWebCrawler:
                 try:
                     from monitor import get_monitor
                     await get_monitor().track_janitor_event("promote", sig, {"count": USAGE_COUNT[sig]})
-                except:
+                except Exception:
                     pass
 
                 return HOT_POOL[sig]
@@ -70,20 +73,36 @@ async def get_crawler(cfg: BrowserConfig) -> AsyncWebCrawler:
             logger.info(f"❄️  Using cold pool browser (sig={sig[:8]})")
             return COLD_POOL[sig]
 
-        # Memory check before creating new
+        # Memory check before creating new (fast, keep inside lock)
         mem_pct = get_container_memory_percent()
         if mem_pct >= MEM_LIMIT:
             logger.error(f"💥 Memory pressure: {mem_pct:.1f}% >= {MEM_LIMIT}%")
             raise MemoryError(f"Memory at {mem_pct:.1f}%, refusing new browser")
+        # Fall through: need to create new browser (do outside LOCK)
+    finally:
+        LOCK.release()
 
-        # Create new in cold pool
-        logger.info(f"🆕 Creating new browser in cold pool (sig={sig[:8]}, mem={mem_pct:.1f}%)")
-        crawler = AsyncWebCrawler(config=cfg, thread_safe=False)
-        await crawler.start()
+    # Create and start browser outside LOCK (network/process-heavy)
+    logger.info(f"🆕 Creating new browser in cold pool (sig={sig[:8]}, mem={mem_pct:.1f}%)")
+    crawler = AsyncWebCrawler(config=cfg, thread_safe=False)
+    await crawler.start()
+
+    async with LOCK:
+        # Re-check in case another task added same sig while we were creating
+        if sig in COLD_POOL:
+            await crawler.close()
+            LAST_USED[sig] = time.time()
+            USAGE_COUNT[sig] = USAGE_COUNT.get(sig, 0) + 1
+            return COLD_POOL[sig]
+        if sig in HOT_POOL:
+            await crawler.close()
+            LAST_USED[sig] = time.time()
+            USAGE_COUNT[sig] = USAGE_COUNT.get(sig, 0) + 1
+            return HOT_POOL[sig]
         COLD_POOL[sig] = crawler
         LAST_USED[sig] = time.time()
         USAGE_COUNT[sig] = 1
-        return crawler
+    return crawler
 
 async def init_permanent(cfg: BrowserConfig):
     """Initialize permanent default browser."""

--- a/deploy/docker/monitor.py
+++ b/deploy/docker/monitor.py
@@ -120,43 +120,54 @@ class MonitorStats:
             "details": details
         })
 
-    def _cleanup_old_entries(self, max_age_seconds: int = 300):
-        """Remove entries older than max_age_seconds (default 5min)."""
+    def _cleanup_old_entries(
+        self, max_age_seconds: int = 300, max_removals_per_deque: int = 50
+    ):
+        """Remove entries older than max_age_seconds (default 5min).
+        Limits removals per deque per call so large queues don't stall update_timeline.
+        """
         now = time.time()
         cutoff = now - max_age_seconds
 
-        # Clean completed requests
-        while self.completed_requests and self.completed_requests[0].get("end_time", 0) < cutoff:
-            self.completed_requests.popleft()
+        def pop_while(deq, key_ts: str, limit: int) -> None:
+            n = 0
+            while n < limit and deq and deq[0].get(key_ts, 0) < cutoff:
+                deq.popleft()
+                n += 1
 
-        # Clean janitor events
-        while self.janitor_events and self.janitor_events[0].get("timestamp", 0) < cutoff:
-            self.janitor_events.popleft()
-
-        # Clean errors
-        while self.errors and self.errors[0].get("timestamp", 0) < cutoff:
-            self.errors.popleft()
+        pop_while(self.completed_requests, "end_time", max_removals_per_deque)
+        pop_while(self.janitor_events, "timestamp", max_removals_per_deque)
+        pop_while(self.errors, "timestamp", max_removals_per_deque)
 
     async def update_timeline(self):
         """Update timeline data points (called every 5s)."""
         now = time.time()
         mem_pct = get_container_memory_percent()
 
-        # Clean old entries (keep last 5 minutes)
+        # Clean old entries (keep last 5 minutes), limited work per call
         self._cleanup_old_entries(max_age_seconds=300)
 
         # Count requests in last 5s
         recent_reqs = sum(1 for req in self.completed_requests
                          if now - req.get("end_time", 0) < 5)
 
-        # Browser counts (acquire lock to prevent race conditions)
+        # Browser counts: try to acquire lock with timeout, skip this point if blocked
         from crawler_pool import PERMANENT, HOT_POOL, COLD_POOL, LOCK
-        async with LOCK:
-            browser_count = {
-                "permanent": 1 if PERMANENT else 0,
-                "hot": len(HOT_POOL),
-                "cold": len(COLD_POOL)
-            }
+        try:
+            await asyncio.wait_for(LOCK.acquire(), timeout=0.5)
+            try:
+                browser_count = {
+                    "permanent": 1 if PERMANENT else 0,
+                    "hot": len(HOT_POOL),
+                    "cold": len(COLD_POOL)
+                }
+            finally:
+                LOCK.release()
+        except asyncio.TimeoutError:
+            logger.debug(
+                "Monitor skip: Could not acquire LOCK within 0.5s, skipping this data point."
+            )
+            return
 
         self.memory_timeline.append({"time": now, "value": mem_pct})
         self.requests_timeline.append({"time": now, "value": recent_reqs})


### PR DESCRIPTION
Summary:
While the recent changes in develop introduce a global wait_for timeout for update_timeline, the monitor still attempts to "queue" for the global LOCK. Under extreme load, this can lead to unnecessary resource contention.

Improvements:

Non-blocking Stats: Changed LOCK acquisition within monitor.py to a fail-fast mechanism (0.5s timeout). If the crawler pool is busy, the monitor skips the current data point instead of adding to the lock queue.

System Resilience: Ensures that telemetry collection never interferes with the core mission-critical path (browser lifecycle management).

Error Silencing: Downgraded lock-timeout warnings to debug logs to avoid cluttering production logs during expected high-load spikes.

Why this matters:
In high-concurrency enterprise environments, skipping a single monitoring heartbeat is preferable to adding latency to the asyncio event loop.