### PR TITLE
fix: disable /execute_js endpoint by default

### DIFF
--- a/deploy/docker/server.py
+++ b/deploy/docker/server.py
@@ -83,6 +83,11 @@ GLOBAL_SEM = asyncio.Semaphore(MAX_PAGES)
 # Hooks are disabled by default for security (RCE risk). Set to "true" to enable.
 HOOKS_ENABLED = os.environ.get("CRAWL4AI_HOOKS_ENABLED", "false").lower() == "true"
 
+# /execute_js runs arbitrary JavaScript in the headless browser, which can
+# make unrestricted network requests (bypassing any Python-level SSRF checks).
+# Disabled by default. Set to "true" to enable.
+EXECUTE_JS_ENABLED = os.environ.get("CRAWL4AI_EXECUTE_JS_ENABLED", "false").lower() == "true"
+
 # ── default browser config helper ─────────────────────────────
 def get_default_browser_config() -> BrowserConfig:
     """Get default BrowserConfig from config.yml."""
@@ -494,6 +499,8 @@ async def execute_js(
         ```
 
     """
+    if not EXECUTE_JS_ENABLED:
+        raise HTTPException(403, "/execute_js is disabled. Set CRAWL4AI_EXECUTE_JS_ENABLED=true to enable.")
     validate_url_scheme(body.url)
     from crawler_pool import get_crawler
     try:
@@ -506,6 +513,10 @@ async def execute_js(
         return JSONResponse(data)
     except Exception as e:
         raise HTTPException(500, detail=str(e))
+
+# Hide from MCP tool list when disabled
+if not EXECUTE_JS_ENABLED:
+    del execute_js.__mcp_kind__
 
 
 @app.get("/llm/{url:path}")


### PR DESCRIPTION
## Why

The `/execute_js` MCP tool runs arbitrary JavaScript in the headless browser. The browser makes its own network connections, completely bypassing any Python-level security checks (URL scheme validation, SSRF protection). From a safe initial URL like `https://example.com`, injected JS can `fetch()` internal services, cloud metadata endpoints, or any host reachable from the container.

We verified this: JS running via `/execute_js` can successfully fetch `http://127.0.0.1:11235/health` and exfiltrate the response, even with SSRF protection enabled at the Python level.

## Changes

- Guards `/execute_js` behind `CRAWL4AI_EXECUTE_JS_ENABLED` env var (default: `false`)
- Returns 403 on direct HTTP access when disabled
- Removes the tool from the MCP tool list when disabled (deletes `__mcp_kind__` attribute so `attach_mcp` skips registration)
- Operators who need JS execution can opt in explicitly

## Test plan

- [x] Docker: `execute_js` not listed in `/mcp/schema` tools when disabled
- [x] Docker: direct HTTP POST returns 403
- [x] Docker: all other MCP tools (md, html, screenshot, pdf, crawl, ask) still work
- [x] Existing tests pass