### PR TITLE
Preserve native Unicode in MCP tool responses by disabling ASCII escaping

### DIFF
--- a/deploy/docker/mcp_bridge.py
+++ b/deploy/docker/mcp_bridge.py
@@ -137,8 +137,8 @@ def attach_mcp(
         except HTTPException as exc:
             # map server‑side errors into MCP "text/error" payloads
             err = {"error": exc.status_code, "detail": exc.detail}
-            return [t.TextContent(type = "text", text=json.dumps(err))]
-        return [t.TextContent(type = "text", text=json.dumps(res, default=str))]
+            return [t.TextContent(type = "text", text=json.dumps(err, ensure_ascii=False))]
+        return [t.TextContent(type = "text", text=json.dumps(res, default=str, ensure_ascii=False))]
 
     @mcp.list_resources()
     async def _list_resources() -> List[t.Resource]:
@@ -152,7 +152,7 @@ def attach_mcp(
         if name not in resources:
             raise HTTPException(404, "resource not found")
         res = resources[name]()
-        return [t.TextContent(type = "text", text=json.dumps(res, default=str))]
+        return [t.TextContent(type = "text", text=json.dumps(res, default=str, ensure_ascii=False))]
 
     @mcp.list_resource_templates()
     async def _list_templates() -> List[t.ResourceTemplate]:


### PR DESCRIPTION
## Summary
- `json.dumps()` in `deploy/docker/mcp_bridge.py` defaulted to `ensure_ascii=True`, escaping all non-ASCII characters (Chinese, Japanese, Korean, etc.) as `\uXXXX` sequences in MCP tool
  results
  - Added `ensure_ascii=False` to all 3 `json.dumps()` calls in `_call_tool()` (success path, error path) and `_read_resource()`
  - Fixes ~2-3x token overhead for CJK content with zero impact on English/ASCII content

Fixes #1962 

## List of files changed and why
- `deploy/docker/mcp_bridge.py` — added `ensure_ascii=False` to 3 `json.dumps()` calls (lines 140, 141, 155)

## How Has This Been Tested?
MCP tool result: {"markdown": "\u8df3\u8f6c\u5230\u5185\u5bb9..."}  # 507 \uXXXX sequences

  **After fix — verified via live MCP tool calls against `localhost:11235`:**

  | Tool | URL | Result |
  |---|---|---|
  | `md` | `https://zh.wikipedia.org/wiki/Hello` | ✅ Native CJK: `跳转到内容`, `维基百科` |
  | `md` | `https://example.com` | ✅ English unaffected |
  | `md` | Invalid URL | ✅ Error JSON (line 140 path) still works |
  | `html` | `https://zh.wikipedia.org/wiki/Hello` | ✅ Native CJK throughout |
  | `crawl` | `https://ja.wikipedia.org/wiki/Hello` | ✅ 0 escaped sequences from serialization |
  | `execute_js` | `https://zh.wikipedia.org/wiki/Hello` | ✅ 11,997 native non-ASCII chars, 0 escaped |

  **Size reduction on a real page:**
  Before (escaped): 5,132 chars
  After (native):   2,597 chars
  Overhead removed: ~2x character reduction (2.5-3x token reduction)

  **Existing test suite:** 17/18 tests pass. The 1 failure (`test_sse_handler_is_raw_asgi`) is pre-existing and unrelated — it tests for a stale function name from a prior refactor.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added/updated unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
