### PR TITLE
fix: follow single-frame framesets

### DIFF
--- a/crawl4ai/async_configs.py
+++ b/crawl4ai/async_configs.py
@@ -1118,6 +1118,8 @@ class CrawlerRunConfig():
                                          If None, scrolls until the entire page is loaded. Default: None.
         process_iframes (bool): If True, attempts to process and inline iframe content.
                                 Default: False.
+        follow_frames (bool): If True, returns child frame content for single-frame framesets.
+                              Default: True.
         remove_overlay_elements (bool): If True, remove overlays/popups before extracting HTML.
                                         Default: False.
         simulate_user (bool): If True, simulate user interactions (mouse moves, clicks) for anti-bot measures.
@@ -1279,6 +1281,7 @@ class CrawlerRunConfig():
         scroll_delay: float = 0.2,
         max_scroll_steps: Optional[int] = None,
         process_iframes: bool = False,
+        follow_frames: bool = True,
         remove_overlay_elements: bool = False,
         simulate_user: bool = False,
         override_navigator: bool = False,
@@ -1406,6 +1409,7 @@ class CrawlerRunConfig():
         self.scroll_delay = scroll_delay
         self.max_scroll_steps = max_scroll_steps
         self.process_iframes = process_iframes
+        self.follow_frames = follow_frames
         self.remove_overlay_elements = remove_overlay_elements
         self.simulate_user = simulate_user
         self.override_navigator = override_navigator
@@ -1686,6 +1690,7 @@ class CrawlerRunConfig():
             scroll_delay=kwargs.get("scroll_delay", 0.2),
             max_scroll_steps=kwargs.get("max_scroll_steps"),
             process_iframes=kwargs.get("process_iframes", False),
+            follow_frames=kwargs.get("follow_frames", True),
             remove_overlay_elements=kwargs.get("remove_overlay_elements", False),
             simulate_user=kwargs.get("simulate_user", False),
             override_navigator=kwargs.get("override_navigator", False),
@@ -1810,6 +1815,7 @@ class CrawlerRunConfig():
             "scroll_delay": self.scroll_delay,
             "max_scroll_steps": self.max_scroll_steps,
             "process_iframes": self.process_iframes,
+            "follow_frames": self.follow_frames,
             "remove_overlay_elements": self.remove_overlay_elements,
             "simulate_user": self.simulate_user,
             "override_navigator": self.override_navigator,

--- a/crawl4ai/async_crawler_strategy.py
+++ b/crawl4ai/async_crawler_strategy.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import re
 import time
 from abc import ABC, abstractmethod
 from typing import Callable, Dict, Any, List, Union
@@ -401,6 +402,52 @@ class AsyncPlaywrightCrawlerStrategy(AsyncCrawlerStrategy):
 
         # Return the page object
         return page
+
+    async def _try_follow_frameset(self, page):
+        """
+        Return the child frame content for single-frame frameset redirects.
+
+        Deprecated frameset pages are often used as full-page wrappers around a
+        single child frame. In that case the top-level HTML is just an empty
+        shell, while Playwright has already loaded the meaningful content in the
+        child frame.
+        """
+        try:
+            frames = page.frames
+            if len(frames) != 2:
+                return None, None
+
+            main_html = await page.content()
+            if "<frameset" not in main_html.lower():
+                return None, None
+
+            match = re.search(r"<frameset([^>]*)>", main_html, re.IGNORECASE)
+            if not match:
+                return None, None
+
+            attrs = match.group(1)
+            rows = re.search(r"rows=[\"']([^\"']+)[\"']", attrs, re.IGNORECASE)
+            cols = re.search(r"cols=[\"']([^\"']+)[\"']", attrs, re.IGNORECASE)
+
+            def is_full_viewport(value: str) -> bool:
+                parts = [part.strip().lower() for part in value.split(",")]
+                return len(parts) == 1 and parts[0] in {"100%", "*"}
+
+            if rows and not is_full_viewport(rows.group(1)):
+                return None, None
+            if cols and not is_full_viewport(cols.group(1)):
+                return None, None
+
+            child_frame = frames[1]
+            child_html = await child_frame.content()
+            child_url = child_frame.url
+
+            if not child_html or not child_url:
+                return None, None
+
+            return child_html, child_url
+        except Exception:
+            return None, None
 
     async def create_session(self, **kwargs) -> str:
         """
@@ -968,6 +1015,11 @@ class AsyncPlaywrightCrawlerStrategy(AsyncCrawlerStrategy):
             if config.remove_overlay_elements:
                 await self.remove_overlay_elements(page)
 
+            frame_url = None
+            frame_html = None
+            if config.follow_frames and not config.css_selector:
+                frame_html, frame_url = await self._try_follow_frameset(page)
+
             if config.css_selector:
                 try:
                     # Handle comma-separated selectors by splitting them
@@ -989,6 +1041,8 @@ class AsyncPlaywrightCrawlerStrategy(AsyncCrawlerStrategy):
                     html = f"<div class='crawl4ai-result'>\n" + "\n".join(html_parts) + "\n</div>"                    
                 except Error as e:
                     raise RuntimeError(f"Failed to extract HTML content: {str(e)}")
+            elif frame_html is not None:
+                html = frame_html
             else:
                 html = await page.content()
             
@@ -1043,7 +1097,7 @@ class AsyncPlaywrightCrawlerStrategy(AsyncCrawlerStrategy):
             # This ensures we capture the current page URL at the time we return the response, 
             # which correctly reflects any JavaScript navigation that occurred.
             ###
-            redirected_url = page.url  # Use current page URL to capture JS redirects
+            redirected_url = frame_url or page.url  # Use current page URL to capture JS redirects
             
             # Return complete response
             return AsyncCrawlResponse(

--- a/tests/test_follow_frames.py
+++ b/tests/test_follow_frames.py
@@ -1,0 +1,72 @@
+import pytest
+
+from crawl4ai.async_configs import CrawlerRunConfig
+from crawl4ai.async_crawler_strategy import AsyncPlaywrightCrawlerStrategy
+
+
+class FakeFrame:
+    def __init__(self, html, url):
+        self._html = html
+        self.url = url
+
+    async def content(self):
+        return self._html
+
+
+class FakePage:
+    def __init__(self, html, frames):
+        self._html = html
+        self.frames = frames
+
+    async def content(self):
+        return self._html
+
+
+@pytest.mark.asyncio
+async def test_try_follow_frameset_returns_single_full_viewport_child():
+    child = FakeFrame("<html><body>Frame content</body></html>", "https://example.com/frame")
+    page = FakePage(
+        """
+        <html>
+          <frameset rows="100%">
+            <frame src="https://example.com/frame">
+          </frameset>
+        </html>
+        """,
+        [FakeFrame("", "https://example.com"), child],
+    )
+
+    html, url = await AsyncPlaywrightCrawlerStrategy._try_follow_frameset(object(), page)
+
+    assert html == "<html><body>Frame content</body></html>"
+    assert url == "https://example.com/frame"
+
+
+@pytest.mark.asyncio
+async def test_try_follow_frameset_ignores_multi_frame_layout():
+    page = FakePage(
+        """
+        <html>
+          <frameset cols="25%,75%">
+            <frame src="/nav"><frame src="/content">
+          </frameset>
+        </html>
+        """,
+        [
+            FakeFrame("", "https://example.com"),
+            FakeFrame("nav", "https://example.com/nav"),
+            FakeFrame("content", "https://example.com/content"),
+        ],
+    )
+
+    assert await AsyncPlaywrightCrawlerStrategy._try_follow_frameset(object(), page) == (None, None)
+
+
+def test_crawler_run_config_follow_frames_round_trips():
+    default_config = CrawlerRunConfig()
+    disabled_config = CrawlerRunConfig(follow_frames=False)
+
+    assert default_config.follow_frames is True
+    assert default_config.to_dict()["follow_frames"] is True
+    assert CrawlerRunConfig.from_kwargs({"follow_frames": False}).follow_frames is False
+    assert disabled_config.to_dict()["follow_frames"] is False


### PR DESCRIPTION
## Summary
Fixes #1974

Add support for following single-frame frameset wrappers by returning the already-loaded child frame content and surfacing the child frame URL as the redirected URL.

## List of files changed and why
- `crawl4ai/async_crawler_strategy.py` - Detect conservative single-frame framesets and use the child frame HTML instead of the empty frameset shell.
- `crawl4ai/async_configs.py` - Add `follow_frames` runtime config with a default of `True` and serialization support.
- `tests/test_follow_frames.py` - Cover frameset following, multi-frame rejection, and config round-tripping.

## How Has This Been Tested?
- `. .venv/bin/activate && python -m pytest tests/test_follow_frames.py`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added/updated unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
