### PR TITLE
fix: bind gunicorn to [::] for IPv6 dual-stack support (#1928)

### DIFF
--- a/deploy/docker/supervisord.conf
+++ b/deploy/docker/supervisord.conf
@@ -14,7 +14,7 @@ stderr_logfile=/dev/stderr      ; Redirect redis stderr to container stderr
 stderr_logfile_maxbytes=0
 
 [program:gunicorn]
-command=/usr/local/bin/gunicorn --bind 0.0.0.0:11235 --workers 1 --threads 4 --timeout 1800 --graceful-timeout 30 --keep-alive 300 --log-level info --worker-class uvicorn.workers.UvicornWorker server:app
+command=/usr/local/bin/gunicorn --bind [::]:11235 --workers 1 --threads 4 --timeout 1800 --graceful-timeout 30 --keep-alive 300 --log-level info --worker-class uvicorn.workers.UvicornWorker server:app
 directory=/app                  ; Working directory for the app
 user=appuser                    ; Run gunicorn as our non-root user
 autorestart=true


### PR DESCRIPTION
## Summary

Fixes #1928

`0.0.0.0` binds gunicorn to IPv4 only. Clients following [RFC 8305](https://www.rfc-editor.org/rfc/rfc8305) (Happy Eyeballs) try IPv6 first, receiving a connection reset. Changing to `[::]` enables dual-stack on Linux — the kernel accepts both IPv4 and IPv6 connections on the same socket, so existing IPv4-only setups are unaffected.

## Fix

```diff
- --bind 0.0.0.0:11235
+ --bind [::]:11235
```

Note: PR #1929 by @atomic-carpenter identified the same fix.

## Docker verification ✅

Built and tested locally. Gunicorn logs confirm:
```
Listening at: http://[::]:11235
```

| Test | Result |
|------|--------|
| `curl -4` IPv4 | ✅ `{"status": "ok"}` |
| `curl -6` IPv6 | ✅ `{"status": "ok"}` |
| Real crawl `POST /crawl` | ✅ `success: true` |

> **Note:** macOS Docker Desktop abstracts the network stack so IPv6 failure can't be reproduced on Mac — the fix should be validated on a Linux host to confirm the original bug is resolved.

## Test plan
- [ ] On Linux: `curl -6 http://localhost:11235/health` succeeds (previously connection reset)
- [ ] On Linux: `curl -4 http://localhost:11235/health` still succeeds (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)