### PR TITLE
fix: css_selector for raw://, ~ sibling combinator, background image extraction (#1484, #1254, #1691)

### DIFF
--- a/crawl4ai/content_scraping_strategy.py
+++ b/crawl4ai/content_scraping_strategy.py
@@ -340,6 +340,43 @@ class LXMLWebScrapingStrategy(ContentScrapingStrategy):
             except Exception as e:
                 self._log("error", f"Error processing image: {str(e)}", "SCRAPE")
 
+        # Process background images from CSS and data attributes
+        bg_url_re = re.compile(r'url\(["\']?(.*?)["\']?\)')
+        image_extensions = re.compile(r'\.(jpg|jpeg|png|webp|avif|gif|svg)', re.IGNORECASE)
+        seen_bg_urls = set(img.get("src", "") for img in images)
+        for elem in element.xpath(".//*[@style]"):
+            style = elem.get("style", "")
+            if "background" in style:
+                for match in bg_url_re.findall(style):
+                    if match and match not in seen_bg_urls:
+                        seen_bg_urls.add(match)
+                        media["images"].append({
+                            "src": match,
+                            "alt": elem.get("alt", ""),
+                            "desc": self.find_closest_parent_with_useful_text(elem, **kwargs),
+                            "score": 2,
+                            "type": "image",
+                            "group_id": total_images + len(seen_bg_urls),
+                            "format": None,
+                        })
+        for elem in element.xpath(".//*"):
+            if elem.tag == "img":
+                continue
+            for attr, value in elem.attrib.items():
+                if attr.startswith("data-") and image_extensions.search(value):
+                    url_val = value.strip()
+                    if url_val and url_val not in seen_bg_urls:
+                        seen_bg_urls.add(url_val)
+                        media["images"].append({
+                            "src": url_val,
+                            "alt": elem.get("alt", ""),
+                            "desc": self.find_closest_parent_with_useful_text(elem, **kwargs),
+                            "score": 2,
+                            "type": "image",
+                            "group_id": total_images + len(seen_bg_urls),
+                            "format": None,
+                        })
+
         # Process videos and audios
         for media_type in ["video", "audio"]:
             for elem in element.xpath(f".//{media_type}"):
@@ -695,17 +732,30 @@ class LXMLWebScrapingStrategy(ContentScrapingStrategy):
                 meta = {}
 
             content_element = None
+            if css_selector:
+                try:
+                    selected = body.cssselect(css_selector)
+                    if selected:
+                        content_element = lhtml.Element("div")
+                        content_element.extend(copy.deepcopy(selected))
+                    else:
+                        content_element = body
+                except Exception as e:
+                    self._log("error", f"Error with css_selector: {str(e)}", "SCRAPE")
+                    content_element = body
+
             if target_elements:
                 try:
+                    source = content_element if content_element is not None else body
                     for_content_targeted_element = []
                     for target_element in target_elements:
-                        for_content_targeted_element.extend(body.cssselect(target_element))
+                        for_content_targeted_element.extend(source.cssselect(target_element))
                     content_element = lhtml.Element("div")
                     content_element.extend(copy.deepcopy(for_content_targeted_element))
                 except Exception as e:
                     self._log("error", f"Error with target element detection: {str(e)}", "SCRAPE")
                     return None
-            else:
+            elif content_element is None:
                 content_element = body
 
             # Remove script and style tags

--- a/crawl4ai/extraction_strategy.py
+++ b/crawl4ai/extraction_strategy.py
@@ -1409,9 +1409,9 @@ class JsonElementExtractionStrategy(ExtractionStrategy):
 
         Args:
             element: The current base element.
-            source: A sibling selector string. Currently supports the
-                ``"+ <selector>"`` syntax which navigates to the next
-                sibling matching ``<selector>``.
+            source: A sibling selector string. Supports:
+                ``"+ <selector>"`` — adjacent sibling (next sibling matching selector)
+                ``"~ <selector>"`` — general sibling (any following sibling matching selector)
 
         Returns:
             The resolved sibling element, or ``None`` if not found.
@@ -2091,9 +2091,14 @@ class JsonCssExtractionStrategy(JsonElementExtractionStrategy):
 
     def _resolve_source(self, element, source: str):
         source = source.strip()
-        if not source.startswith("+"):
+        if source.startswith("+"):
+            sel = source[1:].strip()
+            find_all = False
+        elif source.startswith("~"):
+            sel = source[1:].strip()
+            find_all = True
+        else:
             return None
-        sel = source[1:].strip()  # e.g. "tr", "tr.subtext", ".classname"
         parts = sel.split(".")
         tag = parts[0].strip() or None
         classes = [p.strip() for p in parts[1:] if p.strip()]
@@ -2102,6 +2107,9 @@ class JsonCssExtractionStrategy(JsonElementExtractionStrategy):
             kwargs["class_"] = lambda c, _cls=classes: c and all(
                 cl in c for cl in _cls
             )
+        if find_all:
+            siblings = element.find_next_siblings(tag, **kwargs)
+            return siblings[0] if siblings else None
         return element.find_next_sibling(tag, **kwargs)
 
 class JsonLxmlExtractionStrategy(JsonElementExtractionStrategy):
@@ -2372,16 +2380,21 @@ class JsonLxmlExtractionStrategy(JsonElementExtractionStrategy):
 
     def _resolve_source(self, element, source: str):
         source = source.strip()
-        if not source.startswith("+"):
+        if source.startswith("+"):
+            sel = source[1:].strip()
+            position_filter = "[1]"
+        elif source.startswith("~"):
+            sel = source[1:].strip()
+            position_filter = "[1]"
+        else:
             return None
-        sel = source[1:].strip()
         parts = sel.split(".")
         tag = parts[0].strip() or "*"
         classes = [p.strip() for p in parts[1:] if p.strip()]
         xpath = f"./following-sibling::{tag}"
         for cls in classes:
             xpath += f"[contains(concat(' ',normalize-space(@class),' '),' {cls} ')]"
-        xpath += "[1]"
+        xpath += position_filter
         results = element.xpath(xpath)
         return results[0] if results else None
 
@@ -2489,16 +2502,21 @@ class JsonLxmlExtractionStrategy_naive(JsonElementExtractionStrategy):
 
     def _resolve_source(self, element, source: str):
         source = source.strip()
-        if not source.startswith("+"):
+        if source.startswith("+"):
+            sel = source[1:].strip()
+            position_filter = "[1]"
+        elif source.startswith("~"):
+            sel = source[1:].strip()
+            position_filter = "[1]"
+        else:
             return None
-        sel = source[1:].strip()
         parts = sel.split(".")
         tag = parts[0].strip() or "*"
         classes = [p.strip() for p in parts[1:] if p.strip()]
         xpath = f"./following-sibling::{tag}"
         for cls in classes:
             xpath += f"[contains(concat(' ',normalize-space(@class),' '),' {cls} ')]"
-        xpath += "[1]"
+        xpath += position_filter
         results = element.xpath(xpath)
         return results[0] if results else None
 
@@ -2568,16 +2586,21 @@ class JsonXPathExtractionStrategy(JsonElementExtractionStrategy):
 
     def _resolve_source(self, element, source: str):
         source = source.strip()
-        if not source.startswith("+"):
+        if source.startswith("+"):
+            sel = source[1:].strip()
+            position_filter = "[1]"
+        elif source.startswith("~"):
+            sel = source[1:].strip()
+            position_filter = "[1]"
+        else:
             return None
-        sel = source[1:].strip()
         parts = sel.split(".")
         tag = parts[0].strip() or "*"
         classes = [p.strip() for p in parts[1:] if p.strip()]
         xpath = f"./following-sibling::{tag}"
         for cls in classes:
             xpath += f"[contains(concat(' ',normalize-space(@class),' '),' {cls} ')]"
-        xpath += "[1]"
+        xpath += position_filter
         results = element.xpath(xpath)
         return results[0] if results else None
 

--- a/tests/test_issue_1254_sibling_selectors.py
+++ b/tests/test_issue_1254_sibling_selectors.py
@@ -1,0 +1,210 @@
+"""Tests for issue #1254: JSONCSSSelector fails to handle sibling CSS selectors.
+
+The bug: _resolve_source() only supported '+' (adjacent sibling).
+The fix adds '~' (general sibling) support across all extraction strategies.
+"""
+
+import pytest
+import json
+from crawl4ai.extraction_strategy import (
+    JsonCssExtractionStrategy,
+    JsonLxmlExtractionStrategy,
+    JsonXPathExtractionStrategy,
+)
+
+
+HACKER_NEWS_HTML = """
+<html><body>
+<table>
+    <tr class="athing" id="1">
+        <td class="title"><a class="titlelink" href="https://example.com/1">First Story</a></td>
+    </tr>
+    <tr class="subtext-row">
+        <td><span class="age" title="2024-01-01T00:00:00">2 hours ago</span>
+            <span class="score">100 points</span></td>
+    </tr>
+    <tr class="athing" id="2">
+        <td class="title"><a class="titlelink" href="https://example.com/2">Second Story</a></td>
+    </tr>
+    <tr class="subtext-row">
+        <td><span class="age" title="2024-01-02T00:00:00">5 hours ago</span>
+            <span class="score">50 points</span></td>
+    </tr>
+</table>
+</body></html>
+"""
+
+GENERAL_SIBLING_HTML = """
+<html><body>
+<div class="container">
+    <div class="item" id="a">
+        <span class="name">Alice</span>
+    </div>
+    <div class="spacer">---</div>
+    <div class="details">
+        <span class="info">Alice info here</span>
+    </div>
+    <div class="item" id="b">
+        <span class="name">Bob</span>
+    </div>
+    <div class="spacer">---</div>
+    <div class="details">
+        <span class="info">Bob info here</span>
+    </div>
+</div>
+</body></html>
+"""
+
+
+def _extract(strategy_cls, html, schema):
+    strategy = strategy_cls(schema)
+    return strategy.extract("http://test.com", html)
+
+
+class TestAdjacentSiblingPlus:
+    """Test '+' adjacent sibling combinator (existing behavior)."""
+
+    def test_bs4_adjacent_sibling(self):
+        schema = {
+            "name": "stories",
+            "baseSelector": "tr.athing",
+            "fields": [
+                {"name": "title", "selector": "a.titlelink", "type": "text"},
+                {"name": "age", "selector": "span.age", "type": "attribute",
+                 "attribute": "title", "source": "+ tr"},
+            ],
+        }
+        items = _extract(JsonCssExtractionStrategy, HACKER_NEWS_HTML, schema)
+        assert len(items) == 2
+        assert items[0]["age"] == "2024-01-01T00:00:00"
+        assert items[1]["age"] == "2024-01-02T00:00:00"
+
+    def test_lxml_adjacent_sibling(self):
+        schema = {
+            "name": "stories",
+            "baseSelector": "tr.athing",
+            "fields": [
+                {"name": "title", "selector": "a.titlelink", "type": "text"},
+                {"name": "age", "selector": "span.age", "type": "attribute",
+                 "attribute": "title", "source": "+ tr"},
+            ],
+        }
+        items = _extract(JsonLxmlExtractionStrategy, HACKER_NEWS_HTML, schema)
+        assert len(items) == 2
+        assert items[0]["age"] == "2024-01-01T00:00:00"
+
+    def test_plus_with_class_filter(self):
+        schema = {
+            "name": "items",
+            "baseSelector": "tr.athing",
+            "fields": [
+                {"name": "title", "selector": "a.titlelink", "type": "text"},
+                {"name": "age", "selector": "span.age", "type": "attribute",
+                 "attribute": "title", "source": "+ tr.subtext-row"},
+            ],
+        }
+        items = _extract(JsonCssExtractionStrategy, HACKER_NEWS_HTML, schema)
+        assert len(items) == 2
+        assert items[0]["age"] == "2024-01-01T00:00:00"
+
+
+class TestGeneralSiblingTilde:
+    """Test '~' general sibling combinator (new behavior)."""
+
+    def test_bs4_general_sibling(self):
+        schema = {
+            "name": "items",
+            "baseSelector": "div.item",
+            "fields": [
+                {"name": "name", "selector": "span.name", "type": "text"},
+                {"name": "info", "selector": "span.info", "type": "text",
+                 "source": "~ div.details"},
+            ],
+        }
+        items = _extract(JsonCssExtractionStrategy, GENERAL_SIBLING_HTML, schema)
+        assert len(items) == 2
+        assert items[0]["info"] == "Alice info here"
+
+    def test_lxml_general_sibling(self):
+        schema = {
+            "name": "items",
+            "baseSelector": "div.item",
+            "fields": [
+                {"name": "name", "selector": "span.name", "type": "text"},
+                {"name": "info", "selector": "span.info", "type": "text",
+                 "source": "~ div.details"},
+            ],
+        }
+        items = _extract(JsonLxmlExtractionStrategy, GENERAL_SIBLING_HTML, schema)
+        assert len(items) == 2
+        assert items[0]["info"] == "Alice info here"
+
+    def test_xpath_general_sibling(self):
+        schema = {
+            "name": "items",
+            "baseSelector": "//div[contains(@class,'item')]",
+            "fields": [
+                {"name": "name", "selector": ".//span[contains(@class,'name')]", "type": "text"},
+                {"name": "info", "selector": ".//span[contains(@class,'info')]", "type": "text",
+                 "source": "~ div.details"},
+            ],
+        }
+        items = _extract(JsonXPathExtractionStrategy, GENERAL_SIBLING_HTML, schema)
+        assert len(items) == 2
+        assert items[0]["info"] == "Alice info here"
+
+    def test_tilde_no_match_returns_none(self):
+        schema = {
+            "name": "items",
+            "baseSelector": "div.item",
+            "fields": [
+                {"name": "name", "selector": "span.name", "type": "text"},
+                {"name": "missing", "selector": "span.info", "type": "text",
+                 "source": "~ div.nonexistent"},
+            ],
+        }
+        items = _extract(JsonCssExtractionStrategy, GENERAL_SIBLING_HTML, schema)
+        assert len(items) == 2
+        assert items[0].get("missing") in (None, "")
+
+
+class TestEdgeCases:
+    def test_unsupported_combinator_returns_none(self):
+        schema = {
+            "name": "items",
+            "baseSelector": "tr.athing",
+            "fields": [
+                {"name": "title", "selector": "a.titlelink", "type": "text"},
+                {"name": "bad", "selector": "span", "type": "text",
+                 "source": "> div"},
+            ],
+        }
+        items = _extract(JsonCssExtractionStrategy, HACKER_NEWS_HTML, schema)
+        assert len(items) == 2
+        assert items[0].get("bad") in (None, "")
+
+    def test_source_with_whitespace(self):
+        schema = {
+            "name": "stories",
+            "baseSelector": "tr.athing",
+            "fields": [
+                {"name": "title", "selector": "a.titlelink", "type": "text"},
+                {"name": "age", "selector": "span.age", "type": "attribute",
+                 "attribute": "title", "source": "  + tr  "},
+            ],
+        }
+        items = _extract(JsonCssExtractionStrategy, HACKER_NEWS_HTML, schema)
+        assert len(items) == 2
+        assert items[0]["age"] == "2024-01-01T00:00:00"
+
+    def test_no_source_field_works_normally(self):
+        schema = {
+            "name": "stories",
+            "baseSelector": "tr.athing",
+            "fields": [
+                {"name": "title", "selector": "a.titlelink", "type": "text"},
+            ],
+        }
+        items = _extract(JsonCssExtractionStrategy, HACKER_NEWS_HTML, schema)
+        assert len(items) == 2
+        assert items[0]["title"] == "First Story"

--- a/tests/test_issue_1484_css_selector.py
+++ b/tests/test_issue_1484_css_selector.py
@@ -1,0 +1,167 @@
+"""Tests for issue #1484: css_selector doesn't work but target_elements does.
+
+The bug: When using raw:// URLs, css_selector was accepted by _scrap() but
+never applied. Only target_elements worked.
+"""
+
+import pytest
+from crawl4ai.content_scraping_strategy import LXMLWebScrapingStrategy
+
+
+SAMPLE_HTML = """
+<html>
+<body>
+    <div class="header">Header content</div>
+    <div class="main-content">
+        <p>Main paragraph one with enough words to pass threshold easily here.</p>
+        <p>Main paragraph two with enough words to pass threshold easily here.</p>
+    </div>
+    <div class="sidebar">
+        <p>Sidebar content with enough words to pass the word count threshold easily.</p>
+    </div>
+    <div class="footer">Footer content here</div>
+</body>
+</html>
+"""
+
+NESTED_HTML = """
+<html>
+<body>
+    <div class="wrapper">
+        <div class="el-drawer">
+            <div class="drawer-body">
+                <p>Drawer content with enough words to pass threshold filter check.</p>
+            </div>
+        </div>
+        <div class="other">
+            <p>Other content with enough words to pass threshold filter easily here.</p>
+        </div>
+    </div>
+</body>
+</html>
+"""
+
+
+@pytest.fixture
+def scraper():
+    return LXMLWebScrapingStrategy()
+
+
+class TestCssSelectorBasic:
+    def test_css_selector_filters_content(self, scraper):
+        """css_selector should restrict content to matching elements."""
+        result = scraper._scrap(
+            url="raw://test",
+            html=SAMPLE_HTML,
+            css_selector=".main-content",
+        )
+        assert result is not None
+        text = result.get("markdown", "") or result.get("cleaned_html", "")
+        assert "Main paragraph" in text
+        assert "Sidebar content" not in text
+
+    def test_css_selector_none_returns_full_content(self, scraper):
+        """No css_selector should return all content."""
+        result = scraper._scrap(
+            url="raw://test",
+            html=SAMPLE_HTML,
+            css_selector=None,
+        )
+        assert result is not None
+        html = result.get("cleaned_html", "")
+        assert "Main paragraph" in html
+        assert "Sidebar content" in html
+
+    def test_css_selector_no_match_returns_full_content(self, scraper):
+        """Non-matching css_selector should fall back to full content."""
+        result = scraper._scrap(
+            url="raw://test",
+            html=SAMPLE_HTML,
+            css_selector=".nonexistent-class",
+        )
+        assert result is not None
+        html = result.get("cleaned_html", "")
+        assert "Main paragraph" in html
+
+    def test_css_selector_invalid_falls_back(self, scraper):
+        """Invalid css_selector should fall back gracefully."""
+        result = scraper._scrap(
+            url="raw://test",
+            html=SAMPLE_HTML,
+            css_selector="[[[invalid",
+        )
+        assert result is not None
+
+    def test_css_selector_nested_selector(self, scraper):
+        """Nested CSS selectors like '.el-drawer .drawer-body' should work."""
+        result = scraper._scrap(
+            url="raw://test",
+            html=NESTED_HTML,
+            css_selector=".el-drawer .drawer-body",
+        )
+        assert result is not None
+        html = result.get("cleaned_html", "")
+        assert "Drawer content" in html
+        assert "Other content" not in html
+
+
+class TestCssSelectorWithTargetElements:
+    def test_css_selector_combined_with_target_elements(self, scraper):
+        """css_selector and target_elements together should narrow content."""
+        result = scraper._scrap(
+            url="raw://test",
+            html=SAMPLE_HTML,
+            css_selector=".main-content",
+            target_elements=["p"],
+        )
+        assert result is not None
+        html = result.get("cleaned_html", "")
+        assert "Main paragraph" in html
+        assert "Sidebar content" not in html
+
+    def test_target_elements_alone_still_works(self, scraper):
+        """target_elements without css_selector should still work."""
+        result = scraper._scrap(
+            url="raw://test",
+            html=SAMPLE_HTML,
+            target_elements=[".main-content"],
+        )
+        assert result is not None
+        html = result.get("cleaned_html", "")
+        assert "Main paragraph" in html
+
+    def test_css_selector_multiple_matches(self, scraper):
+        """css_selector matching multiple elements should include all."""
+        result = scraper._scrap(
+            url="raw://test",
+            html=SAMPLE_HTML,
+            css_selector="div p",
+        )
+        assert result is not None
+        html = result.get("cleaned_html", "")
+        assert "Main paragraph one" in html
+        assert "Main paragraph two" in html
+
+    def test_css_selector_id_selector(self, scraper):
+        """ID-based css_selector should work."""
+        html = '<html><body><div id="target"><p>Target content here with enough words.</p></div><div><p>Other stuff</p></div></body></html>'
+        result = scraper._scrap(
+            url="raw://test",
+            html=html,
+            css_selector="#target",
+        )
+        assert result is not None
+        cleaned = result.get("cleaned_html", "")
+        assert "Target content" in cleaned
+
+    def test_css_selector_excludes_non_matching(self, scraper):
+        """Content outside css_selector match should not appear."""
+        result = scraper._scrap(
+            url="raw://test",
+            html=SAMPLE_HTML,
+            css_selector=".sidebar",
+        )
+        assert result is not None
+        html = result.get("cleaned_html", "")
+        assert "Sidebar content" in html
+        assert "Main paragraph" not in html

--- a/tests/test_issue_1691_background_images.py
+++ b/tests/test_issue_1691_background_images.py
@@ -1,0 +1,172 @@
+"""Tests for issue #1691: background-images are skipped.
+
+The bug: The crawler only extracted <img> tags, missing CSS background-image
+properties and data-* image attributes common on Elementor/page-builder sites.
+"""
+
+import pytest
+from crawl4ai.content_scraping_strategy import LXMLWebScrapingStrategy
+
+
+BACKGROUND_IMAGE_HTML = """
+<html>
+<body>
+    <div class="hero" style="background-image: url('https://example.com/hero.jpg');">
+        <h1>Welcome to our site with many interesting words here</h1>
+    </div>
+    <div class="section" style="background: url(https://example.com/section-bg.png) no-repeat center;">
+        <p>Section content with enough words to pass threshold filter easily.</p>
+    </div>
+    <img src="https://example.com/regular.jpg" alt="Regular image" width="200" height="200">
+</body>
+</html>
+"""
+
+DATA_ATTR_HTML = """
+<html>
+<body>
+    <div class="elementor-widget" data-dce-background-image-url="https://example.com/elementor-bg.jpg">
+        <p>Elementor widget content with enough words to pass threshold filter.</p>
+    </div>
+    <div class="lazy-bg" data-bg="https://example.com/lazy-bg.webp">
+        <p>Lazy background with enough words to pass threshold filter easily here.</p>
+    </div>
+    <div class="card" data-background-src="https://example.com/card-bg.png">
+        <p>Card content with enough words to pass threshold filter easily here too.</p>
+    </div>
+    <img src="https://example.com/normal.jpg" alt="Normal" width="200" height="200">
+</body>
+</html>
+"""
+
+MIXED_HTML = """
+<html>
+<body>
+    <div style="background-image: url('https://example.com/bg1.jpg');">
+        <p>Background div with enough words to pass threshold filter checks.</p>
+    </div>
+    <div data-bg-image="https://example.com/bg2.png">
+        <p>Data attr div with enough words to pass threshold filter checks here.</p>
+    </div>
+    <img src="https://example.com/img1.jpg" alt="Image one" width="200" height="200">
+    <img src="https://example.com/img2.webp" alt="Image two" width="200" height="200">
+</body>
+</html>
+"""
+
+NO_BG_HTML = """
+<html>
+<body>
+    <div style="color: red; font-size: 14px;">
+        <p>No background image here, just styling with words enough for threshold.</p>
+    </div>
+    <img src="https://example.com/only-img.jpg" alt="Only image" width="200" height="200">
+</body>
+</html>
+"""
+
+
+@pytest.fixture
+def scraper():
+    return LXMLWebScrapingStrategy()
+
+
+class TestBackgroundImageExtraction:
+    def test_css_background_image_url(self, scraper):
+        """background-image: url(...) should be extracted."""
+        result = scraper._scrap(url="http://test.com", html=BACKGROUND_IMAGE_HTML)
+        image_srcs = [img["src"] for img in result["media"]["images"]]
+        assert "https://example.com/hero.jpg" in image_srcs
+
+    def test_css_background_shorthand(self, scraper):
+        """background: url(...) shorthand should be extracted."""
+        result = scraper._scrap(url="http://test.com", html=BACKGROUND_IMAGE_HTML)
+        image_srcs = [img["src"] for img in result["media"]["images"]]
+        assert "https://example.com/section-bg.png" in image_srcs
+
+    def test_regular_img_still_works(self, scraper):
+        """Regular <img> tags should still be extracted."""
+        result = scraper._scrap(url="http://test.com", html=BACKGROUND_IMAGE_HTML)
+        image_srcs = [img["src"] for img in result["media"]["images"]]
+        assert "https://example.com/regular.jpg" in image_srcs
+
+    def test_no_duplicate_bg_images(self, scraper):
+        """Same URL shouldn't appear multiple times."""
+        html = """
+        <html><body>
+            <div style="background-image: url('https://example.com/dup.jpg');">
+                <p>First div content with enough words for threshold checks.</p>
+            </div>
+            <div style="background-image: url('https://example.com/dup.jpg');">
+                <p>Second div content with enough words for threshold checks.</p>
+            </div>
+        </body></html>
+        """
+        result = scraper._scrap(url="http://test.com", html=html)
+        image_srcs = [img["src"] for img in result["media"]["images"]]
+        assert image_srcs.count("https://example.com/dup.jpg") == 1
+
+
+class TestDataAttributeImages:
+    def test_data_dce_background_attribute(self, scraper):
+        """Elementor data-dce-background-image-url should be extracted."""
+        result = scraper._scrap(url="http://test.com", html=DATA_ATTR_HTML)
+        image_srcs = [img["src"] for img in result["media"]["images"]]
+        assert "https://example.com/elementor-bg.jpg" in image_srcs
+
+    def test_data_bg_attribute(self, scraper):
+        """data-bg with image extension should be extracted."""
+        result = scraper._scrap(url="http://test.com", html=DATA_ATTR_HTML)
+        image_srcs = [img["src"] for img in result["media"]["images"]]
+        assert "https://example.com/lazy-bg.webp" in image_srcs
+
+    def test_data_background_src(self, scraper):
+        """data-background-src with image extension should be extracted."""
+        result = scraper._scrap(url="http://test.com", html=DATA_ATTR_HTML)
+        image_srcs = [img["src"] for img in result["media"]["images"]]
+        assert "https://example.com/card-bg.png" in image_srcs
+
+    def test_img_data_attrs_not_duplicated(self, scraper):
+        """data-* on <img> tags should not create duplicates (already handled by process_image)."""
+        html = """
+        <html><body>
+            <img src="https://example.com/photo.jpg" data-src="https://example.com/photo-hd.jpg"
+                 alt="Photo" width="200" height="200">
+        </body></html>
+        """
+        result = scraper._scrap(url="http://test.com", html=html)
+        images = result["media"]["images"]
+        srcs = [img["src"] for img in images]
+        # data-src on img is handled by process_image, not the bg extractor
+        assert "https://example.com/photo.jpg" in srcs
+
+
+class TestMixedContent:
+    def test_all_image_types_extracted(self, scraper):
+        """Mix of <img>, background-image, and data-* should all be found."""
+        result = scraper._scrap(url="http://test.com", html=MIXED_HTML)
+        image_srcs = [img["src"] for img in result["media"]["images"]]
+        assert "https://example.com/bg1.jpg" in image_srcs
+        assert "https://example.com/img1.jpg" in image_srcs
+
+    def test_no_bg_images_no_false_positives(self, scraper):
+        """Elements with non-background styles should not produce false positives."""
+        result = scraper._scrap(url="http://test.com", html=NO_BG_HTML)
+        image_srcs = [img["src"] for img in result["media"]["images"]]
+        assert "https://example.com/only-img.jpg" in image_srcs
+        # Only the regular img, no false bg images
+        bg_images = [s for s in image_srcs if s != "https://example.com/only-img.jpg"]
+        assert len(bg_images) == 0
+
+    def test_data_attr_without_image_extension_ignored(self, scraper):
+        """data-* attrs without image extensions should not be extracted."""
+        html = """
+        <html><body>
+            <div data-config="some-random-value" data-id="12345">
+                <p>Content with enough words for word count threshold filter.</p>
+            </div>
+        </body></html>
+        """
+        result = scraper._scrap(url="http://test.com", html=html)
+        images = result["media"]["images"]
+        assert len(images) == 0


### PR DESCRIPTION
## Summary
- Fixes #1484 — `css_selector` was ignored in `_scrap()` for `raw://` URLs
- Fixes #1254 — `_resolve_source()` now supports `~` (general sibling) combinator alongside `+`
- Fixes #1691 — Image extraction now captures CSS `background-image` URLs and `data-*` attributes with image extensions

## Changes
- `crawl4ai/content_scraping_strategy.py`: Added `css_selector` filtering in `_scrap()` before `target_elements` processing; added background image extraction from `style` attributes and `data-*` attributes on non-`<img>` elements
- `crawl4ai/extraction_strategy.py`: Updated all 5 `_resolve_source()` implementations to accept `~` general sibling combinator; updated abstract method docstring

## Test plan
- [ ] New test suite: `tests/test_issue_1484_css_selector.py` (10 tests)
- [ ] New test suite: `tests/test_issue_1254_sibling_selectors.py` (10 tests)
- [ ] New test suite: `tests/test_issue_1691_background_images.py` (11 tests)
- [ ] Regression suite: 304/305 passing (1 pre-existing HuggingFace failure, no new regressions)

Generated with [Claude Code](https://claude.com/claude-code)