### PR TITLE
fix: relax lxml upper bound to allow 6.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "aiohttp>=3.11.11",
     "aiosqlite~=0.20",
     "anyio>=4.0.0",
-    "lxml~=5.3",
+    "lxml>=5.3,<7",
     "unclecode-litellm==1.81.13",
     "numpy>=1.26.0,<3",
     "pillow>=10.4",


### PR DESCRIPTION
Relax lxml pin from `~=5.3` to `>=5.3,<7`.

lxml 6.x is fully compatible — tested with lxml 6.0.2. The current pin blocks Python 3.14 users since lxml 5.x has no pre-built wheels for that version.