### PR TITLE
fix(markdown): preserve image URL in citation conversion

### DIFF
--- a/crawl4ai/markdown_generation_strategy.py
+++ b/crawl4ai/markdown_generation_strategy.py
@@ -129,7 +129,7 @@ class DefaultMarkdownGenerator(MarkdownGenerationStrategy):
             parts.append(
                 f"{text}⟨{num}⟩"
                 if not match.group(0).startswith("!")
-                else f"![{text}⟨{num}⟩]"
+                else f"![{text}⟨{num}⟩]({url})"
             )
             last_end = match.end()
 


### PR DESCRIPTION
## Bug

`DefaultMarkdownGenerator.convert_links_to_citations` converts `![alt](url)` image links to `![alt⟨n⟩]` — dropping the `(url)` part. This is invalid Markdown: images without a URL render as broken empty brackets rather than the actual image.

**Before (broken):**
```
Input:  ![Logo](https://example.com/logo.png)
Output: ![Logo⟨1⟩]        ← no URL → broken image
```

**After (fixed):**
```
Input:  ![Logo](https://example.com/logo.png)
Output: ![Logo⟨1⟩](https://example.com/logo.png)  ← image renders + citation number
```

## Root cause

The citation conversion for images only rebuilt the `![text⟨n⟩]` part without the trailing `(url)`:

```python
# Before
else f"![{text}⟨{num}⟩]"
```

Regular hyperlinks `[text](url)` → `text⟨n⟩` correctly omit the URL (it goes to the References section). But images need their URL kept inline because:
1. Markdown does not support reference-style images in all renderers.
2. The visual image must remain intact — users can't "look up" an image by citation number.

## Fix

One-character change: add `({url})` back to the image output:

```python
# After
else f"![{text}⟨{num}⟩]({url})"
```