### PR TITLE
fix: preserve colspan and rowspan in HTML table cleaning

### DIFF
--- a/crawl4ai/config.py
+++ b/crawl4ai/config.py
@@ -47,7 +47,7 @@ WORD_TOKEN_RATE = 1.3
 MIN_WORD_THRESHOLD = 1
 IMAGE_DESCRIPTION_MIN_WORD_THRESHOLD = 1
 
-IMPORTANT_ATTRS = ["src", "href", "alt", "title", "width", "height", "class", "id"]
+IMPORTANT_ATTRS = ["src", "href", "alt", "title", "width", "height", "class", "id", "colspan", "rowspan"]
 ONLY_TEXT_ELIGIBLE_TAGS = [
     "b",
     "i",

--- a/tests/test_html_table_colspan_rowspan.py
+++ b/tests/test_html_table_colspan_rowspan.py
@@ -1,0 +1,35 @@
+import pytest
+from crawl4ai import AsyncWebCrawler, CrawlerRunConfig
+
+@pytest.mark.asyncio
+async def test_colspan_rowspan_preserved():
+    """
+    Test that colspan and rowspan attributes are preserved during HTML cleaning/sanitization.
+    This ensures table structures don't break when crawling.
+    """
+    html = """
+    <html>
+    <body>
+        <table>
+            <tr>
+                <td colspan="2" id="cell1">Header 1</td>
+                <td rowspan="2" id="cell2">Header 2</td>
+            </tr>
+            <tr>
+                <td>Data 1</td>
+                <td>Data 2</td>
+            </tr>
+        </table>
+    </body>
+    </html>
+    """
+    
+    async with AsyncWebCrawler() as crawler:
+        config = CrawlerRunConfig()
+        result = await crawler.arun(f"raw:{html}", config=config)
+        
+    assert result.success, "Crawl should succeed"
+    
+    # Check that colspan and rowspan attributes are preserved in the sanitized HTML
+    assert 'colspan="2"' in result.html, "colspan attribute was removed during sanitization"
+    assert 'rowspan="2"' in result.html, "rowspan attribute was removed during sanitization"


### PR DESCRIPTION


## What's the Issue?
During the **HTML sanitization and cleaning phase**, essential structural table attributes (`colspan` and `rowspan`) were inadvertently being stripped away. 

> **Why does this matter?**  
> The removal of these attributes completely breaks the structural integrity of complex tables. This leads to malformed Markdown generation and data loss during the scraping process, making table extraction unreliable.

---

## The Solution
To fix this, I updated the global sanitization rules to explicitly preserve table layout attributes.

### **Changes Made:**
- Added `"colspan"` and `"rowspan"` to the `IMPORTANT_ATTRS` list inside `crawl4ai/config.py`.
- Ensured that the `BeautifulSoup`-based cleaner retains these crucial attributes for `<td>` and `<th>` elements during the DOM processing phase.

---

## Testing & Verification
I implemented robust testing to ensure this bug doesn't return:

- [x] **New Unit Test Added**: `tests/test_html_table_colspan_rowspan.py`
- [x] **Simulated Crawl Test**: The test uses `AsyncWebCrawler` with a `raw:` HTML string containing a complex table setup.
- [x] **Assertion check**: Verified that the final sanitized HTML perfectly retains the `colspan="2"` and `rowspan="2"` attributes.
- [x] **Local Test Status**: All tests are currently passing! 