### PR TITLE
fix: use .search() instead of .match() for negative patterns in PruningContentFilter

### DIFF
--- a/crawl4ai/content_filter_strategy.py
+++ b/crawl4ai/content_filter_strategy.py
@@ -768,11 +768,11 @@ class PruningContentFilter(RelevantContentFilter):
         class_id_score = 0
         if "class" in node.attrs:
             classes = " ".join(node["class"])
-            if self.negative_patterns.match(classes):
+            if self.negative_patterns.search(classes):
                 class_id_score -= 0.5
         if "id" in node.attrs:
             element_id = node["id"]
-            if self.negative_patterns.match(element_id):
+            if self.negative_patterns.search(element_id):
                 class_id_score -= 0.5
         return class_id_score
 


### PR DESCRIPTION
## Summary

`PruningContentFilter._compute_class_id_weight()` uses `self.negative_patterns.match()` (lines 771, 775) to check CSS classes and element IDs against negative patterns. However, `re.match()` only matches at the **start** of the string, so a class like `"main sidebar-nav"` would not be caught by a pattern intended to match `"sidebar"` or `"nav"`.

The base class `RelevantContentFilter.is_excluded()` (line 327) correctly uses `.search()` for the same `self.negative_patterns` regex. This fix aligns `_compute_class_id_weight` with that behavior.

## Changes

- `content_filter_strategy.py` line 771: `self.negative_patterns.match(classes)` → `self.negative_patterns.search(classes)`
- `content_filter_strategy.py` line 775: `self.negative_patterns.match(element_id)` → `self.negative_patterns.search(element_id)`

## Impact

Without this fix, negative patterns (e.g., sidebar, nav, footer) fail to penalize elements when the matching substring is not at the start of the class/id string, causing irrelevant content to score higher than it should.
