### PR TITLE
Fix exit code checking in tests/test_webhook_feature.sh

### DIFF
--- a/tests/test_webhook_feature.sh
+++ b/tests/test_webhook_feature.sh
@@ -286,8 +286,10 @@ python3 /tmp/test_webhook.py &
 WEBHOOK_PID=$!
 
 # Wait for test to complete
+set +e
 wait $WEBHOOK_PID
 TEST_EXIT_CODE=$?
+set -e
 
 # Step 7: Verify results
 log_info "Step 7: Verifying test results..."


### PR DESCRIPTION
## Summary
This PR fixes error handling in the webhook integration test script so test failures are reported explicitly instead of exiting early due to shell strict mode (`set -e`).

File changed:
- `tests/test_webhook_feature.sh`

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added/updated unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
