### PR TITLE
fix: log failure reason before COMPLETE and fix misleading SCRAPE ✓ (#1949)

### DIFF
--- a/crawl4ai/async_webcrawler.py
+++ b/crawl4ai/async_webcrawler.py
@@ -638,6 +638,14 @@ class AsyncWebCrawler:
                             head_html = crawl_result.html[:head_end + 7]
                             crawl_result.head_fingerprint = compute_head_fingerprint(head_html)
 
+                    # Log failure reason before COMPLETE so users can see why it failed.
+                    if crawl_result and not crawl_result.success and crawl_result.error_message:
+                        self.logger.error_status(
+                            url=cache_context.display_url,
+                            error=crawl_result.error_message,
+                            tag="ERROR",
+                        )
+
                     self.logger.url_status(
                         url=cache_context.display_url,
                         success=crawl_result.success if crawl_result else False,
@@ -852,10 +860,10 @@ class AsyncWebCrawler:
             )
         )
 
-        # Log processing completion
+        # Log processing completion — reflect actual content outcome
         self.logger.url_status(
             url=_url,
-            success=True,
+            success=bool(cleaned_html),
             timing=int((time.perf_counter() - t1) * 1000) / 1000,
             tag="SCRAPE"
         )


### PR DESCRIPTION
## Problem

When a crawl fails (anti-bot detection, empty HTML, etc.), users see only `[COMPLETE] ✗` with zero explanation — even with `verbose=True`. The `CrawlResult.error_message` is correctly set but was never logged to the console.

A second issue: the `[SCRAPE]` log always emitted `✓` regardless of whether scraping produced any content, which was actively misleading.

**Before:**
```
[FETCH]...  ↓ https://example.com  | ✗ | ⏱: 0.52s
[SCRAPE]..  ◆ https://example.com  | ✓ | ⏱: 0.00s   ← misleading ✓
[COMPLETE] ● https://example.com   | ✗ | ⏱: 0.52s   ← no reason shown
```

**After:**
```
[FETCH]...  ↓ https://example.com  | ✗ | ⏱: 0.64s
[SCRAPE]..  ◆ https://example.com  | ✗ | ⏱: 0.00s   ← correct ✗
[ERROR]...  × https://example.com  | Error: Blocked by anti-bot protection: Near-empty content (0 bytes) with HTTP 200
[COMPLETE] ● https://example.com   | ✗ | ⏱: 0.64s   ← user now knows why
```

## Fix

Two-line change in `async_webcrawler.py`:
1. Before the COMPLETE log: if `crawl_result.success=False` and `error_message` is set, emit an `[ERROR]` log with the reason
2. In `aprocess_html`: change SCRAPE log from hardcoded `success=True` to `success=bool(cleaned_html)`

## Test plan

- [x] Reproduced bug: SCRAPE ✓, COMPLETE ✗, no error log — confirmed
- [x] After fix: ERROR log appears before COMPLETE with full reason
- [x] 7 targeted tests — all pass
- [x] Full regression suite: 297 passed, 1 skipped, 0 failures

Fixes #1949

🤖 Generated with [Claude Code](https://claude.com/claude-code)