### PR TITLE
fix(docker): cap FastAPI below 0.137

### DIFF
--- a/deploy/docker/requirements.txt
+++ b/deploy/docker/requirements.txt
@@ -1,4 +1,4 @@
-fastapi>=0.115.12
+fastapi>=0.115.12,<0.137
 uvicorn>=0.34.2
 gunicorn>=23.0.0
 slowapi==0.1.9


### PR DESCRIPTION
## Summary
Fixes #2025 by capping Docker's FastAPI dependency below 0.137, avoiding the `_IncludedRouter` route objects that currently trigger `AttributeError` in the Prometheus/FastAPI instrumentation path.

## List of files changed and why
- `deploy/docker/requirements.txt` - Add an upper bound to FastAPI so Docker installs resolve to the last pre-0.137 release until the instrumentation compatibility issue is fixed upstream.

## How Has This Been Tested?
- Ran `python3 -m venv /tmp/crawl4ai-venv` and `/tmp/crawl4ai-venv/bin/python -m pip install --dry-run -r deploy/docker/requirements.txt` to verify dependency resolution succeeds and selects `fastapi-0.136.3`.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added/updated unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
