### PR TITLE
fix: remove eval() on user-supplied expressions in computed fields

### DIFF
--- a/crawl4ai/extraction_strategy.py
+++ b/crawl4ai/extraction_strategy.py
@@ -1227,7 +1227,12 @@ class JsonElementExtractionStrategy(ExtractionStrategy):
     def _compute_field(self, item, field):
         try:
             if "expression" in field:
-                return eval(field["expression"], {}, item)
+                import logging
+                logging.getLogger(__name__).warning(
+                    "Computed field expressions are disabled for security. "
+                    "Use 'function' for programmatic access."
+                )
+                return field.get("default")
             elif "function" in field:
                 return field["function"](item)
         except Exception as e:


### PR DESCRIPTION
## Why

The `expression` key in computed fields passes user-supplied strings directly to `eval()`. When crawl4ai runs as an MCP server, this input comes from untrusted MCP clients — making it a remote code execution vector.

The `expression` key exists alongside a `function` key that accepts Python callables. Both serve the same purpose (computed fields), but `expression` is the only one reachable via JSON since callables cannot be serialized. This means `expression` is both the only JSON-accessible path and the dangerous one. Removing it closes the RCE vector without affecting Python SDK users, who can use `function` instead.

## Changes

- Replaces `eval()` with a warning log and default value return
- `function` key preserved for Python SDK users

## Test plan

- [x] Existing tests pass
- [x] Docker: `/md` endpoint returns markdown normally
- [x] Docker: `/crawl` endpoint works with default config

🤖 Generated with [Claude Code](https://claude.com/claude-code)