### PR TITLE
fix: resolve dict attribute error in MarkdownGenerator deserialization

### DIFF
--- a/crawl4ai/models.py
+++ b/crawl4ai/models.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, HttpUrl, PrivateAttr, Field, ConfigDict, BeforeValidator
+from pydantic import BaseModel, HttpUrl, PrivateAttr, Field, ConfigDict, BeforeValidator, field_validator
 from typing import Annotated
 from typing import List, Dict, Optional, Callable, Awaitable, Union, Any
 from typing import AsyncGenerator
@@ -140,6 +140,12 @@ class CrawlResult(BaseModel):
     screenshot: Optional[str] = None
     pdf: Optional[bytes] = None
     mhtml: Optional[str] = None
+    markdown_data: Optional[MarkdownGenerationResult] = Field(
+        default=None,
+        alias="markdown",
+        exclude=True,
+        repr=False,
+    )
     _markdown: Optional[MarkdownGenerationResult] = PrivateAttr(default=None)
     extracted_content: Optional[str] = None
     metadata: Optional[dict] = None
@@ -163,7 +169,16 @@ class CrawlResult(BaseModel):
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-# NOTE: The StringCompatibleMarkdown class, custom __init__ method, property getters/setters,
+    @field_validator("markdown_data", mode="before")
+    @classmethod
+    def validate_markdown(cls, v):
+        if isinstance(v, dict):
+            # This converts a raw dictionary (from cache/JSON)
+            # into the structured Pydantic object
+            return MarkdownGenerationResult(**v)
+        return v
+
+# NOTE: The StringCompatibleMarkdown class, model_post_init hook, property getters/setters,
 # and model_dump override all exist to support a smooth transition from markdown as a string
 # to markdown as a MarkdownGenerationResult object, while maintaining backward compatibility.
 # 
@@ -175,15 +190,8 @@ class CrawlResult(BaseModel):
 # When backward compatibility is no longer needed in future versions, this entire mechanism
 # can be simplified to a standard field with no custom accessors or serialization logic.
     
-    def __init__(self, **data):
-        markdown_result = data.pop('markdown', None)
-        super().__init__(**data)
-        if markdown_result is not None:
-            self._markdown = (
-                MarkdownGenerationResult(**markdown_result)
-                if isinstance(markdown_result, dict)
-                else markdown_result
-            )
+    def model_post_init(self, __context):
+        self._markdown = self.markdown_data
     
     @property
     def markdown(self):
@@ -203,7 +211,10 @@ class CrawlResult(BaseModel):
         """
         Setter for the markdown property.
         """
+        if isinstance(value, dict):
+            value = MarkdownGenerationResult(**value)
         self._markdown = value
+        self.markdown_data = value
     
     @property
     def markdown_v2(self):

--- a/tests/unit/test_crawl_result_markdown_validator.py
+++ b/tests/unit/test_crawl_result_markdown_validator.py
@@ -1,0 +1,22 @@
+from crawl4ai.models import CrawlResult
+
+
+def test_crawl_result_converts_markdown_dict_input():
+    result = CrawlResult(
+        url="https://example.com",
+        html="<html></html>",
+        success=True,
+        markdown={
+            "raw_markdown": "# Hello",
+            "markdown_with_citations": "# Hello",
+            "references_markdown": "",
+            "fit_markdown": "Hello",
+            "fit_html": "<p>Hello</p>",
+        },
+    )
+
+    assert result.markdown is not None
+    assert result.markdown.raw_markdown == "# Hello"
+    assert str(result.markdown) == "# Hello"
+    assert "Hello" in result.markdown
+    assert result.model_dump()["markdown"]["raw_markdown"] == "# Hello"


### PR DESCRIPTION
Fixes #1880

This PR addresses an AttributeError that occurred when CrawlResult was initialized from a dictionary (e.g., from cache or JSON), where the markdown field remained a raw dict instead of being hydrated into a MarkdownGenerationResult object.

List of files changed and why
crawl4ai/models.py: Updated CrawlResult with a Pydantic alias and validator to ensure proper object hydration while maintaining the backward-compatible string-like interface.

tests/unit/test_crawl_result_markdown_validator.py: New test file to verify that passing a dictionary to the markdown parameter correctly results in a MarkdownGenerationResult object.

How Has This Been Tested?
Manual Verification: Created a reproduction script that initialized CrawlResult with a raw dictionary and verified that property access (e.g., .raw_markdown) worked without error.

Unit Testing: Ran the newly created test case to confirm the validator intercepts and converts dictionary inputs correctly.

Serialization Test: Verified that model_dump() still correctly exports the markdown field for storage.

Checklist:
[x] My code follows the style guidelines of this project

[x] I have performed a self-review of my own code

[x] I have commented my code, particularly in hard-to-understand areas

[x] I have made corresponding changes to the documentation

[x] I have added/updated unit tests that prove my fix is effective or that my feature works

[x] New and existing unit tests pass locally with my changes