### PR TITLE
feat: load aws credentials to access bedrock models

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,6 +520,53 @@ if __name__ == "__main__":
 </details>
 
 <details>
+<summary>☁️ <strong>AWS Bedrock LLM Support with Flexible Authentication</strong></summary>
+
+Crawl4AI supports AWS Bedrock models with multiple authentication methods. Credentials are resolved with priority: **explicit code > environment variables > AWS profile > IAM role**.
+
+```python
+    # Method 1: IAM Role (recommended for EC2/ECS/Lambda)
+    LLMConfig(
+        provider="bedrock/us.anthropic.claude-sonnet-4-6",
+        provider_config={
+          "aws_region_name": "us-east-1",
+        }
+    )
+
+    # Method 2: AWS Profile
+    LLMConfig(
+        provider="bedrock/us.anthropic.claude-sonnet-4-6",
+        provider_config={
+            "aws_region_name": "us-east-1",
+            "aws_profile_name": "my-profile",
+        }
+    )
+
+    # Method 3: Explicit Credentials (highest priority)
+    LLMConfig(
+        provider="bedrock/us.anthropic.claude-sonnet-4-6",
+        provider_config={
+            "aws_region_name": "us-east-1",
+            "aws_access_key_id": "AKIA...",
+            "aws_secret_access_key": "...",
+        }
+    )
+
+    # Method 4: Environment Variables (automatic fallback)
+    # Set: export AWS_REGION=us-east-1
+    #      export AWS_ACCESS_KEY_ID=AKIA...
+    #      export AWS_SECRET_ACCESS_KEY=...
+    # or Set: export AWS_REGION=us-east-1
+    #      export AWS_PROFILE=...
+    LLMConfig(
+        provider="bedrock/us.anthropic.claude-sonnet-4-6",
+        # Automatically uses AWS environment variables
+    )
+```
+
+</details>
+
+<details>
 <summary>🤖 <strong>Using Your own Browser with Custom User Profile</strong></summary>
 
 ```python

--- a/crawl4ai/async_configs.py
+++ b/crawl4ai/async_configs.py
@@ -2028,6 +2028,7 @@ class LLMConfig:
         provider: str = DEFAULT_PROVIDER,
         api_token: Optional[str] = None,
         base_url: Optional[str] = None,
+        provider_config: Optional[Dict] = None,
         temperature: Optional[float] = None,
         max_tokens: Optional[int] = None,
         top_p: Optional[float] = None,
@@ -2041,6 +2042,7 @@ class LLMConfig:
     ):
         """Configuaration class for LLM provider and API token."""
         self.provider = provider
+        self.provider_config = provider_config or {}
         if api_token and not api_token.startswith("env:"):
             self.api_token = api_token
         elif api_token and api_token.startswith("env:"):
@@ -2076,6 +2078,7 @@ class LLMConfig:
             provider=kwargs.get("provider", DEFAULT_PROVIDER),
             api_token=kwargs.get("api_token"),
             base_url=kwargs.get("base_url"),
+            provider_config=kwargs.get("provider_config"),
             temperature=kwargs.get("temperature"),
             max_tokens=kwargs.get("max_tokens"),
             top_p=kwargs.get("top_p"),
@@ -2093,6 +2096,7 @@ class LLMConfig:
             "provider": self.provider,
             "api_token": self.api_token,
             "base_url": self.base_url,
+            "provider_config": self.provider_config,
             "temperature": self.temperature,
             "max_tokens": self.max_tokens,
             "top_p": self.top_p,

--- a/crawl4ai/extraction_strategy.py
+++ b/crawl4ai/extraction_strategy.py
@@ -688,6 +688,7 @@ class LLMExtractionStrategy(ExtractionStrategy):
                 self.llm_config.api_token,
                 base_url=self.llm_config.base_url,
                 json_response=self.force_json_response,
+                provider_config=self.llm_config.provider_config,
                 extra_args=self.extra_args,
                 base_delay=self.llm_config.backoff_base_delay,
                 max_attempts=self.llm_config.backoff_max_attempts,
@@ -891,6 +892,7 @@ class LLMExtractionStrategy(ExtractionStrategy):
                 self.llm_config.api_token,
                 base_url=self.llm_config.base_url,
                 json_response=self.force_json_response,
+                provider_config=self.llm_config.provider_config,
                 extra_args=self.extra_args,
                 base_delay=self.llm_config.backoff_base_delay,
                 max_attempts=self.llm_config.backoff_max_attempts,
@@ -1602,6 +1604,7 @@ class JsonElementExtractionStrategy(ExtractionStrategy):
                 json_response=True,
                 api_token=llm_config.api_token,
                 base_url=llm_config.base_url,
+                provider_config=llm_config.provider_config,
             )
             if usage is not None:
                 usage.completion_tokens += response.usage.completion_tokens
@@ -1919,6 +1922,7 @@ In this scenario, use your best judgment to generate the schema. You need to exa
                     json_response=True,
                     api_token=llm_config.api_token,
                     base_url=llm_config.base_url,
+                    provider_config=llm_config.provider_config,
                     messages=messages,
                     extra_args=kwargs,
                 )

--- a/crawl4ai/utils.py
+++ b/crawl4ai/utils.py
@@ -1749,6 +1749,7 @@ def perform_completion_with_backoff(
     max_attempts=3,
     exponential_factor=2,
     messages=None,
+    provider_config=None,
     **kwargs,
 ):
     """
@@ -1782,6 +1783,29 @@ def perform_completion_with_backoff(
     extra_args = {"temperature": 0.01, "api_key": api_token, "base_url": base_url}
     if json_response:
         extra_args["response_format"] = {"type": "json_object"}
+
+    if provider.startswith("bedrock/"):
+        pc = provider_config or {}
+
+        region = pc.get("aws_region_name") or os.getenv("AWS_REGION") or os.getenv("AWS_DEFAULT_REGION")
+        if region:
+            extra_args["aws_region_name"] = region
+
+        profile = pc.get("aws_profile_name") or os.getenv("AWS_PROFILE")
+        if profile:
+            extra_args["aws_profile_name"] = profile
+
+        access_key = pc.get("aws_access_key_id") or os.getenv("AWS_ACCESS_KEY_ID")
+        if access_key:
+            extra_args["aws_access_key_id"] = access_key
+
+        secret_key = pc.get("aws_secret_access_key") or os.getenv("AWS_SECRET_ACCESS_KEY")
+        if secret_key:
+            extra_args["aws_secret_access_key"] = secret_key
+
+        session_token = pc.get("aws_session_token") or os.getenv("AWS_SESSION_TOKEN")
+        if session_token:
+            extra_args["aws_session_token"] = session_token
 
     if kwargs.get("extra_args"):
         extra_args.update(kwargs["extra_args"])
@@ -1841,6 +1865,7 @@ async def aperform_completion_with_backoff(
     max_attempts=3,
     exponential_factor=2,
     messages=None,
+    provider_config=None,
     **kwargs,
 ):
     """
@@ -1875,6 +1900,29 @@ async def aperform_completion_with_backoff(
     extra_args = {"temperature": 0.01, "api_key": api_token, "base_url": base_url}
     if json_response:
         extra_args["response_format"] = {"type": "json_object"}
+
+    if provider.startswith("bedrock/"):
+        pc = provider_config or {}
+
+        region = pc.get("aws_region_name") or os.getenv("AWS_REGION") or os.getenv("AWS_DEFAULT_REGION")
+        if region:
+            extra_args["aws_region_name"] = region
+
+        profile = pc.get("aws_profile_name") or os.getenv("AWS_PROFILE")
+        if profile:
+            extra_args["aws_profile_name"] = profile
+
+        access_key = pc.get("aws_access_key_id") or os.getenv("AWS_ACCESS_KEY_ID")
+        if access_key:
+            extra_args["aws_access_key_id"] = access_key
+
+        secret_key = pc.get("aws_secret_access_key") or os.getenv("AWS_SECRET_ACCESS_KEY")
+        if secret_key:
+            extra_args["aws_secret_access_key"] = secret_key
+
+        session_token = pc.get("aws_session_token") or os.getenv("AWS_SESSION_TOKEN")
+        if session_token:
+            extra_args["aws_session_token"] = session_token
 
     if kwargs.get("extra_args"):
         extra_args.update(kwargs["extra_args"])

--- a/tests/test_completion_provider_config.py
+++ b/tests/test_completion_provider_config.py
@@ -1,0 +1,191 @@
+import os
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from crawl4ai.utils import aperform_completion_with_backoff, perform_completion_with_backoff
+
+
+@pytest.fixture
+def mock_completion(monkeypatch):
+    mock = MagicMock()
+    mock_response = MagicMock()
+    mock_response.usage.completion_tokens = 10
+    mock_response.usage.prompt_tokens = 20
+    mock_response.usage.total_tokens = 30
+    mock_response.usage.completion_tokens_details = None
+    mock_response.usage.prompt_tokens_details = None
+    mock.return_value = mock_response
+    monkeypatch.setattr("litellm.completion", mock)
+    return mock
+
+
+@pytest.fixture
+def mock_acompletion(monkeypatch):
+    mock = AsyncMock()
+    mock_response = MagicMock()
+    mock_response.usage.completion_tokens = 10
+    mock_response.usage.prompt_tokens = 20
+    mock_response.usage.total_tokens = 30
+    mock_response.usage.completion_tokens_details = None
+    mock_response.usage.prompt_tokens_details = None
+    mock.return_value = mock_response
+    monkeypatch.setattr("litellm.acompletion", mock)
+    return mock
+
+
+class TestPerformCompletionWithProviderConfig:
+    def setup_method(self):
+        env_vars = [
+            "AWS_REGION",
+            "AWS_DEFAULT_REGION",
+            "AWS_PROFILE",
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "AWS_SESSION_TOKEN",
+        ]
+        for var in env_vars:
+            os.environ.pop(var, None)
+
+    def test_bedrock_provider_config_passed_to_litellm(self, mock_completion):
+        provider_config = {
+            "aws_region_name": "us-west-2",
+            "aws_profile_name": "dev",
+            "aws_access_key_id": "AKIA123",
+            "aws_secret_access_key": "secret123",
+            "aws_session_token": "token123",
+        }
+
+        perform_completion_with_backoff(
+            provider="bedrock/anthropic.claude-v2",
+            prompt_with_variables="test prompt",
+            api_token=None,
+            provider_config=provider_config,
+        )
+
+        mock_completion.assert_called_once()
+        call_kwargs = mock_completion.call_args.kwargs
+
+        assert {k: v for k, v in call_kwargs.items() if k.startswith("aws_")} == {
+            "aws_region_name": "us-west-2",
+            "aws_profile_name": "dev",
+            "aws_access_key_id": "AKIA123",
+            "aws_secret_access_key": "secret123",
+            "aws_session_token": "token123",
+        }
+
+    def test_bedrock_env_var_fallback(self, mock_completion):
+        os.environ["AWS_REGION"] = "ap-southeast-1"
+        os.environ["AWS_ACCESS_KEY_ID"] = "AKIA_ENV"
+        os.environ["AWS_SECRET_ACCESS_KEY"] = "SECRET_ENV"
+
+        perform_completion_with_backoff(
+            provider="bedrock/anthropic.claude-v2",
+            prompt_with_variables="test prompt",
+            api_token=None,
+            provider_config=None,
+        )
+
+        mock_completion.assert_called_once()
+        call_kwargs = mock_completion.call_args.kwargs
+
+        assert {k: v for k, v in call_kwargs.items() if k.startswith("aws_")} == {
+            "aws_region_name": "ap-southeast-1",
+            "aws_access_key_id": "AKIA_ENV",
+            "aws_secret_access_key": "SECRET_ENV",
+        }
+
+    def test_bedrock_explicit_overrides_env(self, mock_completion):
+        os.environ["AWS_REGION"] = "us-east-1"
+        os.environ["AWS_ACCESS_KEY_ID"] = "AKIA_ENV"
+
+        provider_config = {"aws_region_name": "us-west-2", "aws_access_key_id": "AKIA_EXPLICIT"}
+
+        perform_completion_with_backoff(
+            provider="bedrock/anthropic.claude-v2",
+            prompt_with_variables="test prompt",
+            api_token=None,
+            provider_config=provider_config,
+        )
+
+        mock_completion.assert_called_once()
+        call_kwargs = mock_completion.call_args.kwargs
+
+        assert {k: v for k, v in call_kwargs.items() if k.startswith("aws_")} == {
+            "aws_region_name": "us-west-2",
+            "aws_access_key_id": "AKIA_EXPLICIT",
+        }
+
+    def test_non_bedrock_provider_unaffected(self, mock_completion):
+        provider_config = {"aws_region_name": "us-west-2", "aws_access_key_id": "AKIA123"}
+
+        perform_completion_with_backoff(
+            provider="openai/gpt-4",
+            prompt_with_variables="test prompt",
+            api_token="sk-test",
+            provider_config=provider_config,
+        )
+
+        mock_completion.assert_called_once()
+        call_kwargs = mock_completion.call_args.kwargs
+
+        assert "aws_region_name" not in call_kwargs
+        assert "aws_access_key_id" not in call_kwargs
+        assert call_kwargs["api_key"] == "sk-test"
+
+
+class TestAPerformCompletionWithProviderConfig:
+    def setup_method(self):
+        env_vars = [
+            "AWS_REGION",
+            "AWS_DEFAULT_REGION",
+            "AWS_PROFILE",
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "AWS_SESSION_TOKEN",
+        ]
+        for var in env_vars:
+            os.environ.pop(var, None)
+
+    @pytest.mark.asyncio
+    async def test_async_bedrock_provider_config_passed(self, mock_acompletion):
+        provider_config = {"aws_region_name": "us-west-2", "aws_access_key_id": "AKIA123"}
+
+        await aperform_completion_with_backoff(
+            provider="bedrock/anthropic.claude-v2",
+            prompt_with_variables="test prompt",
+            api_token=None,
+            provider_config=provider_config,
+        )
+
+        mock_acompletion.assert_called_once()
+        call_kwargs = mock_acompletion.call_args.kwargs
+
+        assert {k: v for k, v in call_kwargs.items() if k.startswith("aws_")} == {
+            "aws_region_name": "us-west-2",
+            "aws_access_key_id": "AKIA123",
+        }
+
+    @pytest.mark.asyncio
+    async def test_async_bedrock_env_fallback(self, mock_acompletion):
+        os.environ["AWS_REGION"] = "eu-west-1"
+        os.environ["AWS_ACCESS_KEY_ID"] = "AKIA_ENV"
+
+        await aperform_completion_with_backoff(
+            provider="bedrock/anthropic.claude-v2",
+            prompt_with_variables="test prompt",
+            api_token=None,
+            provider_config=None,
+        )
+
+        mock_acompletion.assert_called_once()
+        call_kwargs = mock_acompletion.call_args.kwargs
+
+        assert {k: v for k, v in call_kwargs.items() if k.startswith("aws_")} == {
+            "aws_region_name": "eu-west-1",
+            "aws_access_key_id": "AKIA_ENV",
+        }
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_llm_provider_config.py
+++ b/tests/test_llm_provider_config.py
@@ -1,0 +1,140 @@
+import os
+
+import pytest
+
+from crawl4ai.async_configs import LLMConfig
+
+
+class TestAWSBedrockProviderConfig:
+    def setup_method(self):
+        env_vars = [
+            "AWS_REGION",
+            "AWS_DEFAULT_REGION",
+            "AWS_PROFILE",
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "AWS_SESSION_TOKEN",
+        ]
+        for var in env_vars:
+            os.environ.pop(var, None)
+
+    def test_provider_config_basic(self):
+        config = LLMConfig(
+            provider="bedrock/anthropic.claude-v2", provider_config={"aws_region_name": "us-east-1"}
+        )
+        assert config.provider == "bedrock/anthropic.claude-v2"
+        assert config.provider_config == {"aws_region_name": "us-east-1"}
+
+    def test_provider_config_empty_default(self):
+        config = LLMConfig(provider="bedrock/anthropic.claude-v2")
+        assert config.provider_config == {}
+
+    def test_provider_config_none_becomes_empty(self):
+        config = LLMConfig(provider="bedrock/anthropic.claude-v2", provider_config=None)
+        assert config.provider_config == {}
+
+    def test_provider_config_aws_credentials(self):
+        config = LLMConfig(
+            provider="bedrock/anthropic.claude-v2",
+            provider_config={
+                "aws_region_name": "us-west-2",
+                "aws_profile_name": "dev",
+                "aws_access_key_id": "AKIA123",
+                "aws_secret_access_key": "secret123",
+                "aws_session_token": "token123",
+            },
+        )
+        assert config.provider_config == {
+            "aws_region_name": "us-west-2",
+            "aws_profile_name": "dev",
+            "aws_access_key_id": "AKIA123",
+            "aws_secret_access_key": "secret123",
+            "aws_session_token": "token123",
+        }
+
+    def test_to_dict_includes_provider_config(self):
+        config = LLMConfig(
+            provider="bedrock/anthropic.claude-v2", provider_config={"aws_region_name": "us-east-1"}
+        )
+        config_dict = config.to_dict()
+        assert "provider_config" in config_dict
+        assert config_dict["provider_config"] == {"aws_region_name": "us-east-1"}
+
+    def test_from_kwargs_with_provider_config(self):
+        kwargs = {
+            "provider": "bedrock/anthropic.claude-v2",
+            "provider_config": {"aws_region_name": "us-west-2"},
+            "temperature": 0.7,
+        }
+        config = LLMConfig.from_kwargs(kwargs)
+        assert config.provider_config == {"aws_region_name": "us-west-2"}
+        assert config.temperature == 0.7
+
+    def test_clone_with_provider_config(self):
+        config1 = LLMConfig(
+            provider="bedrock/anthropic.claude-v2", provider_config={"aws_region_name": "us-east-1"}
+        )
+        config2 = config1.clone(provider_config={"aws_region_name": "eu-west-1"})
+        assert config2.provider_config == {"aws_region_name": "eu-west-1"}
+        assert config1.provider_config == {"aws_region_name": "us-east-1"}
+
+    def test_explicit_provider_config_priority(self):
+        os.environ["AWS_REGION"] = "us-west-2"
+        config = LLMConfig(
+            provider="bedrock/anthropic.claude-v2", provider_config={"aws_region_name": "us-east-1"}
+        )
+        assert config.provider_config["aws_region_name"] == "us-east-1"
+
+    def test_environment_variable_fallback(self):
+        os.environ["AWS_REGION"] = "ap-southeast-1"
+        os.environ["AWS_ACCESS_KEY_ID"] = "AKIA_FROM_ENV"
+        config = LLMConfig(provider="bedrock/anthropic.claude-v2")
+        assert config.provider_config == {}
+
+    def test_mixed_explicit_and_env(self):
+        os.environ["AWS_ACCESS_KEY_ID"] = "AKIA_FROM_ENV"
+        os.environ["AWS_SECRET_ACCESS_KEY"] = "SECRET_FROM_ENV"
+        config = LLMConfig(
+            provider="bedrock/anthropic.claude-v2", provider_config={"aws_region_name": "us-east-1"}
+        )
+        assert config.provider_config["aws_region_name"] == "us-east-1"
+
+    def test_llm_extraction_strategy_receives_provider_config(self):
+        from crawl4ai.extraction_strategy import LLMExtractionStrategy
+
+        llm_config = LLMConfig(
+            provider="bedrock/anthropic.claude-v2",
+            provider_config={"aws_region_name": "us-east-1", "aws_access_key_id": "AKIA123"},
+        )
+        strategy = LLMExtractionStrategy(llm_config=llm_config, instruction="Extract content")
+        assert strategy.llm_config.provider_config == {
+            "aws_region_name": "us-east-1",
+            "aws_access_key_id": "AKIA123",
+        }
+
+    def test_bedrock_provider_detected(self):
+        providers = [
+            "bedrock/anthropic.claude-v2",
+            "bedrock/anthropic.claude-instant-v1",
+            "bedrock/us.anthropic.claude-sonnet-4-6",
+            "bedrock/amazon.titan-text-express-v1",
+        ]
+        for provider in providers:
+            config = LLMConfig(provider=provider, provider_config={"aws_region_name": "us-east-1"})
+            assert config.provider.startswith("bedrock/")
+            assert config.provider_config["aws_region_name"] == "us-east-1"
+
+    def test_empty_provider_config_values(self):
+        config = LLMConfig(
+            provider="bedrock/anthropic.claude-v2",
+            provider_config={
+                "aws_region_name": "",
+                "aws_profile_name": None,
+                "aws_access_key_id": "",
+            },
+        )
+        assert "aws_region_name" in config.provider_config
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
AWS profile name, region name, AKSK can be set from env var or in LLMConfig parameters to configure authentication of accessing AWS Bedrock models.

## List of files changed and why
- crawl4ai/async_configs.py: add a parameter to accept by-provider configs
- crawl4ai/extraction_strategy.py: add a parameter to accept by-provider configs
- crawl4ai/utils.py: load aws variables from parameter and env var
- README.md: add example code for aws bedrock

## How Has This Been Tested?

### Unittest
- tests/test_completion_provider_config.py
- tests/test_llm_provider_config.py

### E2E
1. Setup LLMConfig by example codes in readme with personal credentials
2. Crawl web with configed model

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added/updated unit tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
