### PR TITLE
fix: cap Python metadata before 3.15

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "Crawl4AI"
 dynamic = ["version"]
 description = "🚀🤖 Crawl4AI: Open-source LLM Friendly Web Crawler & scraper"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.15"
 license = "Apache-2.0"
 authors = [
     {name = "Unclecode", email = "unclecode@kidocode.com"}

--- a/setup.py
+++ b/setup.py
@@ -61,5 +61,5 @@ setup(
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
     ],
-    python_requires=">=3.10",
+    python_requires=">=3.10,<3.15",
 )

--- a/tests/test_python_requires_metadata.py
+++ b/tests/test_python_requires_metadata.py
@@ -1,0 +1,45 @@
+import ast
+from pathlib import Path
+
+
+EXPECTED_REQUIRES_PYTHON = ">=3.10,<3.15"
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read_pyproject_requires_python() -> str:
+    in_project_section = False
+
+    for line in (ROOT / "pyproject.toml").read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped == "[project]":
+            in_project_section = True
+            continue
+        if in_project_section and stripped.startswith("["):
+            break
+        if in_project_section and stripped.startswith("requires-python"):
+            return ast.literal_eval(stripped.split("=", 1)[1].strip())
+
+    raise AssertionError("pyproject.toml is missing [project].requires-python")
+
+
+def _read_setup_python_requires() -> str:
+    tree = ast.parse((ROOT / "setup.py").read_text(encoding="utf-8"))
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if not isinstance(node.func, ast.Name) or node.func.id != "setup":
+            continue
+        for keyword in node.keywords:
+            if keyword.arg == "python_requires":
+                return ast.literal_eval(keyword.value)
+
+    raise AssertionError("setup.py is missing setup(python_requires=...)")
+
+
+def test_project_metadata_caps_future_python_versions() -> None:
+    assert _read_pyproject_requires_python() == EXPECTED_REQUIRES_PYTHON
+
+
+def test_legacy_setup_py_matches_project_python_requirement() -> None:
+    assert _read_setup_python_requires() == EXPECTED_REQUIRES_PYTHON


### PR DESCRIPTION
## Summary

Fixes #2006.

Cap the published Python requirement at `>=3.10,<3.15` so resolvers do not try to solve Crawl4AI for currently unsupported future Python 3.15+ environments. The existing PyPI metadata for 0.8.7-0.8.9 is already `>=3.10`; this change narrows the declared range to the Python versions the package can reasonably resolve against today while preserving the current lower bound.

## List of files changed and why

- `pyproject.toml` - update the primary package metadata `requires-python` range.
- `setup.py` - keep the legacy setuptools entry point in sync with `pyproject.toml`.
- `tests/test_python_requires_metadata.py` - add a focused regression test that checks both metadata entry points stay aligned.

## How Has This Been Tested?

- `uv run --no-project --with pytest pytest tests/test_python_requires_metadata.py`
- `uv build --wheel --out-dir "$tmpdir"` and inspected the generated wheel `METADATA`, confirming `Requires-Python: >=3.10,<3.15`.

Note: I did not update `uv.lock` with my local `uv 0.7.6` because it would downgrade the lockfile format and re-resolve unrelated dependencies. The package metadata generated from the build is correct without a lockfile rewrite.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (not applicable; no complex code added)
- [x] I have made corresponding changes to the documentation (not applicable; package metadata only)
- [x] I have added/updated unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
