### PR TITLE
Fix `from_serializable_dict` to ignore plain data dicts with "type" key

### DIFF
--- a/crawl4ai/async_configs.py
+++ b/crawl4ai/async_configs.py
@@ -242,8 +242,18 @@ def from_serializable_dict(data: Any) -> Any:
     if isinstance(data, (str, int, float, bool)):
         return data
 
-    # Handle typed data
-    if isinstance(data, dict) and "type" in data:
+    # Handle typed data.
+    # Only enter the typed-object path for dicts that match the shapes produced
+    # by to_serializable_dict(): {"type": "<ClassName>", "params": {...}} or
+    # {"type": "dict", "value": {...}}.  Plain business dicts that happen to
+    # carry a "type" key (e.g. JSON-Schema fragments, JsonCss field specs like
+    # {"type": "text", "name": "..."}) have neither "params" nor "value" and
+    # must fall through to the raw-dict path below so they are passed as data.
+    if (
+        isinstance(data, dict)
+        and "type" in data
+        and ("params" in data or (data["type"] == "dict" and "value" in data))
+    ):
         # Handle plain dictionaries
         if data["type"] == "dict" and "value" in data:
             return {k: from_serializable_dict(v) for k, v in data["value"].items()}


### PR DESCRIPTION


## Summary

The typed-object entry condition (`"type" in data`) was too broad: it also matched plain business dicts that happen to carry a "type" key, such as JsonCssExtractionStrategy field specs ({"type": "text"}) and LLMExtractionStrategy JSON Schema fragments ({"type": "string"}). These were never config objects, but the deserializer tried to treat them as such, hit the ALLOWED_DESERIALIZE_TYPES allowlist, and raised a ValueError — causing /crawl to return HTTP 500 for perfectly valid extraction-strategy payloads.

Fix: narrow the entry condition to require "params" (or "type":"dict"
+ "value"), matching only the shapes that to_serializable_dict() actually produces. Dicts with "type" but no "params"/"value" fall through to the raw-dict path and are passed as plain data.

The RCE protection from commit 0104db6 is fully preserved: any real class-instantiation attack still requires "type" + "params", still enters the typed path, and is still blocked by the allowlist.

Fixes #1797

## How Has This Been Tested?
- Ran `deploy/docker/tests/run_security_tests.py`
- Ran `deploy/docker/tests/test_security_fixes.py`
- Ran `tests/docker_example.py` for testing CSS Extraction and LLM extraction with docker

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added/updated unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
