### PR TITLE
Fix NlpSentenceChunking destroying sentence order

### DIFF
--- a/crawl4ai/chunking_strategy.py
+++ b/crawl4ai/chunking_strategy.py
@@ -86,7 +86,7 @@ class NlpSentenceChunking(ChunkingStrategy):
         sentences = sent_tokenize(text)
         sens = [sent.strip() for sent in sentences]
 
-        return list(set(sens))
+        return list(dict.fromkeys(sens))
 
 
 # Topic-based segmentation using TextTiling


### PR DESCRIPTION
## Summary

`NlpSentenceChunking.chunk()` used `list(set(sens))` to deduplicate sentences, but `set()` is unordered in Python — this destroyed document sentence order, producing arbitrarily shuffled chunks.

**Fix:** Replaced with `list(dict.fromkeys(sens))` which deduplicates while preserving insertion order (Python 3.7+).

Closes #1909