### PR TITLE
docker: listen on all addresses

### DIFF
--- a/deploy/docker/supervisord.conf
+++ b/deploy/docker/supervisord.conf
@@ -14,7 +14,7 @@ stderr_logfile=/dev/stderr      ; Redirect redis stderr to container stderr
 stderr_logfile_maxbytes=0
 
 [program:gunicorn]
-command=/usr/local/bin/gunicorn --bind 0.0.0.0:11235 --workers 1 --threads 4 --timeout 1800 --graceful-timeout 30 --keep-alive 300 --log-level info --worker-class uvicorn.workers.UvicornWorker server:app
+command=/usr/local/bin/gunicorn --bind [::]:11235 --workers 1 --threads 4 --timeout 1800 --graceful-timeout 30 --keep-alive 300 --log-level info --worker-class uvicorn.workers.UvicornWorker server:app
 directory=/app                  ; Working directory for the app
 user=appuser                    ; Run gunicorn as our non-root user
 autorestart=true


### PR DESCRIPTION
## Summary

Listen on all local addresses by default, so that the service is reachable by curl, requests, etc.

Fixes: https://github.com/unclecode/crawl4ai/issues/1928

## List of files changed and why

deploy/docker/supervisord.conf

## How Has This Been Tested?

    podman run -i -p 11235:11235 --name crawl4ai --shm-size=1g unclecode/crawl4ai

Using the example in README.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added/updated unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
