### PR TITLE
fix: CrawlerRunConfig docstring in Link/Domain Handling section

### DIFF
--- a/crawl4ai/async_configs.py
+++ b/crawl4ai/async_configs.py
@@ -1337,8 +1337,6 @@ class CrawlerRunConfig():
                                                     Default: SOCIAL_MEDIA_DOMAINS (from config).
         exclude_external_links (bool): If True, exclude all external links from the results.
                                        Default: False.
-        exclude_internal_links (bool): If True, exclude internal links from the results.
-                                       Default: False.
         exclude_social_media_links (bool): If True, exclude links pointing to social media domains.
                                            Default: False.
         exclude_domains (list of str): List of specific domains to exclude from results.
@@ -1348,6 +1346,9 @@ class CrawlerRunConfig():
         score_links (bool): If True, calculate intrinsic quality scores for all links using URL structure,
                            text quality, and contextual relevance metrics. Separate from link_preview_config.
                            Default: False.
+        preserve_https_for_internal_links (bool): If True, preserves HTTPS scheme for internal links even when the server redirects to HTTP. 
+                                                  Useful for security-conscious crawling.
+                                                  Default: False.
 
         # Debugging and Logging Parameters
         verbose (bool): Enable verbose logging.


### PR DESCRIPTION
## Summary
Fixed duplicate `exclude_internal_links` parameter entry and added missing `preserve_https_for_internal_links` parameter in `CrawlerRunConfig` docstring.

## List of files changed and why
- `crawl4ai/async_configs.py` - Removed duplicate `exclude_internal_links` entry and added missing `preserve_https_for_internal_links` parameter in `CrawlerRunConfig` docstring

## How Has This Been Tested?
Documentation-only changes. Verified by comparing the `async_configs.py` docstring against the actual parameters in the Link/Domain Handling section.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added/updated unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes