### PR TITLE
fix: send async logger output to stderr

### DIFF
--- a/crawl4ai/async_logger.py
+++ b/crawl4ai/async_logger.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Optional, Dict, Any, List
 import os
+import sys
 from datetime import datetime
 from urllib.parse import unquote
 from rich.console import Console
@@ -118,6 +119,7 @@ class AsyncLogger(AsyncLoggerBase):
         icons: Optional[Dict[str, str]] = None,
         colors: Optional[Dict[LogLevel, LogColor]] = None,
         verbose: bool = True,
+        console: Optional[Console] = None,
     ):
         """
         Initialize the logger.
@@ -129,6 +131,7 @@ class AsyncLogger(AsyncLoggerBase):
             icons: Custom icons for different tags
             colors: Custom colors for different log levels
             verbose: Whether to output to console
+            console: Optional Rich console for log output. Defaults to stderr.
         """
         self.log_file = log_file
         self.log_level = log_level
@@ -136,7 +139,7 @@ class AsyncLogger(AsyncLoggerBase):
         self.icons = icons or self.DEFAULT_ICONS
         self.colors = colors or self.DEFAULT_COLORS
         self.verbose = verbose
-        self.console = Console()
+        self.console = console or Console(file=sys.stderr)
 
         # Create log file directory if needed
         if log_file:

--- a/tests/loggers/test_async_logger_stderr.py
+++ b/tests/loggers/test_async_logger_stderr.py
@@ -1,0 +1,25 @@
+from io import StringIO
+
+from rich.console import Console
+
+from crawl4ai.async_logger import AsyncLogger
+
+
+def test_async_logger_writes_to_stderr_by_default(capsys):
+    logger = AsyncLogger(verbose=True)
+
+    logger.info("structured stdout should stay clean")
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "structured stdout should stay clean" in captured.err
+
+
+def test_async_logger_accepts_custom_console():
+    stream = StringIO()
+    console = Console(file=stream, force_terminal=False, width=120)
+    logger = AsyncLogger(verbose=True, console=console)
+
+    logger.info("custom stream")
+
+    assert "custom stream" in stream.getvalue()


### PR DESCRIPTION
## Summary
Fixes #1968

Routes `AsyncLogger` console output to stderr by default so stdout remains clean for stdio protocols such as MCP, while still allowing callers to pass a custom Rich console.

## List of files changed and why
- `crawl4ai/async_logger.py` - Default logger console output to stderr and add an optional custom console parameter.
- `tests/loggers/test_async_logger_stderr.py` - Cover stderr default behavior and custom console override.

## How Has This Been Tested?
- `. .venv/bin/activate && python -m pytest tests/loggers/test_async_logger_stderr.py`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added/updated unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
