### PR TITLE
fix: close browser contexts from snapshot

### DIFF
--- a/crawl4ai/browser_manager.py
+++ b/crawl4ai/browser_manager.py
@@ -1969,7 +1969,7 @@ class BrowserManager:
             session_ids = list(self.sessions.keys())
             for session_id in session_ids:
                 await self.kill_session(session_id)
-            for ctx in self.contexts_by_config.values():
+            for ctx in list(self.contexts_by_config.values()):
                 try:
                     await ctx.close()
                 except Exception:
@@ -1995,7 +1995,7 @@ class BrowserManager:
                     await self.kill_session(session_id)
 
                 # Close all contexts we created
-                for ctx in self.contexts_by_config.values():
+                for ctx in list(self.contexts_by_config.values()):
                     try:
                         await ctx.close()
                     except Exception:
@@ -2032,7 +2032,7 @@ class BrowserManager:
             session_ids = list(self.sessions.keys())
             for session_id in session_ids:
                 await self.kill_session(session_id)
-            for ctx in self.contexts_by_config.values():
+            for ctx in list(self.contexts_by_config.values()):
                 try:
                     await ctx.close()
                 except Exception:
@@ -2064,7 +2064,7 @@ class BrowserManager:
             await self.kill_session(session_id)
 
         # Now close all contexts we created. This reclaims memory from ephemeral contexts.
-        for ctx in self.contexts_by_config.values():
+        for ctx in list(self.contexts_by_config.values()):
             try:
                 await ctx.close()
             except Exception as e:

--- a/tests/browser/test_browser_manager_close.py
+++ b/tests/browser/test_browser_manager_close.py
@@ -1,0 +1,35 @@
+from types import SimpleNamespace
+
+import pytest
+
+from crawl4ai.browser_manager import BrowserManager
+
+
+class _Context:
+    def __init__(self, manager=None):
+        self.manager = manager
+        self.closed = False
+
+    async def close(self):
+        self.closed = True
+        if self.manager:
+            self.manager.contexts_by_config.pop("second", None)
+
+
+@pytest.mark.asyncio
+async def test_close_iterates_over_context_snapshot():
+    manager = BrowserManager.__new__(BrowserManager)
+    manager.config = SimpleNamespace(cdp_url=None, sleep_on_close=False)
+    manager.sessions = {}
+    manager.browser = manager.managed_browser = manager.playwright = None
+    manager.logger = SimpleNamespace(error=lambda **_: None)
+    manager._using_cached_cdp = manager._launched_persistent = False
+    manager._context_refcounts = manager._context_last_used = manager._page_to_sig = {}
+    first, second = _Context(manager), _Context()
+    manager.contexts_by_config = {"first": first, "second": second}
+
+    await manager.close()
+
+    assert first.closed
+    assert second.closed
+    assert manager.contexts_by_config == {}


### PR DESCRIPTION
## Summary
Fixes #1999

Close browser contexts from a stable snapshot so shutdown is not interrupted if `contexts_by_config` changes while a context is being closed.

## List of files changed and why
- `crawl4ai/browser_manager.py` - Iterate over a snapshot of context values in BrowserManager close paths.
- `tests/browser/test_browser_manager_close.py` - Add a regression test for context-map mutation during close.

## How Has This Been Tested?
- `python -m pytest -q tests/browser/test_browser_manager_close.py`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added/updated unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
