### PR TITLE
fix: arun_many respects CrawlerRunConfig.semaphore_count (#1818)

### DIFF
--- a/crawl4ai/async_webcrawler.py
+++ b/crawl4ai/async_webcrawler.py
@@ -1029,7 +1029,9 @@ class AsyncWebCrawler:
             primary_cfg = config[0] if isinstance(config, list) else config
             mean_delay = getattr(primary_cfg, "mean_delay", 0.1)
             max_range = getattr(primary_cfg, "max_range", 0.3)
+            semaphore_count = getattr(primary_cfg, "semaphore_count", 5)
             dispatcher = MemoryAdaptiveDispatcher(
+                max_session_permit=semaphore_count,
                 rate_limiter=RateLimiter(
                     base_delay=(mean_delay, mean_delay + max_range),
                     max_delay=60.0,


### PR DESCRIPTION
## Summary

- `arun_many()` was creating `MemoryAdaptiveDispatcher` with default `max_session_permit=20`, completely ignoring `CrawlerRunConfig.semaphore_count`
- This caused deep crawl to launch up to 20 concurrent browser pages against a single site, overwhelming servers and causing `Page.goto: Timeout` on all subpages
- The reporter's workaround (`semaphore_count=1`) had no effect because the value was silently ignored
- **Fix:** pass `config.semaphore_count` as `max_session_permit` to the dispatcher (one-line change)

The previous fix (PR #1829) targeted session-page reuse (`window.stop()`), but deep crawl assigns each URL a unique session_id — there is no page reuse, so that fix was irrelevant to this bug.

Fixes #1818

## Test plan

- [x] Verified `CrawlerRunConfig(semaphore_count=1)` now produces `MemoryAdaptiveDispatcher(max_session_permit=1)`
- [x] Default `semaphore_count=5` is more conservative than the previous hardcoded 20
- [ ] Reporter (@yumingmin88) to verify deep crawl of `simon.com.cn/case` no longer times out

🤖 Generated with [Claude Code](https://claude.com/claude-code)