### PR TITLE
docs: add Obscura as a CDP backend example

### DIFF
--- a/docs/examples/obscura_cdp_backend.py
+++ b/docs/examples/obscura_cdp_backend.py
@@ -1,0 +1,48 @@
+"""
+Use Obscura as a CDP backend for Crawl4AI.
+
+Obscura (https://github.com/h4ckf0r0day/obscura) is an open-source headless
+browser engine written in Rust. It runs JavaScript via V8 and speaks the Chrome
+DevTools Protocol, so Crawl4AI can drive it through the standard `cdp_url` path.
+It has no layout or paint engine, so it suits HTML and Markdown extraction rather
+than screenshots or PDFs.
+
+Setup:
+  1. Build Obscura: `OPENSSL_NO_VENDOR=1 cargo build --release`
+  2. Start the CDP server: `obscura serve --port 9222`
+     (it also serves the /json/version endpoint Crawl4AI uses to find the ws URL)
+  3. Run this script.
+
+The second URL below (quotes.toscrape.com/js) builds its content client-side, so
+crawling it exercises Obscura's JavaScript engine rather than just static HTML.
+
+Obscura rejects screenshot and PDF capture (no paint engine). Use a full Chromium
+for the visual leg if you need pixels.
+"""
+
+import asyncio
+
+from crawl4ai import AsyncWebCrawler, BrowserConfig, CrawlerRunConfig, CacheMode
+
+OBSCURA_CDP_URL = "http://127.0.0.1:9222"
+
+
+async def main():
+    browser_config = BrowserConfig(browser_mode="cdp", cdp_url=OBSCURA_CDP_URL)
+    run_config = CrawlerRunConfig(cache_mode=CacheMode.BYPASS)
+
+    async with AsyncWebCrawler(config=browser_config) as crawler:
+        for url in ["https://example.com", "https://quotes.toscrape.com/js/"]:
+            result = await crawler.arun(url=url, config=run_config)
+            print("-" * 40)
+            if result.success:
+                markdown = result.markdown.raw_markdown
+                print(f"{url}  (status {result.status_code}, {len(markdown)} chars)")
+                print(markdown[:200])
+            else:
+                print(f"{url}  failed: {result.error_message}")
+        print("-" * 40)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
  ## Summary
  
  Adds a runnable example that connects Crawl4AI to Obscura, an open-source Rust
  headless browser, over CDP. Obscura speaks the DevTools Protocol, so Crawl4AI
  drives it through the existing `cdp_url` path with no library changes (same
  pattern as the Scrapeless example). No issue to link, this is a new example only.
  
  ## List of files changed and why
  
  - `docs/examples/obscura_cdp_backend.py` - new example. Start `obscura serve`,
    connect with `BrowserConfig(browser_mode="cdp", cdp_url=...)`, and crawl a
    static page plus a JS-rendered page to Markdown.
    
  ## How Has This Been Tested?

  Built Obscura from source, ran `obscura serve --port 9222`, and ran Crawl4AI
  against it through `connect_over_cdp`. Verified:

  - static page to Markdown (example.com)
  - JS rendering: quotes.toscrape.com/js builds its content client-side, the quotes
    were extracted after Obscura ran the page JS (they are not in the raw HTML)
  - `wait_for="css:div.quote"`
  - `js_code` execution before extraction
  - `JsonCssExtractionStrategy` (10 quotes with authors)
  - link extraction (49 links)
  
  Also ran the project's unit tests: `pytest tests/unit/` -> 48 passed. The
  browser and integration suites need a chromium binary plus network/API access
  not available in my environment; this PR adds an example file and touches no
  library code, so it does not affect them.
  
  Screenshots and PDFs are not supported by Obscura (no paint engine) and are out
  of scope.

  ## Checklist:
  
  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [ ] I have added/updated unit tests that prove my fix is effective or that my feature works
  - [x] New and existing unit tests pass locally with my changes