### PR TITLE
fix: pin 5 unpinned action(s),extract 4 unsafe expression(s) to env vars

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -58,16 +58,16 @@ jobs:
           echo "Semantic versions - Major: $MAJOR, Minor: $MINOR"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Build and push Docker images
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           push: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,22 +19,28 @@ jobs:
       - name: Send to Google Apps Script (Stars only)
         if: github.event_name == 'watch'
         run: |
-          curl -fSs -X POST "${{ secrets.GOOGLE_SCRIPT_ENDPOINT }}" \
+          curl -fSs -X POST "${GOOGLE_SCRIPT_ENDPOINT}" \
             -H 'Content-Type: application/json' \
             -d '{"url":"${{ github.event.sender.html_url }}"}'
+        env:
+          GOOGLE_SCRIPT_ENDPOINT: ${{ secrets.GOOGLE_SCRIPT_ENDPOINT }}
       - name: Set webhook based on event type
         id: set-webhook
         run: |
           if [ "${{ github.event_name }}" == "discussion" ]; then
-            echo "webhook=${{ secrets.DISCORD_DISCUSSIONS_WEBHOOK }}" >> $GITHUB_OUTPUT
+            echo "webhook=${DISCORD_DISCUSSIONS_WEBHOOK}" >> $GITHUB_OUTPUT
           elif [ "${{ github.event_name }}" == "watch" ]; then
-            echo "webhook=${{ secrets.DISCORD_STAR_GAZERS }}" >> $GITHUB_OUTPUT
+            echo "webhook=${DISCORD_STAR_GAZERS}" >> $GITHUB_OUTPUT
           else
-            echo "webhook=${{ secrets.DISCORD_WEBHOOK }}" >> $GITHUB_OUTPUT
+            echo "webhook=${DISCORD_WEBHOOK}" >> $GITHUB_OUTPUT
           fi
 
+        env:
+          DISCORD_DISCUSSIONS_WEBHOOK: ${{ secrets.DISCORD_DISCUSSIONS_WEBHOOK }}
+          DISCORD_STAR_GAZERS: ${{ secrets.DISCORD_STAR_GAZERS }}
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
       - name: Discord Notification
-        uses: Ilshidur/action-discord@master
+        uses: Ilshidur/action-discord@d2594079a10f1d6739ee50a2471f0ca57418b554 # master
         env:
           DISCORD_WEBHOOK: ${{ steps.set-webhook.outputs.webhook }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
           echo "✅ Package uploaded to https://pypi.org/project/crawl4ai/"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           tag_name: v${{ steps.get_version.outputs.VERSION }}
           name: Release v${{ steps.get_version.outputs.VERSION }}


### PR DESCRIPTION
> This is a re-submission of #1869, which was closed due to a branch issue on my end. Same fixes, apologies for the noise.

## Security: Harden GitHub Actions workflows

Hey, I found some CI/CD security issues in this repo's GitHub Actions workflows. These are the same vulnerability classes that were exploited in the tj-actions/changed-files supply chain attack. I've been reviewing repos that are affected and submitting fixes where I can.

This PR applies mechanical fixes and flags anything else that needs a manual look. Happy to answer any questions.

### Fixes applied

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-007 | high | `.github/workflows/docker-release.yml` | Pinned 3 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/main.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-002 | high | `.github/workflows/main.yml` | Extracted 4 unsafe expression(s) to env vars |
| RGS-007 | high | `.github/workflows/release.yml` | Pinned 1 third-party action(s) to commit SHA |


### Additional findings (manual review recommended)

| Rule | Severity | File | Description |
| RGS-004 | high | `.github/workflows/main.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/main.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/main.yml` | Comment-Triggered Workflow Without Author Authorization Check |


### Why this matters

GitHub Actions workflows that use untrusted input in `run:` blocks or reference unpinned third-party actions are vulnerable to code injection and supply chain attacks. These are the same vulnerability classes exploited in the [tj-actions/changed-files incident](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-attack-and-its-impact) which compromised CI secrets across thousands of repositories.

### How to verify

Review the diff, each change is mechanical and preserves workflow behavior:
- **Expression extraction**: Moves `${{ }}` expressions from `run:` blocks into `env:` mappings, preventing shell injection
- **SHA pinning**: Pins third-party actions to immutable commit SHAs (original version tag preserved as comment)


---

If this PR is not welcome, just close it and I won't send another.