### PR TITLE
Fix: AsyncWebCrawler blocks event loop with `scrap`, use `ascrap` instead.

### DIFF
--- a/crawl4ai/async_webcrawler.py
+++ b/crawl4ai/async_webcrawler.py
@@ -764,7 +764,7 @@ class AsyncWebCrawler:
             ################################
             # Scraping Strategy Execution  #
             ################################
-            result: ScrapingResult = scraping_strategy.scrap(
+            result: ScrapingResult = await scraping_strategy.ascrap(
                 url, html, **params)
 
             if result is None:


### PR DESCRIPTION
## Summary
`AsyncWebCrawler.arun()` uses synchronous scraping (`scrap`) which blocks the event loop. It should use  asynchronous `ascrap`.

Discovered during production capacity issue.

## Testing
- Already covered: https://github.com/unclecode/crawl4ai/blob/main/tests/test_scraping_strategy.py, no point asserting ascrap called.