### PR TITLE
fix: disable /config/dump endpoint by default

### DIFF
--- a/deploy/docker/server.py
+++ b/deploy/docker/server.py
@@ -83,6 +83,10 @@ GLOBAL_SEM = asyncio.Semaphore(MAX_PAGES)
 # Hooks are disabled by default for security (RCE risk). Set to "true" to enable.
 HOOKS_ENABLED = os.environ.get("CRAWL4AI_HOOKS_ENABLED", "false").lower() == "true"
 
+# /config/dump endpoint uses eval() and is disabled by default for security.
+# Set to "true" to enable (e.g. for local development).
+CONFIG_DUMP_ENABLED = os.environ.get("CRAWL4AI_CONFIG_DUMP_ENABLED", "false").lower() == "true"
+
 # ── default browser config helper ─────────────────────────────
 def get_default_browser_config() -> BrowserConfig:
     """Get default BrowserConfig from config.yml."""
@@ -311,6 +315,8 @@ async def get_token(req: TokenRequest):
 
 @app.post("/config/dump")
 async def config_dump(raw: RawCode):
+    if not CONFIG_DUMP_ENABLED:
+        raise HTTPException(403, "/config/dump is disabled. Set CRAWL4AI_CONFIG_DUMP_ENABLED=true to enable.")
     try:
         return JSONResponse(_safe_eval_config(raw.code.strip()))
     except Exception as e:


### PR DESCRIPTION
## Why

Despite its name, `/config/dump` accepts arbitrary Python expressions via POST and runs them through `eval()`. The AST check restricts the top-level call to `CrawlerRunConfig(...)` or `BrowserConfig(...)` and forbids nested calls, but the eval namespace exposes all public `crawl4ai` names. Attribute access chains, comprehensions, and subscript access are not restricted — making this a known-broken sandbox pattern.

The endpoint is not an MCP tool (not exposed via the MCP protocol), but it is reachable via direct HTTP access to the container. In deployments where the container is network-accessible beyond the reverse proxy, this becomes a code execution vector.

The endpoint is a developer convenience for inspecting config serialization — not required for crawling or production use.

## Changes

- Guards `/config/dump` behind `CRAWL4AI_CONFIG_DUMP_ENABLED` env var (default: `false`)
- Returns 403 when disabled
- Operators who need it for local development can opt in explicitly

## Test plan

- [x] Docker: `/config/dump` returns 403 with clear message when disabled
- [x] All other endpoints unaffected
- [x] Existing tests pass