### PR TITLE
docs: replace invalid v0.7.0 release notes URL with GitHub docs link for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -928,7 +928,7 @@ from crawl4ai import CrawlerRunConfig, MatchMode, CacheMode
 
 - **⚡ Performance Boost**: Up to 3x faster with optimized resource handling and memory efficiency
 
-Read the full details in our [0.7.0 Release Notes](https://docs.crawl4ai.com/blog/release-v0.7.0) or check the [CHANGELOG](https://github.com/unclecode/crawl4ai/blob/main/CHANGELOG.md).
+Read the full details in our [0.7.0 Release Notes](https://github.com/unclecode/crawl4ai/blob/main/docs/blog/release-v0.7.0.md) or check the [CHANGELOG](https://github.com/unclecode/crawl4ai/blob/main/CHANGELOG.md).
 
 </details>
 


### PR DESCRIPTION
## Summary
Fixes an invalid URL for the v0.7.0 release notes in the `README.md`.

The previous link (https://docs.crawl4ai.com/blog/release-v0.7.0) returns a 404 ("The page you requested could not be found.").  
This PR updates the link to the corresponding GitHub documentation page and keeps the release notes links consistent with the style used for other versions.

## List of files changed and why
- `README.md` – Updated the v0.7.0 release notes link to the GitHub docs path because the previous docs site URL returns a 404.

## How Has This Been Tested?
- Manually verified that the previous URL returns a 404.
- Confirmed the updated GitHub documentation link correctly opens the v0.7.0 release notes.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added/updated unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes