### PR TITLE
fix: prevent infinite loop in OverlappingWindowChunking when overlap >= window_size

### DIFF
--- a/crawl4ai/chunking_strategy.py
+++ b/crawl4ai/chunking_strategy.py
@@ -241,6 +241,10 @@ class OverlappingWindowChunking(ChunkingStrategy):
         if len(words) <= self.window_size:
             return [text]
 
+        # The stride must be positive so ``start`` always advances. Otherwise an
+        # overlap >= window_size leaves start unchanged (or moving backwards),
+        # turning the crawl into an infinite loop that never terminates.
+        stride = max(1, self.window_size - self.overlap)
         start = 0
         while start < len(words):
             end = start + self.window_size
@@ -250,6 +254,6 @@ class OverlappingWindowChunking(ChunkingStrategy):
             if end >= len(words):
                 break
 
-            start = end - self.overlap
+            start += stride
 
         return chunks

--- a/tests/general/test_chunking_strategy.py
+++ b/tests/general/test_chunking_strategy.py
@@ -1,0 +1,39 @@
+"""Unit tests for word-based chunking strategies."""
+
+from crawl4ai.chunking_strategy import OverlappingWindowChunking
+
+
+def _words(n):
+    return " ".join(str(i) for i in range(n))
+
+
+def test_overlapping_window_basic_overlap():
+    chunks = OverlappingWindowChunking(window_size=100, overlap=20).chunk(_words(250))
+    assert len(chunks) > 1
+    assert chunks[0].split()[0] == "0"
+    # The chunks must cover the text up to and including the final word.
+    assert chunks[-1].split()[-1] == "249"
+
+
+def test_overlapping_window_no_overlap():
+    chunks = OverlappingWindowChunking(window_size=100, overlap=0).chunk(_words(250))
+    assert len(chunks) == 3  # 0-100, 100-200, 200-250
+
+
+def test_overlapping_window_short_text_single_chunk():
+    chunks = OverlappingWindowChunking(window_size=100, overlap=10).chunk(_words(50))
+    assert len(chunks) == 1
+
+
+def test_overlapping_window_overlap_equal_to_window_terminates():
+    # Regression: overlap >= window_size previously left `start` unchanged,
+    # so chunk() looped forever. It must now terminate and still reach the end.
+    chunks = OverlappingWindowChunking(window_size=100, overlap=100).chunk(_words(250))
+    assert len(chunks) >= 1
+    assert chunks[-1].split()[-1] == "249"
+
+
+def test_overlapping_window_overlap_greater_than_window_terminates():
+    chunks = OverlappingWindowChunking(window_size=50, overlap=80).chunk(_words(200))
+    assert len(chunks) >= 1
+    assert chunks[-1].split()[-1] == "199"


### PR DESCRIPTION
## Summary

`OverlappingWindowChunking.chunk()` hangs in an infinite loop whenever `overlap >= window_size`.

It advanced the window with `start = end - self.overlap`. When `overlap == window_size`, `start` is unchanged on every iteration; when `overlap > window_size`, `start` moves backwards. Either way the `while start < len(words)` loop never terminates and the chunk list grows without bound until the process runs out of memory or is killed.

The fix advances with a guaranteed-positive stride of `max(1, window_size - overlap)`. For valid configurations (`overlap < window_size`) the stride equals `window_size - overlap`, so `start += stride` is exactly equivalent to the old `start = end - overlap` and the produced chunks are unchanged. Degenerate configurations now terminate instead of hanging.

## List of files changed and why

- `crawl4ai/chunking_strategy.py` — guard the slide step in `OverlappingWindowChunking.chunk()` so `start` always advances.
- `tests/general/test_chunking_strategy.py` — new unit tests for `OverlappingWindowChunking`: normal overlap, zero overlap, short input, and the `overlap >= window_size` regression that previously hung.

## How Has This Been Tested?

I verified that for valid configurations (window=100/overlap=20, window=100/overlap=0, window=1000/overlap=100) the new stride-based loop produces byte-for-byte identical output to the previous implementation, and that the degenerate `overlap >= window_size` configurations now terminate and still reach the final word instead of looping forever. The added unit tests encode these cases.

Note: I validated the chunking logic in isolation and did not run the full crawl4ai dependency stack locally, so the new tests are intended to be confirmed by CI.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added/updated unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
