### PR TITLE
fix: preserve whitespace around inline children in JsonCssExtractionStrategy

### DIFF
--- a/crawl4ai/extraction_strategy.py
+++ b/crawl4ai/extraction_strategy.py
@@ -2025,7 +2025,9 @@ class JsonCssExtractionStrategy(JsonElementExtractionStrategy):
         return element.select(selector)
 
     def _get_element_text(self, element) -> str:
-        return element.get_text(strip=True)
+        # ``separator=" "`` preserves spaces around inline children;
+        # without it, ``<span>foo <b>bar</b> baz</span>`` → ``foobarbaz``.
+        return element.get_text(separator=" ", strip=True)
 
     def _get_element_html(self, element) -> str:
         return str(element)

--- a/tests/test_jsoncss_text_whitespace.py
+++ b/tests/test_jsoncss_text_whitespace.py
@@ -1,0 +1,45 @@
+"""Regression: JsonCssExtractionStrategy must preserve whitespace
+around inline children when extracting text fields.
+
+Without ``separator=" "``, ``element.get_text(strip=True)`` strips
+each child text node and concatenates them with no separator,
+turning ``<span>foo <b>bar</b> baz</span>`` into ``"foobarbaz"``.
+"""
+
+from crawl4ai.extraction_strategy import JsonCssExtractionStrategy
+
+
+HTML = """\
+<html><body>
+  <ul>
+    <li class="item"><span class="name">Wireless <b>Logitech</b> Mouse M325</span></li>
+    <li class="item"><span class="name">USB-C <strong>Anker</strong> Hub</span></li>
+    <li class="item"><span class="name">No inline tags here</span></li>
+  </ul>
+</body></html>
+"""
+
+SCHEMA = {
+    "baseSelector": "body",
+    "fields": [
+        {
+            "name": "items",
+            "type": "list",
+            "selector": "ul li.item",
+            "fields": [
+                {"name": "name", "selector": "span.name", "type": "text"},
+            ],
+        }
+    ],
+}
+
+
+def test_jsoncss_preserves_spaces_around_inline_tags() -> None:
+    [record] = JsonCssExtractionStrategy(SCHEMA).extract(url="x", html_content=HTML)
+    names = [item["name"] for item in record["items"]]
+
+    assert names == [
+        "Wireless Logitech Mouse M325",
+        "USB-C Anker Hub",
+        "No inline tags here",
+    ]


### PR DESCRIPTION
## Summary

`JsonCssExtractionStrategy._get_element_text` calls
`element.get_text(strip=True)` without a separator. With nested inline
tags (`<span>foo <b>bar</b> baz</span>`) BeautifulSoup strips each
text node and concatenates them with no separator, yielding
`foobarbaz`. This silently corrupts product names, headlines, and any
other text field whose selector matches an element with inline
children — a very common pattern (`<b>` brand spans, `<strong>`
emphasis, `<sup>`/`<sub>`, etc.).

This PR switches the call to `get_text(separator=" ", strip=True)` so
bs4 normalizes inter-node gaps to a single space. The sibling
`JsonLxmlExtractionStrategy._get_element_text` already does the same
thing via `" ".join(...)` of every text node — this aligns the CSS
strategy with that behavior.

## Reproducer

```python
from crawl4ai.extraction_strategy import JsonCssExtractionStrategy

html = '<html><body><span class="name">Wireless <b>Logitech</b> Mouse M325</span></body></html>'
schema = {
    "baseSelector": "body",
    "fields": [{"name": "name", "selector": "span.name", "type": "text"}],
}
[record] = JsonCssExtractionStrategy(schema).extract(url="x", html_content=html)

# before:  record["name"] == "WirelessLogitechMouse M325"
# after:   record["name"] == "Wireless Logitech Mouse M325"
```

## Behavior change

The only observable difference is for elements whose children sit
adjacent with no whitespace between them, e.g. `<p><b>a</b><b>b</b></p>`:

- before: `"ab"`
- after: `"a b"`

This matches the rendered text and the existing
`JsonLxmlExtractionStrategy` behavior, but is worth calling out for
anyone with snapshots that depend on the old concatenation. Whitespace
around inline tags (the common case) is now preserved correctly.

## Test plan

- [x] New regression test in `tests/test_jsoncss_text_whitespace.py` exercises the strategy's `.extract()` entrypoint directly (no fixtures, no network) and pins the corrected behavior.
- [x] `tests/test_source_sibling_selector.py` — all 14 pre-existing CSS-strategy tests still pass.
- [x] Verified the new test fails on `develop` without the fix and passes with it.
- [x] `black --check` clean on changed files.