### PR TITLE
feat: add Novita AI as LLM provider

### DIFF
--- a/crawl4ai/config.py
+++ b/crawl4ai/config.py
@@ -28,6 +28,9 @@ PROVIDER_MODELS = {
     'gemini/gemini-2.0-flash-exp': os.getenv("GEMINI_API_KEY"),
     'gemini/gemini-2.0-flash-lite-preview-02-05': os.getenv("GEMINI_API_KEY"),
     "deepseek/deepseek-chat": os.getenv("DEEPSEEK_API_KEY"),
+    "novita/moonshotai/kimi-k2.5": os.getenv("NOVITA_API_KEY"),
+    "novita/zai-org/glm-5": os.getenv("NOVITA_API_KEY"),
+    "novita/minimax/minimax-m2.5": os.getenv("NOVITA_API_KEY"),
 }
 PROVIDER_MODELS_PREFIXES = {
     "ollama": "no-token-needed",  # Any model from Ollama no need for API token
@@ -36,6 +39,7 @@ PROVIDER_MODELS_PREFIXES = {
     "anthropic": os.getenv("ANTHROPIC_API_KEY"),
     "gemini": os.getenv("GEMINI_API_KEY"),
     "deepseek": os.getenv("DEEPSEEK_API_KEY"),
+    "novita": os.getenv("NOVITA_API_KEY"),  # OpenAI-compatible; set base_url="https://api.novita.ai/openai"
 }
 
 # Chunk token threshold

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -88,6 +88,9 @@ ANTHROPIC_API_KEY=your-anthropic-key
 # TOGETHER_API_KEY=your-together-key
 # MISTRAL_API_KEY=your-mistral-key
 # GEMINI_API_TOKEN=your-gemini-token
+# Novita AI (OpenAI-compatible)
+# NOVITA_API_KEY=your-novita-key
+# NOVITA_BASE_URL=https://api.novita.ai/openai
 EOL
 ```
 > 🔑 **Note**: Keep your API keys secure! Never commit `.llm.env` to version control.


### PR DESCRIPTION
## Summary

- Registers Novita AI models in `PROVIDER_MODELS` and `PROVIDER_MODELS_PREFIXES` (`crawl4ai/config.py`) so `NOVITA_API_KEY` is auto-resolved for any `novita/…` provider string
- Documents `NOVITA_API_KEY` and `NOVITA_BASE_URL` in the Docker deployment README

## Usage

Novita AI exposes an OpenAI-compatible endpoint. Use it with `LLMConfig`:

```python
from crawl4ai import LLMConfig

llm_config = LLMConfig(
    provider="novita/moonshotai/kimi-k2.5",
    api_token="env:NOVITA_API_KEY",   # or set NOVITA_API_KEY in environment
    base_url="https://api.novita.ai/openai",
)
```

Supported models:

| Model | Context | Notes |
|-------|---------|-------|
| `novita/moonshotai/kimi-k2.5` | 262k | Recommended default |
| `novita/zai-org/glm-5` | 202k | |
| `novita/minimax/minimax-m2.5` | 204k | |

For Docker deployments, pass the following environment variables:

```
NOVITA_API_KEY=your-novita-key
NOVITA_BASE_URL=https://api.novita.ai/openai
```

The existing `get_llm_base_url()` utility already picks up `NOVITA_BASE_URL` via the generic `{PROVIDER_NAME}_BASE_URL` pattern — no Docker-layer changes were needed.

## How it works

crawl4ai routes all LLM calls through [litellm](https://docs.litellm.ai/). For OpenAI-compatible providers, litellm accepts any model string with an explicit `api_base`. The `PROVIDER_MODELS_PREFIXES` entry ensures the API key is resolved automatically from `NOVITA_API_KEY` whenever a `novita/…` provider string is used, matching the pattern of existing providers (deepseek, groq, etc.).