### PR TITLE
fix: preserve spacing between adjacent spans in markdown

### DIFF
--- a/crawl4ai/html2text/__init__.py
+++ b/crawl4ai/html2text/__init__.py
@@ -1069,6 +1069,16 @@ class CustomHTML2Text(HTML2Text):
                 setattr(self, key, value)
 
     def handle_tag(self, tag, attrs, start):
+        # Adjacent inline spans often represent distinct fields in card/list
+        # layouts (for example, an event title followed by one or more date
+        # spans). When the source HTML has no whitespace between those spans,
+        # the default text conversion concatenates the fields into a single
+        # token. Preserve a readable separator before subsequent spans.
+        if tag == "span" and start and self.outtextlist:
+            last_char = self.outtextlist[-1][-1:] if self.outtextlist[-1] else ""
+            if last_char and not last_char.isspace() and last_char not in "([{":
+                self.o(" ")
+
         # Handle preserved tags
         if tag in self.preserve_tags:
             if start:

--- a/tests/general/test_content_source_parameter.py
+++ b/tests/general/test_content_source_parameter.py
@@ -69,6 +69,27 @@ class TestContentSourceParameter(unittest.TestCase):
         self.assertIsInstance(result, MarkdownGenerationResult)
         self.assertEqual(result.raw_markdown, "# Test Content\n\nThis is a test paragraph.")
 
+    def test_adjacent_spans_get_readable_spacing(self):
+        """Adjacent field spans should not be concatenated in markdown."""
+        html = (
+            '<a href="/event">'
+            '<span>London Build Expo</span>'
+            '<span>25–26 Nov 2026</span>'
+            '<span>2026-11-25</span>'
+            '<span>2026-11-26</span>'
+            '</a>'
+        )
+
+        result = DefaultMarkdownGenerator().generate_markdown(
+            input_html=html, base_url="https://www.excel.london"
+        )
+
+        self.assertIn(
+            "London Build Expo 25–26 Nov 2026 2026-11-25 2026-11-26",
+            result.raw_markdown,
+        )
+        self.assertNotIn("Expo25", result.raw_markdown)
+
     def test_html_source_selection_logic(self):
         """Test that the HTML source selection logic works correctly."""
         # We'll test the dispatch pattern directly to avoid async complexities


### PR DESCRIPTION
## Summary
Fixes #1980

Preserve readable spacing between adjacent inline `<span>` elements when generating markdown, so event card fields such as titles and repeated dates are not concatenated together.

## List of files changed and why
- `crawl4ai/html2text/__init__.py` - Add a separator before adjacent spans when the previous output has no whitespace.
- `tests/general/test_content_source_parameter.py` - Add a regression test for adjacent event title/date spans.

## How Has This Been Tested?
- `python -m pytest tests/general/test_content_source_parameter.py -q`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added/updated unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
