### PR TITLE
fix(chunking): preserve sentence order in NlpSentenceChunking

### DIFF
--- a/crawl4ai/chunking_strategy.py
+++ b/crawl4ai/chunking_strategy.py
@@ -71,7 +71,6 @@ class NlpSentenceChunking(ChunkingStrategy):
         """
         Initialize the NlpSentenceChunking object.
         """
-        from crawl4ai.le.legacy.model_loader import load_nltk_punkt
         load_nltk_punkt()
 
     def chunk(self, text: str) -> list:
@@ -86,7 +85,7 @@ class NlpSentenceChunking(ChunkingStrategy):
         sentences = sent_tokenize(text)
         sens = [sent.strip() for sent in sentences]
 
-        return list(set(sens))
+        return sens
 
 
 # Topic-based segmentation using TextTiling


### PR DESCRIPTION
## Summary
- **Fixes #1909**: `NlpSentenceChunking.chunk()` used `list(set(sens))` which destroyed document sentence order and silently dropped duplicate sentences. Now returns `sens` directly.
- **Fixes broken import**: Removed redundant broken import (`from crawl4ai.le.legacy.model_loader import ...`) in `__init__()` — `load_nltk_punkt` is already imported at module level.

## Test plan
- [x] Verified sentence order is preserved with 10 ordered sentences
- [x] Verified duplicate sentences are no longer silently removed
- [x] Verified deterministic output across multiple runs