### PR TITLE
Package 'nvidia-cuda-toolkit' has no installation candidate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,10 +90,19 @@ RUN apt-get update && apt-get dist-upgrade -y \
     && rm -rf /var/lib/apt/lists/*
 
 RUN if [ "$ENABLE_GPU" = "true" ] && [ "$TARGETARCH" = "amd64" ] ; then \
+    echo "Installing NVIDIA CUDA Toolkit..." && \
     apt-get update && apt-get install -y --no-install-recommends \
-    nvidia-cuda-toolkit \
-    && apt-get clean \ 
-    && rm -rf /var/lib/apt/lists/* ; \
+        wget gnupg ca-certificates && \
+    \
+    wget https://developer.download.nvidia.com/compute/cuda/repos/debian12/x86_64/cuda-keyring_1.1-1_all.deb && \
+    dpkg -i cuda-keyring_1.1-1_all.deb && \
+    rm cuda-keyring_1.1-1_all.deb && \
+    \
+    apt-get update && apt-get install -y --no-install-recommends \
+        cuda-toolkit-12-5 && \
+    \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* ; \
 else \
     echo "Skipping NVIDIA CUDA Toolkit installation (unsupported platform or GPU disabled)"; \
 fi


### PR DESCRIPTION
## Summary
Fix #2020 

Allow `docker compose build` with `ENABLE_GPU=true`

## List of files changed and why
Dockerfile - change installation for nvidia cuda since slim image has no repo support for cuda

## How Has This Been Tested?
`docker compose build` passed, no errors reported 



## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added/updated unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
