### PR TITLE
Fix: docs sidebar anchors

### DIFF
--- a/docs/md_v2/core/browser-crawler-config.md
+++ b/docs/md_v2/core/browser-crawler-config.md
@@ -46,7 +46,7 @@ class BrowserConfig:
         ...
 ```
 
-### Key Fields to Note
+### Key Fields to Note {: #browser-config-key-fields }
 
 1.⠀**`browser_type`**  
    - Options: `"chromium"`, `"firefox"`, or `"webkit"`.  
@@ -127,7 +127,7 @@ class BrowserConfig:
     - Modifies browser fingerprints to avoid basic bot detection.
     - Default is `False`. Recommended for sites with bot protection.
 
-### Helper Methods
+### Helper Methods {: #browser-config-helper-methods }
 
 Both configuration classes provide a `clone()` method to create modified copies:
 
@@ -238,7 +238,7 @@ class CrawlerRunConfig:
         ...
 ```
 
-### Key Fields to Note
+### Key Fields to Note {: #crawler-config-key-fields }
 
 1.⠀**`word_count_threshold`**:  
    - The minimum word count before a block is considered.  
@@ -315,7 +315,7 @@ class CrawlerRunConfig:
     - Allows handling results incrementally instead of waiting for all URLs to finish.
 
 
-### Helper Methods
+### Helper Methods {: #crawler-config-helper-methods}
 
 The `clone()` method is particularly useful for creating variations of your crawler configuration:
 
@@ -350,7 +350,7 @@ The `clone()` method:
 
 ## 3. LLMConfig Essentials
 
-### Key fields to note
+### Key fields to note {: #llm-config-key-fields }
 
 1.⠀**`provider`**:  
 - Which LLM provider to use. 


### PR DESCRIPTION
## Summary
Fixed a systematic offset in the Table of Contents (TOC) within the "Browser Crawler Configuration" documentation. The issue caused sidebar links to navigate to incorrect sections due to automatic anchor ID mismatches. By adding explicit IDs to the headers, the navigation is now stable and accurate.

Fixes: None (Internal documentation improvement)

## List of files changed and why
docs/md_v2/core/browser-crawler-config.md: Added explicit anchor IDs (e.g., {: #browser-config-key-fields }) to several headers to resolve cascading TOC displacement and ensure consistent deep-linking.

## How Has This Been Tested?
-[x] Local Build: Ran mkdocs serve locally to compile the documentation and verify the rendering.
-[x] Browser Verification: Tested the navigation. While there is a minor visual offset when scrolling upwards (likely due to the site's sticky header overlap, which is a global CSS behavior), the logic is now correct: each TOC link now maps to the intended section instead of being displaced to unrelated parts of the document.

## Checklist:

- [ x ] My code follows the style guidelines of this project
- [ x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ x ] I have made corresponding changes to the documentation
- [ ] I have added/updated unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
