### PR TITLE
fix: preserve .tail text when removing empty elements (#1938)

### DIFF
--- a/crawl4ai/content_scraping_strategy.py
+++ b/crawl4ai/content_scraping_strategy.py
@@ -562,6 +562,15 @@ class LXMLWebScrapingStrategy(ContentScrapingStrategy):
             ):
                 parent = el.getparent()
                 if parent is not None:
+                    # Preserve tail text — in lxml, el.tail is text that appears
+                    # after el's closing tag; removing el would silently drop it.
+                    tail = el.tail
+                    if tail:
+                        prev = el.getprevious()
+                        if prev is not None:
+                            prev.tail = (prev.tail or "") + tail
+                        else:
+                            parent.text = (parent.text or "") + tail
                     parent.remove(el)
 
         return root


### PR DESCRIPTION
## Problem

`remove_empty_elements_fast()` was silently dropping `.tail` text when removing empty elements. In lxml, `.tail` is the text that appears *after* an element's closing tag — e.g. the `, some context` in:

```html
<p><small></small>, some context text here</p>
```

When `<small>` is removed because it's empty, the `, some context text here` tail was lost entirely, corrupting the cleaned HTML.

## Fix

Before `parent.remove(el)`, append `el.tail` to the previous sibling's `.tail` (or to `parent.text` if no previous sibling). This is the same pattern already used for `<script>` removal in the same file (lines 730–747).

```python
tail = el.tail
if tail:
    prev = el.getprevious()
    if prev is not None:
        prev.tail = (prev.tail or "") + tail
    else:
        parent.text = (parent.text or "") + tail
parent.remove(el)
```

## Test plan

- [x] 13 targeted unit tests — all pass
- [x] Full regression suite: 303 passed, 1 skipped, 0 failures

Fixes #1938

🤖 Generated with [Claude Code](https://claude.com/claude-code)