### PR TITLE
fix(stealth): use Stealth class from playwright-stealth 2.x

### DIFF
--- a/crawl4ai/browser_adapter.py
+++ b/crawl4ai/browser_adapter.py
@@ -153,35 +153,27 @@ class StealthAdapter(BrowserAdapter):
 
     def __init__(self):
         self._console_script_injected = {}
+        self._stealth = None
         self._stealth_available = self._check_stealth_availability()
 
     def _check_stealth_availability(self) -> bool:
-        """Check if playwright_stealth is available and get the correct function"""
+        """Check if playwright_stealth is importable and instantiate the Stealth helper."""
         try:
-            from playwright_stealth import stealth_async
-            self._stealth_function = stealth_async
-            return True
+            from playwright_stealth import Stealth
         except ImportError:
-            try:
-                from playwright_stealth import stealth_sync
-                self._stealth_function = stealth_sync
-                return True
-            except ImportError:
-                self._stealth_function = None
-                return False
+            return False
+        self._stealth = Stealth()
+        return True
 
     async def apply_stealth(self, page: Page):
         """Apply stealth to a page if available"""
-        if self._stealth_available and self._stealth_function:
-            try:
-                if hasattr(self._stealth_function, '__call__'):
-                    if 'async' in getattr(self._stealth_function, '__name__', ''):
-                        await self._stealth_function(page)
-                    else:
-                        self._stealth_function(page)
-            except Exception as e:
-                # Fail silently or log error depending on requirements
-                pass
+        if not (self._stealth_available and self._stealth):
+            return
+        try:
+            await self._stealth.apply_stealth_async(page)
+        except Exception:
+            # Fail silently or log error depending on requirements
+            pass
 
     async def evaluate(self, page: Page, expression: str, arg: Any = None) -> Any:
         """Standard Playwright evaluate with stealth applied"""


### PR DESCRIPTION
## Summary

Fixes #1959.

`StealthAdapter._check_stealth_availability` imported `stealth_async` / `stealth_sync` from `playwright_stealth`, which 2.x doesn't expose. Replaced with the `Stealth` class — `apply_stealth_async` accepts `Page` or `BrowserContext`, so existing call sites are unchanged.

## Changes

- `crawl4ai/browser_adapter.py` — Swap the broken function-style imports for `Stealth().apply_stealth_async(page)`.

## Test plan

Ran the issue's repro against `develop` (broken) and this branch (fixed), with `enable_stealth=False` as the control:

| version | `enable_stealth=False` | `enable_stealth=True` |
|---|---|---|
| `develop` | `navigator.languages: ["en-US"]` | `navigator.languages: ["en-US"]` ← stealth=True is a no-op |
| this branch | `navigator.languages: ["en-US"]` | `navigator.languages: ["en-US","en"]` ← `Stealth` init script applied |

The added `"en"` is `Stealth()`'s default `navigator_languages_override` — proves the init script is now being injected. On Chromium 147 headless-shell most other classic signals (`navigator.webdriver`, `chrome.csi/loadTimes`, etc.) are already masked by the browser itself, so this is the clearest single-property A/B differentiator.

- [x] Repro from #1959 verified end-to-end against bot.sannysoft.com on both `develop` and this branch
- [x] Confirmed `Stealth.apply_stealth_async` accepts `Page` (signature: `Union[Page, BrowserContext]`) — no call-site changes needed in `browser_manager.py`
