### PR TITLE
fix: use str.split() for accurate word count in PruningContentFilter

### DIFF
--- a/crawl4ai/content_filter_strategy.py
+++ b/crawl4ai/content_filter_strategy.py
@@ -739,7 +739,7 @@ class PruningContentFilter(RelevantContentFilter):
         if self.min_word_threshold:
             # Get raw text from metrics node - avoid extra processing
             text = metrics["node"].get_text(strip=True)
-            word_count = text.count(" ") + 1
+            word_count = len(text.split())
             if word_count < self.min_word_threshold:
                 return -1.0  # Guaranteed removal
         score = 0.0


### PR DESCRIPTION
## Summary

`_compute_composite_score()` uses `text.count(" ") + 1` to count words, which overcounts when consecutive spaces are present. HTML-extracted text from `get_text(strip=True)` commonly contains multiple consecutive spaces between inline elements — each extra space inflates the count by one, making `min_word_threshold` checks too lenient and allowing short/noisy nodes to survive pruning.

**Before (line 742):**
```python
word_count = text.count(" ") + 1
```

**After:**
```python
word_count = len(text.split())
```

The same file already uses `len(text.split())` for the identical purpose at **line 268** and **line 302**, so this change also restores internal consistency.

### Edge case

`text.count(" ") + 1` returns `1` for an empty string, while `len("".split())` correctly returns `0`. This means empty-text nodes that should be removed by `min_word_threshold >= 1` currently slip through.

## Changed files

- `crawl4ai/content_filter_strategy.py` — 1 line in `_compute_composite_score()`

## Testing

Verified that `str.split()` handles consecutive spaces, tabs, and empty strings correctly:

```python
>>> "hello     world".count(" ") + 1   # overcounts
6
>>> len("hello     world".split())       # correct
2
>>> "".count(" ") + 1                    # wrong for empty
1
>>> len("".split())                      # correct
0
```