### PR TITLE
fix: broaden mermaid SVG text extraction and prevent nested fences (#1043)

### DIFF
--- a/crawl4ai/content_scraping_strategy.py
+++ b/crawl4ai/content_scraping_strategy.py
@@ -725,17 +725,53 @@ class LXMLWebScrapingStrategy(ContentScrapingStrategy):
             for svg in body.xpath('.//svg[starts-with(@id, "mermaid-")]'):
                 try:
                     diagram_type = svg.get("aria-roledescription", "diagram")
-                    # Extract text from node/edge labels
                     labels = []
                     seen = set()
+
+                    # Primary: foreignObject-based labels (flowchart, class, state…)
                     for el in svg.cssselect(".nodeLabel, .label span, .edgeLabel span"):
                         text = el.text_content().strip()
                         if text and text not in seen:
                             seen.add(text)
                             labels.append(text)
-                    if labels:
-                        # Build a pre block so it survives markdown conversion
+
+                    # Fallback: native SVG text/tspan elements (sequence, gantt, git…)
+                    if not labels:
+                        for el in svg.xpath(
+                            './/*[local-name()="text"] | .//*[local-name()="tspan"]'
+                        ):
+                            text = (el.text or "").strip()
+                            if text and text not in seen:
+                                seen.add(text)
+                                labels.append(text)
+
+                    if not labels:
+                        continue
+
+                    # Check whether the SVG already lives inside a <pre> block.
+                    # If so, avoid creating a nested fence; just let the outer
+                    # <pre> preserve the text that lxml has already flattened.
+                    ancestor = svg.getparent()
+                    inside_pre = False
+                    while ancestor is not None:
+                        if ancestor.tag == "pre":
+                            inside_pre = True
+                            break
+                        ancestor = ancestor.getparent()
+
+                    if inside_pre:
+                        # The outer <pre> will format the text as a code block.
+                        # Replace the SVG with a plain span so lxml preserves
+                        # the label text without the SVG markup noise.
+                        placeholder = lhtml.Element("span")
+                        placeholder.text = "\n".join(labels)
+                        parent = svg.getparent()
+                        if parent is not None:
+                            parent.replace(svg, placeholder)
+                    else:
+                        # Build a fenced code block that survives markdown conversion
                         placeholder = lhtml.Element("pre")
+                        placeholder.set("data-language", "mermaid")
                         code = etree.SubElement(placeholder, "code")
                         code.set("class", "language-mermaid")
                         code.text = f"%% {diagram_type} diagram\n" + "\n".join(labels)

--- a/crawl4ai/html2text/__init__.py
+++ b/crawl4ai/html2text/__init__.py
@@ -1146,7 +1146,8 @@ class CustomHTML2Text(HTML2Text):
         # Handle pre tags
         if tag == "pre":
             if start:
-                self.o("\n```\n")  # Markdown code block start
+                lang = attrs.get("data-language", "")
+                self.o(f"\n```{lang}\n")  # Markdown code block start
                 self.inside_pre = True
             else:
                 self.o("\n```\n")  # Markdown code block end


### PR DESCRIPTION
## Context

Follow-up to #1845 (merged into develop). Nasrin found three issues in the original fix when tested on the actual reported URL (`https://deepwiki.com/bwmarrin/snowflake`).

## What was wrong

1. **Sequence/gantt/git diagrams produce zero labels** — these diagram types use native SVG `<text>`/`<tspan>` elements instead of `foreignObject` + `.nodeLabel` spans. The original selectors only covered the `foreignObject` path.

2. **Nested markdown fences on deepwiki** — deepwiki wraps each mermaid SVG in an outer `<pre>` block. Creating a second `<pre data-language="mermaid">` inside produced invalid nested ` ``` ` fences.

3. **No `mermaid` language in the fence** — `CustomHTML2Text` hardcoded ` ``` ` with no language identifier, so the output was an unlabelled code block even when `class="language-mermaid"` was set on the inner `<code>`.

## Changes

### `crawl4ai/content_scraping_strategy.py`
- **Add text/tspan XPath fallback** when CSS selectors yield no labels (covers sequence, gantt, git diagram types)
- **Detect outer `<pre>` ancestors** — if the SVG already lives inside a `<pre>`, replace it with a `<span>` (preserving label text inside the existing fence) instead of inserting a new fence

### `crawl4ai/html2text/__init__.py`
- Read `data-language` attribute on `<pre>` tags and emit ` ```{lang} ` — no effect on existing pages; only activates for mermaid SVGs that are NOT inside an outer `<pre>`

## Test plan

- [x] 11 unit tests covering flowchart (outside `<pre>`), flowchart (inside `<pre>`), sequence (tspan fallback), empty SVG, deduplication, multiple SVGs, non-mermaid SVG, html2text language attribute
- [x] Full regression suite: 301 passed, 0 new failures (1 pre-existing `test_cosine_basic` HuggingFace compat failure)
- [x] Manual test on `https://deepwiki.com/bwmarrin/snowflake` — flowchart and sequence diagram text preserved, no nested fences

🤖 Generated with [Claude Code](https://claude.com/claude-code)