### PR TITLE
fix: add LLMTableExtraction to Docker API deserialization allowlist

### DIFF
--- a/crawl4ai/__init__.py
+++ b/crawl4ai/__init__.py
@@ -169,6 +169,7 @@ __all__ = [
     "TableExtractionStrategy",
     "DefaultTableExtraction",
     "NoTableExtraction",
+    "LLMTableExtraction",
     "RelevantContentFilter",
     "PruningContentFilter",
     "BM25ContentFilter",

--- a/crawl4ai/async_configs.py
+++ b/crawl4ai/async_configs.py
@@ -150,7 +150,7 @@ ALLOWED_DESERIALIZE_TYPES = {
     # Dispatchers
     "MemoryAdaptiveDispatcher", "SemaphoreDispatcher",
     # Table extraction
-    "DefaultTableExtraction", "NoTableExtraction",
+    "DefaultTableExtraction", "NoTableExtraction", "LLMTableExtraction",
     # Proxy
     "RoundRobinProxyStrategy",
 }

--- a/deploy/docker/tests/test_security_fixes.py
+++ b/deploy/docker/tests/test_security_fixes.py
@@ -251,7 +251,7 @@ class TestDeserializationAllowlist(unittest.TestCase):
             "DomainAuthorityScorer", "FreshnessScorer", "PathDepthScorer",
             "CacheMode", "MatchMode", "DisplayMode",
             "MemoryAdaptiveDispatcher", "SemaphoreDispatcher",
-            "DefaultTableExtraction", "NoTableExtraction",
+            "DefaultTableExtraction", "NoTableExtraction", "LLMTableExtraction",
             "RoundRobinProxyStrategy",
         }
 


### PR DESCRIPTION
## Summary

- `LLMTableExtraction` was missing from `ALLOWED_DESERIALIZE_TYPES` in `async_configs.py`, causing a `ValueError` when used via the Docker Job Queue API
- Added `LLMTableExtraction` to the allowlist alongside the existing `DefaultTableExtraction` and `NoTableExtraction` entries
- Added `LLMTableExtraction` to `__all__` in `__init__.py` to expose it as part of the public API (it was imported but not exported)
- Updated the hardcoded allowlist copy in `deploy/docker/tests/test_security_fixes.py` to stay in sync

Fixes #1924