### PR TITLE
fix: MCP WS crash, EmbeddingStrategy mock data, /llm provider override (#1678, #1574)

### DIFF
--- a/crawl4ai/adaptive_crawler.py
+++ b/crawl4ai/adaptive_crawler.py
@@ -757,30 +757,7 @@ class EmbeddingStrategy(CrawlStrategy):
         )
         
         variations = json.loads(response.choices[0].message.content)
-        
-        
-        # # Mock data with more variations for split
-        # variations ={'queries': ['what are the best vegetables to use in fried rice?', 'how do I make vegetable fried rice from scratch?', 'can you provide a quick recipe for vegetable fried rice?', 'what cooking techniques are essential for perfect fried rice with vegetables?', 'how to add flavor to vegetable fried rice?', 'are there any tips for making healthy fried rice with vegetables?']}
-        
-        
-        # variations = {'queries': [
-        #     'How do async and await work with coroutines in Python?',
-        #     'What is the role of event loops in asynchronous programming?',
-        #     'Can you explain the differences between async/await and traditional callback methods?',
-        #     'How do coroutines interact with event loops in JavaScript?',
-        #     'What are the benefits of using async await over promises in Node.js?',
-        #     'How to manage multiple coroutines with an event loop?',
-        #     'What are some common pitfalls when using async await with coroutines?',
-        #     'How do different programming languages implement async await and event loops?',
-        #     'What happens when an async function is called without await?',
-        #     'How does the event loop handle blocking operations?',
-        #     'Can you nest async functions and how does that affect the event loop?',
-        #     'What is the performance impact of using async/await?'
-        # ]}
-        
-        # Split into train and validation
-        # all_queries = [query] + variations['queries']
-        
+
         # Randomly shuffle for proper train/val split (keeping original query in training)
         import random
         

--- a/deploy/docker/api.py
+++ b/deploy/docker/api.py
@@ -80,7 +80,10 @@ async def hset_with_ttl(redis, key: str, mapping: dict, config: dict):
 async def handle_llm_qa(
     url: str,
     query: str,
-    config: dict
+    config: dict,
+    provider: Optional[str] = None,
+    temperature: Optional[float] = None,
+    base_url: Optional[str] = None,
 ) -> str:
     """Process QA using LLM with crawled content as context."""
     from crawler_pool import get_crawler, release_crawler
@@ -92,6 +95,14 @@ async def handle_llm_qa(
         last_q_index = url.rfind('?q=')
         if last_q_index != -1:
             url = url[:last_q_index]
+
+        # Validate provider if supplied
+        is_valid, error_msg = validate_llm_provider(config, provider)
+        if not is_valid:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=error_msg
+            )
 
         # Get markdown content (use default config)
         from utils import load_config
@@ -118,14 +129,12 @@ async def handle_llm_qa(
 
     Answer:"""
 
-        # api_token=os.environ.get(config["llm"].get("api_key_env", ""))
-
         response = perform_completion_with_backoff(
-            provider=config["llm"]["provider"],
+            provider=provider or config["llm"]["provider"],
             prompt_with_variables=prompt,
-            api_token=get_llm_api_key(config),  # Returns None to let litellm handle it
-            temperature=get_llm_temperature(config),
-            base_url=get_llm_base_url(config),
+            api_token=get_llm_api_key(config, provider),
+            temperature=temperature or get_llm_temperature(config, provider),
+            base_url=base_url or get_llm_base_url(config, provider),
             base_delay=config["llm"].get("backoff_base_delay", 2),
             max_attempts=config["llm"].get("backoff_max_attempts", 3),
             exponential_factor=config["llm"].get("backoff_exponential_factor", 2)

--- a/deploy/docker/mcp_bridge.py
+++ b/deploy/docker/mcp_bridge.py
@@ -186,15 +186,18 @@ def attach_mcp(
 
         from pydantic import TypeAdapter
         from mcp.types import JSONRPCMessage
+        from mcp.shared.message import SessionMessage
         adapter = TypeAdapter(JSONRPCMessage)
 
         init_done = anyio.Event()
 
         async def srv_to_ws():
-            first = True 
+            first = True
             try:
                 async for msg in s2c_recv:
-                    await ws.send_json(msg.model_dump())
+                    # msg is a SessionMessage; unwrap to get the JSONRPCMessage
+                    json_msg = msg.message if isinstance(msg, SessionMessage) else msg
+                    await ws.send_json(json_msg.model_dump())
                     if first:
                         init_done.set()
                         first = False
@@ -208,11 +211,11 @@ def attach_mcp(
             try:
                 # 1st frame is always "initialize"
                 first = adapter.validate_python(await ws.receive_json())
-                await c2s_send.send(first)
+                await c2s_send.send(SessionMessage(message=first))
                 await init_done.wait()          # block until server ready
                 while True:
                     data = await ws.receive_json()
-                    await c2s_send.send(adapter.validate_python(data))
+                    await c2s_send.send(SessionMessage(message=adapter.validate_python(data)))
             except WebSocketDisconnect:
                 await c2s_send.aclose()
 

--- a/deploy/docker/server.py
+++ b/deploy/docker/server.py
@@ -540,13 +540,16 @@ async def llm_endpoint(
     request: Request,
     url: str = Path(...),
     q: str = Query(...),
+    provider: Optional[str] = Query(None),
+    temperature: Optional[float] = Query(None),
+    base_url: Optional[str] = Query(None),
     _td: Dict = Depends(token_dep),
 ):
     if not q:
         raise HTTPException(400, "Query parameter 'q' is required")
     if not url.startswith(("http://", "https://")) and not url.startswith(("raw:", "raw://")):
         url = "https://" + url
-    answer = await handle_llm_qa(url, q, config)
+    answer = await handle_llm_qa(url, q, config, provider=provider, temperature=temperature, base_url=base_url)
     return JSONResponse({"answer": answer})
 
 

--- a/tests/test_issue_1516_llm_provider.py
+++ b/tests/test_issue_1516_llm_provider.py
@@ -1,0 +1,119 @@
+"""
+Tests for #1516: /llm endpoint provider/temperature/base_url override.
+
+The GET /llm endpoint should accept per-request LLM configuration,
+matching the /md and /llm/job endpoints.
+"""
+
+import inspect
+import pytest
+
+
+# ── server.py: endpoint signature ─────────────────────────────
+
+
+def _read_server_source():
+    with open("deploy/docker/server.py") as f:
+        return f.read()
+
+
+def test_llm_endpoint_has_provider_param():
+    """GET /llm should accept provider query param."""
+    src = _read_server_source()
+    assert "provider: Optional[str] = Query(None)" in src
+
+
+def test_llm_endpoint_has_temperature_param():
+    """GET /llm should accept temperature query param."""
+    src = _read_server_source()
+    assert "temperature: Optional[float] = Query(None)" in src
+
+
+def test_llm_endpoint_has_base_url_param():
+    """GET /llm should accept base_url query param."""
+    src = _read_server_source()
+    assert "base_url: Optional[str] = Query(None)" in src
+
+
+def test_llm_endpoint_passes_params_to_handler():
+    """GET /llm should pass all three params to handle_llm_qa."""
+    src = _read_server_source()
+    assert "provider=provider" in src
+    assert "temperature=temperature" in src
+    assert "base_url=base_url" in src
+
+
+# ── api.py: handler signature ─────────────────────────────────
+
+
+def _read_api_source():
+    with open("deploy/docker/api.py") as f:
+        return f.read()
+
+
+def test_handle_llm_qa_accepts_provider():
+    """handle_llm_qa should accept provider kwarg."""
+    src = _read_api_source()
+    assert "provider: Optional[str] = None" in src
+
+
+def test_handle_llm_qa_accepts_temperature():
+    """handle_llm_qa should accept temperature kwarg."""
+    src = _read_api_source()
+    assert "temperature: Optional[float] = None" in src
+
+
+def test_handle_llm_qa_accepts_base_url():
+    """handle_llm_qa should accept base_url kwarg."""
+    src = _read_api_source()
+    assert "base_url: Optional[str] = None" in src
+
+
+# ── api.py: provider override logic ──────────────────────────
+
+
+def test_provider_validated():
+    """handle_llm_qa should validate the provider."""
+    src = _read_api_source()
+    assert "validate_llm_provider(config, provider)" in src
+
+
+def test_provider_override_in_completion():
+    """Provider override should be passed to perform_completion_with_backoff."""
+    src = _read_api_source()
+    assert 'provider=provider or config["llm"]["provider"]' in src
+
+
+def test_api_key_uses_provider_override():
+    """get_llm_api_key should receive the provider override."""
+    src = _read_api_source()
+    assert "get_llm_api_key(config, provider)" in src
+
+
+def test_temperature_uses_override():
+    """Temperature should use override with fallback."""
+    src = _read_api_source()
+    assert "temperature=temperature or get_llm_temperature(config, provider)" in src
+
+
+def test_base_url_uses_override():
+    """Base URL should use override with fallback."""
+    src = _read_api_source()
+    assert "base_url=base_url or get_llm_base_url(config, provider)" in src
+
+
+# ── parity checks ────────────────────────────────────────────
+
+
+def test_md_endpoint_already_has_provider():
+    """The /md endpoint should already accept provider (for comparison)."""
+    src = _read_server_source()
+    # /md uses body.provider via MarkdownRequest
+    assert "body.provider" in src
+
+
+def test_no_hardcoded_api_key_comment():
+    """Old commented-out api_token line should be removed."""
+    src = _read_api_source()
+    # The old comment was: # api_token=os.environ.get(config["llm"].get("api_key_env", ""))
+    assert 'api_token=os.environ.get(config["llm"]' not in src

--- a/tests/test_issue_1574_embedding_mock.py
+++ b/tests/test_issue_1574_embedding_mock.py
@@ -1,0 +1,155 @@
+"""
+Tests for #1574: EmbeddingStrategy config separation and mock data removal.
+
+Verifies:
+- Commented-out "fried rice" mock data is removed
+- _get_query_llm_config_dict() fallback chain works correctly
+- query_llm_config is kept separate from embedding config
+- base_url and backoff params are passed through
+"""
+
+import inspect
+import pytest
+from typing import Dict, Optional
+from crawl4ai.adaptive_crawler import EmbeddingStrategy, AdaptiveConfig
+
+
+# ── mock data removal ─────────────────────────────────────────
+
+
+def test_no_fried_rice_in_source():
+    """The 'fried rice' mock data must be completely removed."""
+    source = inspect.getsource(EmbeddingStrategy.map_query_semantic_space)
+    assert "fried rice" not in source
+
+
+def test_no_vegetable_in_source():
+    """No 'vegetable fried rice' mock variations should remain."""
+    source = inspect.getsource(EmbeddingStrategy.map_query_semantic_space)
+    assert "vegetable" not in source
+
+
+def test_no_async_await_mock_in_source():
+    """The 'async and await' mock variations should be removed."""
+    source = inspect.getsource(EmbeddingStrategy.map_query_semantic_space)
+    assert "How do async and await work" not in source
+
+
+def test_no_event_loop_mock_in_source():
+    """The 'event loop' mock variations should be removed."""
+    source = inspect.getsource(EmbeddingStrategy.map_query_semantic_space)
+    assert "role of event loops" not in source
+
+
+def test_no_commented_mock_blocks():
+    """No large commented-out mock blocks should remain."""
+    source = inspect.getsource(EmbeddingStrategy.map_query_semantic_space)
+    mock_indicators = ["Mock data", "# variations =", "# variations = {"]
+    for indicator in mock_indicators:
+        assert indicator not in source, f"Found leftover mock indicator: {indicator}"
+
+
+# ── config fallback chain ─────────────────────────────────────
+
+
+def test_query_config_priority_over_llm_config():
+    """query_llm_config should take priority over llm_config."""
+    query_cfg = {"provider": "openai/gpt-4o-mini", "api_token": "qkey", "base_url": None}
+    embed_cfg = {"provider": "openai/text-embedding-3-small", "api_token": "ekey"}
+
+    strategy = EmbeddingStrategy(
+        llm_config=embed_cfg,
+        query_llm_config=query_cfg,
+    )
+    result = strategy._get_query_llm_config_dict()
+    assert result["provider"] == "openai/gpt-4o-mini"
+    assert result["api_token"] == "qkey"
+
+
+def test_fallback_to_llm_config():
+    """When query_llm_config is None, fall back to llm_config."""
+    embed_cfg = {"provider": "openai/gpt-4o-mini", "api_token": "shared"}
+    strategy = EmbeddingStrategy(llm_config=embed_cfg)
+    result = strategy._get_query_llm_config_dict()
+    assert result["provider"] == "openai/gpt-4o-mini"
+
+
+def test_returns_none_when_no_config():
+    """With no config at all, return None (caller uses defaults)."""
+    strategy = EmbeddingStrategy()
+    result = strategy._get_query_llm_config_dict()
+    assert result is None
+
+
+def test_adaptive_config_fallback():
+    """AdaptiveConfig._query_llm_config_dict should be used as fallback."""
+    from crawl4ai import LLMConfig
+    ac = AdaptiveConfig(
+        query_llm_config=LLMConfig(provider="anthropic/claude-3-haiku", api_token="akey")
+    )
+    strategy = EmbeddingStrategy()
+    strategy.config = ac
+    result = strategy._get_query_llm_config_dict()
+    assert result["provider"] == "anthropic/claude-3-haiku"
+
+
+def test_base_url_in_query_config():
+    """base_url should be available from query config dict."""
+    query_cfg = {
+        "provider": "openai/gpt-4o",
+        "api_token": "key",
+        "base_url": "https://custom.example.com/v1",
+    }
+    strategy = EmbeddingStrategy(query_llm_config=query_cfg)
+    result = strategy._get_query_llm_config_dict()
+    assert result["base_url"] == "https://custom.example.com/v1"
+
+
+def test_embedding_config_separate_from_query():
+    """_get_embedding_llm_config_dict should NOT return query config."""
+    from crawl4ai import LLMConfig
+    ac = AdaptiveConfig(
+        embedding_llm_config=LLMConfig(provider="openai/text-embedding-3-small", api_token="ekey"),
+        query_llm_config=LLMConfig(provider="openai/gpt-4o-mini", api_token="qkey"),
+    )
+    strategy = EmbeddingStrategy()
+    strategy.config = ac
+
+    embed_cfg = strategy._get_embedding_llm_config_dict()
+    query_cfg = strategy._get_query_llm_config_dict()
+    assert embed_cfg["provider"] == "openai/text-embedding-3-small"
+    assert query_cfg["provider"] == "openai/gpt-4o-mini"
+
+
+def test_llm_config_object_converted_to_dict():
+    """LLMConfig objects should be converted to dicts via to_dict()."""
+    from crawl4ai import LLMConfig
+    cfg = LLMConfig(provider="openai/gpt-4o", api_token="tok123")
+    strategy = EmbeddingStrategy(query_llm_config=cfg)
+    result = strategy._get_query_llm_config_dict()
+    assert isinstance(result, dict)
+    assert result["provider"] == "openai/gpt-4o"
+    assert result["api_token"] == "tok123"
+
+
+# ── map_query_semantic_space uses correct config ──────────────
+
+
+def test_map_query_uses_get_query_llm_config():
+    """map_query_semantic_space should call _get_query_llm_config_dict."""
+    source = inspect.getsource(EmbeddingStrategy.map_query_semantic_space)
+    assert "_get_query_llm_config_dict" in source
+
+
+def test_map_query_passes_base_url():
+    """map_query_semantic_space should pass base_url to perform_completion."""
+    source = inspect.getsource(EmbeddingStrategy.map_query_semantic_space)
+    assert "base_url=" in source
+
+
+def test_map_query_passes_backoff_params():
+    """map_query_semantic_space should pass backoff params."""
+    source = inspect.getsource(EmbeddingStrategy.map_query_semantic_space)
+    assert "base_delay=" in source
+    assert "max_attempts=" in source
+    assert "exponential_factor=" in source

--- a/tests/test_issue_1678_mcp_ws.py
+++ b/tests/test_issue_1678_mcp_ws.py
@@ -1,0 +1,154 @@
+"""
+Tests for #1678: MCP WebSocket SessionMessage wrapping.
+
+The mcp SDK >=1.18.0 expects SessionMessage wrappers around JSONRPCMessage.
+The WebSocket transport must wrap incoming messages and unwrap outgoing ones.
+"""
+
+import pytest
+from pydantic import TypeAdapter
+from mcp.types import JSONRPCMessage
+from mcp.shared.message import SessionMessage
+
+
+@pytest.fixture
+def adapter():
+    return TypeAdapter(JSONRPCMessage)
+
+
+# ── import / availability ─────────────────────────────────────
+
+
+def test_session_message_importable():
+    """SessionMessage must be importable from mcp.shared.message."""
+    assert SessionMessage is not None
+
+
+def test_session_message_has_message_attr():
+    """SessionMessage instances must expose a .message attribute."""
+    adapter = TypeAdapter(JSONRPCMessage)
+    raw = {"jsonrpc": "2.0", "method": "ping", "id": 1}
+    msg = SessionMessage(message=adapter.validate_python(raw))
+    assert hasattr(msg, "message")
+
+
+# ── wrapping (client → server) ────────────────────────────────
+
+
+def test_wrap_initialize_request(adapter):
+    """'initialize' request should be wrappable in SessionMessage."""
+    raw = {
+        "jsonrpc": "2.0",
+        "method": "initialize",
+        "id": 1,
+        "params": {"protocolVersion": "2024-11-05", "capabilities": {}, "clientInfo": {"name": "test", "version": "0.1"}},
+    }
+    json_msg = adapter.validate_python(raw)
+    session_msg = SessionMessage(message=json_msg)
+    assert isinstance(session_msg, SessionMessage)
+    assert session_msg.message is json_msg
+
+
+def test_wrap_notification(adapter):
+    """Notifications (no id) should be wrappable."""
+    raw = {"jsonrpc": "2.0", "method": "notifications/initialized"}
+    json_msg = adapter.validate_python(raw)
+    session_msg = SessionMessage(message=json_msg)
+    assert session_msg.message is json_msg
+
+
+def test_wrap_tool_call(adapter):
+    """Tool call requests should be wrappable."""
+    raw = {
+        "jsonrpc": "2.0",
+        "method": "tools/call",
+        "id": 42,
+        "params": {"name": "md", "arguments": {"url": "https://example.com"}},
+    }
+    json_msg = adapter.validate_python(raw)
+    session_msg = SessionMessage(message=json_msg)
+    assert session_msg.message is json_msg
+
+
+def test_wrap_preserves_jsonrpc_fields(adapter):
+    """Wrapping should not alter the original JSONRPCMessage content."""
+    raw = {"jsonrpc": "2.0", "method": "resources/list", "id": 7}
+    json_msg = adapter.validate_python(raw)
+    session_msg = SessionMessage(message=json_msg)
+    dumped = session_msg.message.model_dump()
+    assert dumped["jsonrpc"] == "2.0"
+
+
+def test_wrap_multiple_messages_independent(adapter):
+    """Each message gets its own SessionMessage wrapper."""
+    msgs = [
+        {"jsonrpc": "2.0", "method": "ping", "id": i}
+        for i in range(5)
+    ]
+    wrapped = [SessionMessage(message=adapter.validate_python(m)) for m in msgs]
+    assert len(set(id(w) for w in wrapped)) == 5  # all distinct objects
+
+
+# ── unwrapping (server → client) ──────────────────────────────
+
+
+def test_unwrap_session_message(adapter):
+    """Unwrapping SessionMessage should yield the original JSONRPCMessage."""
+    raw = {"jsonrpc": "2.0", "method": "ping", "id": 2}
+    json_msg = adapter.validate_python(raw)
+    session_msg = SessionMessage(message=json_msg)
+
+    # Simulate srv_to_ws unwrap logic
+    unwrapped = session_msg.message if isinstance(session_msg, SessionMessage) else session_msg
+    assert unwrapped is json_msg
+
+
+def test_unwrap_serializable(adapter):
+    """Unwrapped message should be JSON-serializable via model_dump."""
+    raw = {"jsonrpc": "2.0", "result": {"tools": []}, "id": 3}
+    json_msg = adapter.validate_python(raw)
+    session_msg = SessionMessage(message=json_msg)
+    unwrapped = session_msg.message if isinstance(session_msg, SessionMessage) else session_msg
+    dumped = unwrapped.model_dump()
+    assert isinstance(dumped, dict)
+    assert dumped["jsonrpc"] == "2.0"
+
+
+def test_passthrough_raw_jsonrpc(adapter):
+    """If msg is already a raw JSONRPCMessage (backward compat), passthrough works."""
+    raw = {"jsonrpc": "2.0", "method": "test", "id": 3}
+    json_msg = adapter.validate_python(raw)
+
+    result = json_msg.message if isinstance(json_msg, SessionMessage) else json_msg
+    assert result is json_msg
+
+
+# ── round-trip ────────────────────────────────────────────────
+
+
+def test_round_trip_wrap_unwrap(adapter):
+    """Wrap then unwrap should return the original message."""
+    raw = {"jsonrpc": "2.0", "method": "tools/list", "id": 10}
+    json_msg = adapter.validate_python(raw)
+    session_msg = SessionMessage(message=json_msg)
+    unwrapped = session_msg.message
+    assert unwrapped is json_msg
+    assert unwrapped.model_dump() == json_msg.model_dump()
+
+
+def test_round_trip_preserves_params(adapter):
+    """Complex params survive wrap/unwrap."""
+    raw = {
+        "jsonrpc": "2.0",
+        "method": "tools/call",
+        "id": 99,
+        "params": {
+            "name": "md",
+            "arguments": {"url": "https://example.com", "f": "llm", "q": "summarize"},
+        },
+    }
+    json_msg = adapter.validate_python(raw)
+    session_msg = SessionMessage(message=json_msg)
+    dumped = session_msg.message.model_dump()
+    assert dumped["params"]["name"] == "md"
+    assert dumped["params"]["arguments"]["url"] == "https://example.com"


### PR DESCRIPTION
## Summary
- Fixes #1678, #1574
- **#1678**: Wrap `JSONRPCMessage` in `SessionMessage` before sending to `mcp.run()` — fixes `AttributeError: 'JSONRPCMessage' object has no attribute 'message'` with mcp SDK >=1.18.0
- **#1574**: Remove leftover commented-out "fried rice" and "async/await" mock data from `map_query_semantic_space` (config fallback chain already fixed on develop)


## Changes
- `deploy/docker/mcp_bridge.py`: Import `SessionMessage`, wrap incoming messages, unwrap outgoing
- `crawl4ai/adaptive_crawler.py`: Remove ~20 lines of commented-out mock data
- `deploy/docker/server.py`: Add 3 query params to `/llm` endpoint
- `deploy/docker/api.py`: Add provider override + validation to `handle_llm_qa()`

## Test plan
- [x] New test suite: `tests/test_issue_1678_mcp_ws.py` (12 tests)
- [x] New test suite: `tests/test_issue_1574_embedding_mock.py` (15 tests)
- [x] New test suite: `tests/test_issue_1516_llm_provider.py` (14 tests)
- [x] Regression suite: 304 passed, 1 pre-existing failure (unrelated HuggingFace version mismatch)

Generated with [Claude Code](https://claude.com/claude-code)