### PR TITLE
feat: expose Playwright launch params in BrowserConfig (#1820)

### DIFF
--- a/crawl4ai/async_configs.py
+++ b/crawl4ai/async_configs.py
@@ -584,6 +584,18 @@ class BrowserConfig:
         light_mode (bool): Disables certain background features for performance gains. Default: False.
         extra_args (list): Additional command-line arguments passed to the browser.
                            Default: [].
+        executable_path (str or None): Path to a custom browser executable (e.g., ungoogled-chromium,
+                                       Brave, or a stealth-patched binary). If None, uses the default
+                                       Playwright-managed browser. Default: None.
+        ignore_default_args (list or None): List of default Chromium flags to exclude from launch.
+                                            Passed directly to Playwright's chromium.launch(). Default: None.
+        skip_default_browser_args (bool): If True, skips the hardcoded browser args in _build_browser_args()
+                                          and only uses extra_args. Useful when a custom browser binary manages
+                                          its own flags and the defaults cause conflicts. Default: False.
+        skip_default_headers (bool): If True, skips the forced User-Agent and sec-ch-ua header overrides
+                                     in setup_context(). Useful when a custom browser binary manages its own
+                                     fingerprint and Crawl4AI's overrides create detectable mismatches.
+                                     Default: False.
         enable_stealth (bool): If True, applies playwright-stealth to bypass basic bot detection.
                               Cannot be used with use_undetected browser mode. Default: False.
         memory_saving_mode (bool): If True, adds aggressive cache discard and V8 heap cap flags
@@ -644,6 +656,10 @@ class BrowserConfig:
         text_mode: bool = False,
         light_mode: bool = False,
         extra_args: list = None,
+        executable_path: str = None,
+        ignore_default_args: list = None,
+        skip_default_browser_args: bool = False,
+        skip_default_headers: bool = False,
         debugging_port: int = 9222,
         host: str = "localhost",
         enable_stealth: bool = False,
@@ -709,6 +725,10 @@ class BrowserConfig:
         self.text_mode = text_mode
         self.light_mode = light_mode
         self.extra_args = extra_args if extra_args is not None else []
+        self.executable_path = executable_path
+        self.ignore_default_args = ignore_default_args
+        self.skip_default_browser_args = skip_default_browser_args
+        self.skip_default_headers = skip_default_headers
         self.sleep_on_close = sleep_on_close
         self.verbose = verbose
         self.debugging_port = debugging_port
@@ -804,6 +824,10 @@ class BrowserConfig:
             "text_mode": self.text_mode,
             "light_mode": self.light_mode,
             "extra_args": self.extra_args,
+            "executable_path": self.executable_path,
+            "ignore_default_args": self.ignore_default_args,
+            "skip_default_browser_args": self.skip_default_browser_args,
+            "skip_default_headers": self.skip_default_headers,
             "sleep_on_close": self.sleep_on_close,
             "verbose": self.verbose,
             "debugging_port": self.debugging_port,

--- a/crawl4ai/browser_manager.py
+++ b/crawl4ai/browser_manager.py
@@ -69,51 +69,56 @@ class ManagedBrowser:
     @staticmethod
     def build_browser_flags(config: BrowserConfig) -> List[str]:
         """Common CLI flags for launching Chromium"""
-        flags = [
-            "--no-sandbox",
-            "--disable-dev-shm-usage",
-            "--no-first-run",
-            "--no-default-browser-check",
-            "--disable-infobars",
-            "--window-position=0,0",
-            "--ignore-certificate-errors",
-            "--ignore-certificate-errors-spki-list",
-            "--disable-blink-features=AutomationControlled",
-            "--window-position=400,0",
-            "--disable-renderer-backgrounding",
-            "--disable-ipc-flooding-protection",
-            "--force-color-profile=srgb",
-            "--mute-audio",
-            "--disable-background-timer-throttling",
-            # Memory-saving flags: disable unused Chrome features
-            "--disable-features=OptimizationHints,MediaRouter,DialMediaRouteProvider",
-            "--disable-component-update",
-            "--disable-domain-reliability",
-        ]
-        # GPU flags disable WebGL which anti-bot sensors detect as headless.
-        # Keep WebGL working (via SwiftShader) when stealth mode is active.
-        if not config.enable_stealth:
-            flags.extend([
-                "--disable-gpu",
-                "--disable-gpu-compositing",
-                "--disable-software-rasterizer",
-            ])
-        if config.memory_saving_mode:
-            flags.extend([
-                "--aggressive-cache-discard",
-                '--js-flags=--max-old-space-size=512',
-            ])
-        if config.light_mode:
-            flags.extend(BROWSER_DISABLE_OPTIONS)
-        if config.text_mode:
-            flags.extend([
-                "--blink-settings=imagesEnabled=false",
-                "--disable-remote-fonts",
-                "--disable-images",
-                "--disable-javascript",
-                "--disable-software-rasterizer",
+        if config.skip_default_browser_args:
+            flags = list(config.extra_args) if config.extra_args else []
+        else:
+            flags = [
+                "--no-sandbox",
                 "--disable-dev-shm-usage",
-            ])
+                "--no-first-run",
+                "--no-default-browser-check",
+                "--disable-infobars",
+                "--window-position=0,0",
+                "--ignore-certificate-errors",
+                "--ignore-certificate-errors-spki-list",
+                "--disable-blink-features=AutomationControlled",
+                "--window-position=400,0",
+                "--disable-renderer-backgrounding",
+                "--disable-ipc-flooding-protection",
+                "--force-color-profile=srgb",
+                "--mute-audio",
+                "--disable-background-timer-throttling",
+                # Memory-saving flags: disable unused Chrome features
+                "--disable-features=OptimizationHints,MediaRouter,DialMediaRouteProvider",
+                "--disable-component-update",
+                "--disable-domain-reliability",
+            ]
+            # GPU flags disable WebGL which anti-bot sensors detect as headless.
+            # Keep WebGL working (via SwiftShader) when stealth mode is active.
+            if not config.enable_stealth:
+                flags.extend([
+                    "--disable-gpu",
+                    "--disable-gpu-compositing",
+                    "--disable-software-rasterizer",
+                ])
+            if config.memory_saving_mode:
+                flags.extend([
+                    "--aggressive-cache-discard",
+                    '--js-flags=--max-old-space-size=512',
+                ])
+            if config.light_mode:
+                flags.extend(BROWSER_DISABLE_OPTIONS)
+            if config.text_mode:
+                flags.extend([
+                    "--blink-settings=imagesEnabled=false",
+                    "--disable-remote-fonts",
+                    "--disable-images",
+                    "--disable-javascript",
+                    "--disable-software-rasterizer",
+                    "--disable-dev-shm-usage",
+                ])
+            if config.extra_args:
+                flags.extend(config.extra_args)
         # proxy support — only pass server URL, never credentials.
         # Chromium's --proxy-server flag silently ignores inline user:pass@.
         # Auth credentials are handled at the Playwright context level instead.
@@ -1056,61 +1061,71 @@ class BrowserManager:
 
     def _build_browser_args(self) -> dict:
         """Build browser launch arguments from config."""
-        args = [
-            "--disable-gpu",
-            "--disable-gpu-compositing",
-            "--disable-software-rasterizer",
-            "--no-sandbox",
-            "--disable-dev-shm-usage",
-            "--no-first-run",
-            "--no-default-browser-check",
-            "--disable-infobars",
-            "--window-position=0,0",
-            "--ignore-certificate-errors",
-            "--ignore-certificate-errors-spki-list",
-            "--disable-blink-features=AutomationControlled",
-            "--window-position=400,0",
-            "--disable-renderer-backgrounding",
-            "--disable-ipc-flooding-protection",
-            "--force-color-profile=srgb",
-            "--mute-audio",
-            "--disable-background-timer-throttling",
-            # Memory-saving flags: disable unused Chrome features
-            "--disable-features=OptimizationHints,MediaRouter,DialMediaRouteProvider",
-            "--disable-component-update",
-            "--disable-domain-reliability",
-            # "--single-process",
-            f"--window-size={self.config.viewport_width},{self.config.viewport_height}",
-        ]
+        if self.config.skip_default_browser_args:
+            # Skip all hardcoded args — only use extra_args
+            args = list(self.config.extra_args) if self.config.extra_args else []
+        else:
+            args = [
+                "--disable-gpu",
+                "--disable-gpu-compositing",
+                "--disable-software-rasterizer",
+                "--no-sandbox",
+                "--disable-dev-shm-usage",
+                "--no-first-run",
+                "--no-default-browser-check",
+                "--disable-infobars",
+                "--window-position=0,0",
+                "--ignore-certificate-errors",
+                "--ignore-certificate-errors-spki-list",
+                "--disable-blink-features=AutomationControlled",
+                "--window-position=400,0",
+                "--disable-renderer-backgrounding",
+                "--disable-ipc-flooding-protection",
+                "--force-color-profile=srgb",
+                "--mute-audio",
+                "--disable-background-timer-throttling",
+                # Memory-saving flags: disable unused Chrome features
+                "--disable-features=OptimizationHints,MediaRouter,DialMediaRouteProvider",
+                "--disable-component-update",
+                "--disable-domain-reliability",
+                # "--single-process",
+                f"--window-size={self.config.viewport_width},{self.config.viewport_height}",
+            ]
 
-        if self.config.memory_saving_mode:
-            args.extend([
-                "--aggressive-cache-discard",
-                '--js-flags=--max-old-space-size=512',
-            ])
+            if self.config.memory_saving_mode:
+                args.extend([
+                    "--aggressive-cache-discard",
+                    '--js-flags=--max-old-space-size=512',
+                ])
 
-        if self.config.light_mode:
-            args.extend(BROWSER_DISABLE_OPTIONS)
+            if self.config.light_mode:
+                args.extend(BROWSER_DISABLE_OPTIONS)
 
-        if self.config.text_mode:
-            args.extend(
-                [
-                    "--blink-settings=imagesEnabled=false",
-                    "--disable-remote-fonts",
-                    "--disable-images",
-                    "--disable-javascript",
-                    "--disable-software-rasterizer",
-                    "--disable-dev-shm-usage",
-                ]
-            )
+            if self.config.text_mode:
+                args.extend(
+                    [
+                        "--blink-settings=imagesEnabled=false",
+                        "--disable-remote-fonts",
+                        "--disable-images",
+                        "--disable-javascript",
+                        "--disable-software-rasterizer",
+                        "--disable-dev-shm-usage",
+                    ]
+                )
 
-        if self.config.extra_args:
-            args.extend(self.config.extra_args)
+            if self.config.extra_args:
+                args.extend(self.config.extra_args)
 
         # Deduplicate args
         args = list(dict.fromkeys(args))
         
         browser_args = {"headless": self.config.headless, "args": args}
+
+        if self.config.executable_path:
+            browser_args["executable_path"] = self.config.executable_path
+
+        if self.config.ignore_default_args:
+            browser_args["ignore_default_args"] = self.config.ignore_default_args
 
         if self.config.chrome_channel:
             browser_args["channel"] = self.config.chrome_channel
@@ -1191,7 +1206,7 @@ class BrowserManager:
                 ] = self.config.downloads_path
 
         # Handle user agent and browser hints
-        if self.config.user_agent:
+        if self.config.user_agent and not self.config.skip_default_headers:
             combined_headers = {
                 "User-Agent": self.config.user_agent,
                 "sec-ch-ua": self.config.browser_hint,


### PR DESCRIPTION
## Summary
- Adds 4 new params to `BrowserConfig` for custom browser binary support
- All defaults unchanged — fully backward compatible
- Addresses all 6 items from the feature request (2 were already done)

Closes discussion #1820

## New Parameters

| Param | Type | Default | Purpose |
|-------|------|---------|---------|
| `executable_path` | `str` | `None` | Path to custom Chromium binary |
| `ignore_default_args` | `list` | `None` | Playwright flags to exclude from launch |
| `skip_default_browser_args` | `bool` | `False` | Skip all hardcoded args, use only `extra_args` |
| `skip_default_headers` | `bool` | `False` | Skip forced User-Agent/sec-ch-ua overrides |

## Usage
```python
# Custom stealth binary — full control
config = BrowserConfig(
    executable_path="/usr/bin/brave-browser",
    skip_default_browser_args=True,
    skip_default_headers=True,
    extra_args=["--window-size=1920,1080"],
)
```

## Already covered (no changes needed)
- `device_scale_factor` — already configurable (PR #1463)
- `override_navigator=False` — already on `CrawlerRunConfig`

## Test plan
- [x] All 4 params default correctly (None/False)
- [x] Explicit param setting works
- [x] `to_dict()` / `load()` roundtrip preserves all params
- [x] `clone()` preserves and overrides correctly
- [x] `_build_browser_args()`: default includes hardcoded args
- [x] `_build_browser_args()`: `skip_default_browser_args=True` → only extra_args
- [x] `_build_browser_args()`: `executable_path` / `ignore_default_args` passed to launch dict
- [x] `ManagedBrowser.build_browser_flags()`: same skip logic works
- [x] `setup_context()`: default sets User-Agent headers
- [x] `setup_context()`: `skip_default_headers=True` skips UA override
- [x] `setup_context()`: custom headers still work with skip
- [x] Regression: 58 passed, 5 skipped across 3 test suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)