### PR TITLE
fix: preserve .tail text when removing empty elements (#1938)

### DIFF
--- a/crawl4ai/content_scraping_strategy.py
+++ b/crawl4ai/content_scraping_strategy.py
@@ -562,6 +562,14 @@ class LXMLWebScrapingStrategy(ContentScrapingStrategy):
             ):
                 parent = el.getparent()
                 if parent is not None:
+                    # Preserve .tail text before removing the element
+                    tail = el.tail
+                    if tail:
+                        prev = el.getprevious()
+                        if prev is not None:
+                            prev.tail = (prev.tail or "") + tail
+                        else:
+                            parent.text = (parent.text or "") + tail
                     parent.remove(el)
 
         return root


### PR DESCRIPTION
## Summary
- **Fixes #1938**: `remove_empty_elements_fast()` was dropping trailing text (lxml `.tail`) when removing empty elements. For example, on arxiv.org pages, the abstract gets truncated because empty elements left by overlay removal carry `.tail` text that is silently discarded.
- **Fix**: Before removing an element, append its `.tail` to the previous sibling's `.tail` or the parent's `.text`.

## Test plan
- [x] Minimal reproduction: empty `<span>` with `.tail` text — tail now preserved
- [x] Between-elements reproduction: empty `<b>` between paragraphs — connector text preserved
- [x] All 17 existing scraping tests pass (mermaid SVG tests)