### PR TITLE
fix: validate URL schemes in /crawl and /crawl/stream

### DIFF
--- a/deploy/docker/api.py
+++ b/deploy/docker/api.py
@@ -538,6 +538,12 @@ async def handle_crawl_request(
     hook_manager = None
 
     try:
+        _allowed_schemes = ('http://', 'https://', 'raw:', 'raw://')
+        for url in urls:
+            # Detect explicit scheme: contains :// or starts with a known no-// scheme
+            has_scheme = '://' in url or url.lower().startswith(('javascript:', 'data:', 'vbscript:'))
+            if has_scheme and not url.startswith(_allowed_schemes):
+                raise HTTPException(400, f"URL scheme not allowed: {url[:50]}")
         urls = [('https://' + url) if not url.startswith(('http://', 'https://')) and not url.startswith(("raw:", "raw://")) else url for url in urls]
         browser_config = BrowserConfig.load(browser_config)
         crawler_config = CrawlerRunConfig.load(crawler_config)
@@ -720,6 +726,12 @@ async def handle_stream_crawl_request(
     """Handle streaming crawl requests with optional hooks."""
     hooks_info = None
     try:
+        _allowed_schemes = ('http://', 'https://', 'raw:', 'raw://')
+        for url in urls:
+            # Detect explicit scheme: contains :// or starts with a known no-// scheme
+            has_scheme = '://' in url or url.lower().startswith(('javascript:', 'data:', 'vbscript:'))
+            if has_scheme and not url.startswith(_allowed_schemes):
+                raise HTTPException(400, f"URL scheme not allowed: {url[:50]}")
         browser_config = BrowserConfig.load(browser_config)
         # browser_config.verbose = True # Set to False or remove for production stress testing
         browser_config.verbose = False


### PR DESCRIPTION
## Why

The `/screenshot`, `/pdf`, `/html`, and `/execute_js` endpoints validate URL schemes via `validate_url_scheme()`, rejecting `file://`, `javascript:`, and other dangerous schemes. But `/crawl` and `/crawl/stream` skip this check — they normalize unrecognized URLs by prepending `https://`, which silently passes through `file:///etc/passwd` and `javascript:alert(1)` unchanged (these already have a scheme so normalization is a no-op).

Both `/crawl` and `/crawl/stream` are MCP tools, so this is reachable from untrusted MCP clients.

## Changes

- Adds scheme validation before URL normalization in both `handle_crawl_request` and `handle_stream_crawl_request`
- If a URL has an explicit scheme (contains `://` or starts with `javascript:`, `data:`, `vbscript:`), it must be `http://`, `https://`, or `raw:`
- Scheme-less URLs (e.g. `example.com`, `example.com:8080`) pass through and get `https://` prepended as before

## Test plan

- [x] Docker: `file:///etc/passwd` rejected with clear error
- [x] Docker: `javascript:alert(1)` rejected
- [x] Docker: `example.com:8080` not falsely rejected
- [x] Docker: bare `example.com` works (gets `https://` prepended)
- [x] Existing tests pass