### PR TITLE
fix(chunking): preserve sentence order in NlpSentenceChunking

### DIFF
--- a/crawl4ai/chunking_strategy.py
+++ b/crawl4ai/chunking_strategy.py
@@ -86,7 +86,7 @@ class NlpSentenceChunking(ChunkingStrategy):
         sentences = sent_tokenize(text)
         sens = [sent.strip() for sent in sentences]
 
-        return list(set(sens))
+        return sens
 
 
 # Topic-based segmentation using TextTiling


### PR DESCRIPTION
## Summary

Fixes #1909

## Bug

`NlpSentenceChunking.chunk()` was returning `list(set(sens))` which destroys the natural document order of sentences (Python sets are unordered) and incorrectly removes duplicate sentences.

## Fix

Return `sens` directly — `nltk.sent_tokenize()` already returns sentences in document order.