### PR TITLE
fix: preserve element tail text when removing empty elements

### DIFF
--- a/crawl4ai/content_scraping_strategy.py
+++ b/crawl4ai/content_scraping_strategy.py
@@ -562,6 +562,12 @@ class LXMLWebScrapingStrategy(ContentScrapingStrategy):
             ):
                 parent = el.getparent()
                 if parent is not None:
+                    if el.tail:
+                        prev = el.getprevious()
+                        if prev is not None:
+                            prev.tail = (prev.tail or "") + el.tail
+                        else:
+                            parent.text = (parent.text or "") + el.tail
                     parent.remove(el)
 
         return root


### PR DESCRIPTION
## Description

When `remove_empty_elements_fast()` removes an element that has non-empty `.tail` text (the text following an element's closing tag), the text was silently discarded because lxml's `parent.remove(el)` does not merge tail text back into the tree.

For example:
```html
<p>Hello <span class="e"> </span> world</p>
```
would become `<p>Hello </p>` instead of preserving " world".

## Fix

Before removal, the tail text is now merged into:
1. The previous sibling's `.tail` if a previous sibling exists
2. The parent's `.text` if the element is the first child

This follows the same pattern already used elsewhere in the codebase (e.g., script tag removal at line 740-753).

## Related Issue
Fixes #1938