### PR TITLE
feat: expose token usage in CrawlResult (#1745)

### DIFF
--- a/crawl4ai/async_webcrawler.py
+++ b/crawl4ai/async_webcrawler.py
@@ -866,6 +866,7 @@ class AsyncWebCrawler:
         ################################
         # Structured Content Extraction           #
         ################################
+        token_usage = None
         if (
             not bool(extracted_content)
             and config.extraction_strategy
@@ -914,6 +915,17 @@ class AsyncWebCrawler:
                 extracted_content, indent=4, default=str, ensure_ascii=False
             )
 
+            # Capture token usage from extraction strategy
+            if hasattr(config.extraction_strategy, 'total_usage'):
+                _token_usage = config.extraction_strategy.total_usage
+                if _token_usage and hasattr(_token_usage, '__dict__'):
+                    token_usage = {
+                        k: v for k, v in _token_usage.__dict__.items()
+                        if v is not None and v != 0
+                    } or None
+                else:
+                    token_usage = None
+
             # Log extraction completion
             self.logger.url_status(
                         url=_url,
@@ -940,6 +952,7 @@ class AsyncWebCrawler:
             screenshot=screenshot_data,
             pdf=pdf_data,
             extracted_content=extracted_content,
+            token_usage=token_usage,
             success=True,
             error_message="",
         )

--- a/crawl4ai/models.py
+++ b/crawl4ai/models.py
@@ -160,6 +160,8 @@ class CrawlResult(BaseModel):
     cache_status: Optional[str] = None  # "hit", "hit_validated", "hit_fallback", "miss"
     # Anti-bot retry/proxy usage stats
     crawl_stats: Optional[Dict[str, Any]] = None
+    # LLM token usage (populated when using LLMExtractionStrategy)
+    token_usage: Optional[Dict[str, Any]] = None
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 


### PR DESCRIPTION
## Summary

Adds `token_usage` field to `CrawlResult` so LLM token consumption is returned in the crawl response — including via the Docker API.

## What changed

**`crawl4ai/models.py`:**
```python
# Added to CrawlResult
token_usage: Optional[Dict[str, Any]] = None
```

**`crawl4ai/async_webcrawler.py`:**
After extraction completes, reads `config.extraction_strategy.total_usage` and passes it to `CrawlResult`:
```python
if hasattr(config.extraction_strategy, 'total_usage'):
    token_usage = {k: v for k, v in _token_usage.__dict__.items() if v is not None and v != 0}
```

## Before / After

**Before** (Docker API response):
```json
{
  "extracted_content": "...",
  "success": true
  // no token usage
}
```

**After:**
```json
{
  "extracted_content": "...",
  "token_usage": {
    "prompt_tokens": 1234,
    "completion_tokens": 567,
    "total_tokens": 1801
  },
  "success": true
}
```

## Python SDK (also works)

```python
result = await crawler.arun(url, config=config)
print(result.token_usage)
# {'prompt_tokens': 1234, 'completion_tokens': 567, 'total_tokens': 1801}
```

## Test plan

- [x] 15/15 unit tests pass
- [x] 290/291 regression tests pass (1 pre-existing transformers issue)
- [x] CrawlResult serializes token_usage correctly
- [x] Default is None when no LLM extraction is used

Closes #1745

🤖 Generated with [Claude Code](https://claude.com/claude-code)