### PR TITLE
docs: add WSL2 proxy troubleshooting note

### DIFF
--- a/docs/md_v2/advanced/proxy-security.md
+++ b/docs/md_v2/advanced/proxy-security.md
@@ -302,3 +302,32 @@ def safe_proxy_repr(proxy: ProxyConfig):
     - Ensure `ProxyConfig.from_env()` actually loaded entries (`len(proxies) > 0`).
     - Attach `proxy_rotation_strategy` to `CrawlerRunConfig`.
     - Validate the proxy definitions you pass into the strategy.
+
+- "Crawl hangs on WSL2 when a system proxy is required"
+    - Prefer a dedicated Playwright-launched browser so the proxy is applied
+      through Playwright instead of relying on the managed browser subprocess
+      environment.
+    - Put the proxy on `BrowserConfig.proxy_config` for this case, and keep
+      `browser_mode="dedicated"`:
+
+      ```python
+      import asyncio
+      from crawl4ai import AsyncWebCrawler, BrowserConfig, CrawlerRunConfig, ProxyConfig
+
+      async def main():
+          browser_config = BrowserConfig(
+              browser_mode="dedicated",
+              use_managed_browser=False,
+              proxy_config=ProxyConfig(server="http://172.29.240.1:7892"),
+          )
+          run_config = CrawlerRunConfig(page_timeout=15000)
+
+          async with AsyncWebCrawler(config=browser_config) as crawler:
+              result = await crawler.arun("https://example.com", config=run_config)
+              print("success:", result.success)
+
+      asyncio.run(main())
+      ```
+
+    - If your proxy host changes between WSL sessions, derive the Windows host IP
+      from `ip route` and rebuild the proxy URL before creating `BrowserConfig`.


### PR DESCRIPTION
## Summary
Fixes #1930

Adds a WSL2-specific proxy troubleshooting note showing how to use a dedicated Playwright-launched browser with `BrowserConfig.proxy_config` when managed browser startup hangs behind a required system proxy.

## List of files changed and why
- `docs/md_v2/advanced/proxy-security.md` - Documents the WSL2 proxy workaround in the existing troubleshooting section.

## How Has This Been Tested?
- Ran `git diff --check`.
- Reviewed the rendered Markdown source and Python snippet for correctness.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added/updated unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
