### PR TITLE
Add bedrock to PROVIDER_MODELS_PREFIXES so AWS credential auth works

### DIFF
--- a/crawl4ai/config.py
+++ b/crawl4ai/config.py
@@ -36,6 +36,7 @@ PROVIDER_MODELS_PREFIXES = {
     "anthropic": os.getenv("ANTHROPIC_API_KEY"),
     "gemini": os.getenv("GEMINI_API_KEY"),
     "deepseek": os.getenv("DEEPSEEK_API_KEY"),
+    "bedrock": None,  # Bedrock uses AWS credential chain (SigV4) or explicit api_token for bearer auth
 }
 
 # Chunk token threshold


### PR DESCRIPTION
## Summary

`LLMConfig.__init__` checks PROVIDER_MODELS_PREFIXES when `api_token=None`.
If the provider prefix isn't found, it silently falls through to the else
branch and overwrites self.provider with DEFAULT_PROVIDER (`openai/gpt-4o`),
meaning any bedrock/* model string was being replaced before the LLM call was even made.

This broke supported Bedrock auth methods when api_token is not passed in the `LLMConfig`

Only passing `api_token=<bearer_token>` explicitly worked, because the
truthy api_token bypassed the prefix check entirely.

Adding "bedrock": None to PROVIDER_MODELS_PREFIXES keeps
self.provider intact so the correct Bedrock provider is used. The actual
auth (SigV4 signing or Bearer header) is handled downstream based on what credentials are
available in the environment.


## List of files changed and why
crawl4ai/config.py: To add bedrock to PROVIDER_MODELS_PREFIXES for the fix.

## How Has This Been Tested?
Tried LLMExtraction with Bedrock Auth Methods.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added/updated unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
