### PR TITLE
fix: prevent lxml child promotion when removing excluded tags

### DIFF
--- a/crawl4ai/content_scraping_strategy.py
+++ b/crawl4ai/content_scraping_strategy.py
@@ -666,19 +666,23 @@ class LXMLWebScrapingStrategy(ContentScrapingStrategy):
                     comment.getparent().remove(comment)
 
             # Handle tag-based removal first
+            # Clear children before removal to prevent lxml child promotion
             excluded_tags = set(kwargs.get("excluded_tags", []) or [])
             if excluded_tags:
                 for tag in excluded_tags:
                     for element in body.xpath(f".//{tag}"):
                         if element.getparent() is not None:
+                            element.clear()
                             element.getparent().remove(element)
 
             # Handle CSS selector-based exclusion
+            # Prevent lxml from promoting children during tag removal
             excluded_selector = kwargs.get("excluded_selector", "")
             if excluded_selector:
                 try:
                     for element in body.cssselect(excluded_selector):
                         if element.getparent() is not None:
+                            element.clear()  
                             element.getparent().remove(element)
                 except Exception as e:
                     self._log(


### PR DESCRIPTION
## Problem
When using `excluded_tags` or `excluded_selector`, removing a tag (e.g. `<header>`) 
does not remove its children. lxml silently promotes them into the parent — so `<nav>`, 
`<ul>`, `<div>` and other inner elements survive in the tree and appear in scraped output.

## Root Cause
`element.getparent().remove(element)` — lxml follows the XML spec and promotes 
children to the parent when an element is removed.

## Fix
Call `element.clear()` before removal to destroy all children first.

```python
element.clear()                     # destroys all children
element.getparent().remove(element)  # removes empty shell
```

## Related Issue
Closes #1982