### PR TITLE
fix: allow assistant toolbar to scroll

### DIFF
--- a/docs/md_v2/apps/crawl4ai-assistant/content/overlay.css
+++ b/docs/md_v2/apps/crawl4ai-assistant/content/overlay.css
@@ -115,8 +115,9 @@
     font-family: var(--font-primary);
     box-shadow: 0 8px 32px rgba(0, 0, 0, 0.8);
     width: 320px;
+    max-height: 500px;
     color: #e8e9ed;
-    overflow: hidden;
+    overflow-y: auto;
     pointer-events: auto; /* Ensure clicks work */
 }
 


### PR DESCRIPTION
## Summary

Updates the Crawl4AI Assistant toolbar styling so long Click2Crawl content can scroll instead of being clipped by a hidden overflow container.

## Changes

- Adds a 500px maximum height to `.c4ai-toolbar`
- Replaces hidden overflow with vertical scrolling

## Testing

- `git diff --check`
- CSS sanity check verifying the new toolbar rules are present

Fixes unclecode/crawl4ai#1973
