### PR TITLE
fix: support playwright-stealth v2 adapter

### DIFF
--- a/crawl4ai/browser_adapter.py
+++ b/crawl4ai/browser_adapter.py
@@ -8,6 +8,7 @@ from abc import ABC, abstractmethod
 from typing import List, Dict, Any, Optional, Callable
 import time
 import json
+import inspect
 
 # Import both, but use conditionally
 try:
@@ -158,27 +159,31 @@ class StealthAdapter(BrowserAdapter):
     def _check_stealth_availability(self) -> bool:
         """Check if playwright_stealth is available and get the correct function"""
         try:
-            from playwright_stealth import stealth_async
-            self._stealth_function = stealth_async
+            from playwright_stealth import Stealth
+            stealth = Stealth()
+            self._stealth_function = stealth.apply_stealth_async
             return True
         except ImportError:
             try:
-                from playwright_stealth import stealth_sync
-                self._stealth_function = stealth_sync
+                from playwright_stealth import stealth_async
+                self._stealth_function = stealth_async
                 return True
             except ImportError:
-                self._stealth_function = None
-                return False
+                try:
+                    from playwright_stealth import stealth_sync
+                    self._stealth_function = stealth_sync
+                    return True
+                except ImportError:
+                    self._stealth_function = None
+                    return False
 
     async def apply_stealth(self, page: Page):
         """Apply stealth to a page if available"""
         if self._stealth_available and self._stealth_function:
             try:
-                if hasattr(self._stealth_function, '__call__'):
-                    if 'async' in getattr(self._stealth_function, '__name__', ''):
-                        await self._stealth_function(page)
-                    else:
-                        self._stealth_function(page)
+                result = self._stealth_function(page)
+                if inspect.isawaitable(result):
+                    await result
             except Exception as e:
                 # Fail silently or log error depending on requirements
                 pass

--- a/tests/unit/test_stealth_adapter.py
+++ b/tests/unit/test_stealth_adapter.py
@@ -1,0 +1,63 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "crawl4ai" / "browser_adapter.py"
+
+
+def load_browser_adapter():
+    spec = importlib.util.spec_from_file_location("browser_adapter_under_test", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class DummyPage:
+    pass
+
+
+def test_stealth_adapter_uses_playwright_stealth_v2(monkeypatch):
+    calls = []
+
+    class Stealth:
+        async def apply_stealth_async(self, page):
+            calls.append(page)
+
+    monkeypatch.setitem(sys.modules, "playwright_stealth", types.SimpleNamespace(Stealth=Stealth))
+    StealthAdapter = load_browser_adapter().StealthAdapter
+
+    adapter = StealthAdapter()
+    page = DummyPage()
+
+    assert adapter._stealth_available is True
+
+    import asyncio
+
+    asyncio.run(adapter.apply_stealth(page))
+
+    assert calls == [page]
+
+
+def test_stealth_adapter_keeps_legacy_function_support(monkeypatch):
+    calls = []
+
+    async def stealth_async(page):
+        calls.append(page)
+
+    module = types.ModuleType("playwright_stealth")
+    module.stealth_async = stealth_async
+    monkeypatch.setitem(sys.modules, "playwright_stealth", module)
+    StealthAdapter = load_browser_adapter().StealthAdapter
+
+    adapter = StealthAdapter()
+    page = DummyPage()
+
+    assert adapter._stealth_available is True
+
+    import asyncio
+
+    asyncio.run(adapter.apply_stealth(page))
+
+    assert calls == [page]


### PR DESCRIPTION
## Summary
Fixes #1959

Updates the stealth adapter to use the `Stealth().apply_stealth_async(...)` API exposed by `playwright-stealth` 2.x while preserving fallback support for the legacy `stealth_async` / `stealth_sync` functions.

## List of files changed and why
- `crawl4ai/browser_adapter.py` - Prefer the current `playwright-stealth` v2 API and await stealth functions based on the returned value.
- `tests/unit/test_stealth_adapter.py` - Add unit coverage for both the v2 API and legacy async function fallback.

## How Has This Been Tested?
- `python3 -m pytest tests/unit/test_stealth_adapter.py`
- Verified `playwright-stealth==2.0.0` exposes `Stealth().apply_stealth_async(page_or_context)` in a temporary virtual environment.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added/updated unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
