### PR TITLE
fix: respect string literals when splitting JSON objects

### DIFF
--- a/crawl4ai/utils.py
+++ b/crawl4ai/utils.py
@@ -724,8 +724,23 @@ def split_and_parse_json_objects(json_string):
     segments = []
     depth = 0
     start_index = 0
+    in_string = False
+    escape = False
 
     for i, char in enumerate(json_string):
+        # Skip the character escaped by a preceding backslash (e.g. \" or \\).
+        if escape:
+            escape = False
+            continue
+        if char == "\\":
+            escape = True
+            continue
+        if char == '"':
+            in_string = not in_string
+            continue
+        # Braces inside string values must not affect the depth count.
+        if in_string:
+            continue
         if char == "{":
             if depth == 0:
                 start_index = i

--- a/tests/general/test_split_and_parse_json_objects.py
+++ b/tests/general/test_split_and_parse_json_objects.py
@@ -1,0 +1,42 @@
+"""Regression tests for ``split_and_parse_json_objects``.
+
+The helper splits a JSON array string into individual object segments by
+tracking brace depth. Brace characters that appear *inside* JSON string
+values must not affect the depth count, otherwise objects get split at the
+wrong position and fail to parse.
+"""
+
+from crawl4ai.utils import split_and_parse_json_objects
+
+
+def test_plain_objects_parse():
+    parsed, unparsed = split_and_parse_json_objects('[{"a": 1}, {"b": 2}]')
+    assert parsed == [{"a": 1}, {"b": 2}]
+    assert unparsed == []
+
+
+def test_closing_brace_inside_string_value():
+    # A lone "}" inside a string value must not terminate the object early.
+    parsed, unparsed = split_and_parse_json_objects('[{"a": "x}y"}, {"b": 2}]')
+    assert parsed == [{"a": "x}y"}, {"b": 2}]
+    assert unparsed == []
+
+
+def test_opening_brace_inside_string_value():
+    parsed, unparsed = split_and_parse_json_objects('[{"a": "x{y"}, {"b": 2}]')
+    assert parsed == [{"a": "x{y"}, {"b": 2}]
+    assert unparsed == []
+
+
+def test_escaped_quote_inside_string_value():
+    # An escaped quote must not be treated as the end of the string, so the
+    # "}" that follows still counts as being inside the string.
+    parsed, unparsed = split_and_parse_json_objects('[{"a": "he said \\"}\\""}]')
+    assert parsed == [{"a": 'he said "}"'}]
+    assert unparsed == []
+
+
+def test_balanced_braces_inside_string_still_work():
+    parsed, unparsed = split_and_parse_json_objects('[{"text": "see {this}", "n": 1}]')
+    assert parsed == [{"text": "see {this}", "n": 1}]
+    assert unparsed == []


### PR DESCRIPTION
## Summary

`split_and_parse_json_objects` splits a JSON array string into individual
object segments by tracking brace (`{`/`}`) depth. The scan counted **every**
brace, including those that appear inside JSON string values. A value such as
`"x}y"` therefore terminated the object early, so the resulting segment was
invalid JSON, failed to parse, and the valid objects were silently dropped.

Example (before this change):

```python
>>> split_and_parse_json_objects('[{"a": "x}y"}, {"b": 2}]')
([], ['{"a": "x}'])
```

Both objects are lost even though the input is valid JSON.

The fix tracks string state (and backslash escapes) so braces inside string
values no longer affect the depth count:

```python
>>> split_and_parse_json_objects('[{"a": "x}y"}, {"b": 2}]')
([{'a': 'x}y'}, {'b': 2}], [])
```

This helper is used to recover individual objects from LLM extraction output
(`extraction_strategy.py`), where string values containing braces are common.

## List of files changed and why

- `crawl4ai/utils.py` - make the brace scanner in `split_and_parse_json_objects` string-aware (skip braces inside strings, honor `\` escapes).
- `tests/general/test_split_and_parse_json_objects.py` - new regression tests covering closing/opening braces and escaped quotes inside string values, plus plain/balanced cases.

## How Has This Been Tested?

```
$ python -m pytest tests/general/test_split_and_parse_json_objects.py tests/regression/test_reg_utils.py -q
76 passed in 2.07s
```

The three new cases fail on `develop` (objects dropped) and pass with this change; the existing `tests/regression/test_reg_utils.py` suite continues to pass.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added/updated unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
