### PR TITLE
fix: guard against None values in _apply_transform

### DIFF
--- a/crawl4ai/extraction_strategy.py
+++ b/crawl4ai/extraction_strategy.py
@@ -1216,6 +1216,9 @@ class JsonElementExtractionStrategy(ExtractionStrategy):
             str: The transformed value.
         """
 
+        if value is None:
+            return value
+
         if transform == "lowercase":
             return value.lower()
         elif transform == "uppercase":


### PR DESCRIPTION
## Summary

`JsonCssExtractionStrategy._apply_transform()` crashes with `AttributeError` when `value` is `None`. This happens when a CSS or XPath selector finds no matching element — the extracted value is `None`, and calling `.lower()`, `.upper()`, or `.strip()` on it raises:

```
AttributeError: 'NoneType' object has no attribute 'lower'
```

## Changes

- `extraction_strategy.py`: Added an early return guard at the start of `_apply_transform`:
  ```python
  if value is None:
      return value
  ```

## Impact

Without this fix, any extraction schema with transforms will crash on pages where optional fields are missing. This is a common scenario when scraping heterogeneous pages. The fix allows transforms to gracefully pass through `None` values.
