### PR TITLE
fix: add LLMTableExtraction to Docker API deserialization allowlist (#1924)

### DIFF
--- a/crawl4ai/async_configs.py
+++ b/crawl4ai/async_configs.py
@@ -150,7 +150,7 @@ ALLOWED_DESERIALIZE_TYPES = {
     # Dispatchers
     "MemoryAdaptiveDispatcher", "SemaphoreDispatcher",
     # Table extraction
-    "DefaultTableExtraction", "NoTableExtraction",
+    "DefaultTableExtraction", "NoTableExtraction", "LLMTableExtraction",
     # Proxy
     "RoundRobinProxyStrategy",
 }


### PR DESCRIPTION
## Summary

Fixes #1924

`LLMTableExtraction` was missing from `ALLOWED_DESERIALIZE_TYPES` in `async_configs.py`. When passed as `table_extraction` via the Docker Job Queue API, it was silently dropped and fell back to `DefaultTableExtraction` — so table extraction via LLM never ran.

**Reproduction (without fix):**
```python
config = CrawlerRunConfig.load({
    "table_extraction": {"type": "LLMTableExtraction", "params": {...}}
})
type(config.table_extraction).__name__  # → "DefaultTableExtraction" (silently wrong)
```

**With fix:**
```python
type(config.table_extraction).__name__  # → "LLMTableExtraction" ✅
```

## Fix

```diff
- "DefaultTableExtraction", "NoTableExtraction",
+ "DefaultTableExtraction", "NoTableExtraction", "LLMTableExtraction",
```

Note: PR #1925 by @sevenmoonlightsteps identified the same fix.

## Docker verification ✅

Tested end-to-end in a locally built container — `POST /crawl` with `table_extraction: {type: "LLMTableExtraction"}` returns `success: true` and the strategy is correctly instantiated (no silent fallback to `DefaultTableExtraction`).

## Test plan
- [ ] `CrawlerRunConfig.load({"table_extraction": {"type": "LLMTableExtraction", ...}})` → `config.table_extraction` is an `LLMTableExtraction` instance
- [ ] `DefaultTableExtraction` and `NoTableExtraction` still deserialize correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)