### PR TITLE
fix(docker): boot the read-only compose under the non-root appuser

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,13 +25,27 @@ x-base-config: &base-config
   security_opt:
     - no-new-privileges:true
   pids_limit: 512
-  # Read-only root filesystem; only these paths are writable (tmpfs).
+  # Read-only root filesystem. crawl4ai runs as the non-root appuser (uid/gid
+  # 999), so every runtime-writable path needs a tmpfs it can actually write.
+  # The boot crash came from two gaps, not from the bare mounts: ~/.crawl4ai was
+  # never mounted (its import-time makedirs hit the read-only FS, so the worker
+  # crash-looped and nothing bound :11235), and the outputs tmpfs pinned
+  # mode=0700 while owned by root, so appuser couldn't write it. The bare tmpfs
+  # below default to mode 1777 and are already writable; owning them by appuser
+  # is just extra hardening.
   read_only: true
   tmpfs:
     - /tmp
-    - /var/lib/redis
-    - /var/lib/crawl4ai/outputs:mode=0700
-    - /home/appuser/.cache
+    - /var/lib/redis:uid=999,gid=999,mode=0700
+    - /var/lib/crawl4ai/outputs:uid=999,gid=999,mode=0700
+    # crawl4ai writes its home (DB, logs, seeder index) here at import time.
+    - /home/appuser/.crawl4ai:uid=999,gid=999,mode=0700
+    # Only the writable cache subdir gets a tmpfs; a tmpfs over the whole
+    # ~/.cache would shadow the Chromium baked into ~/.cache/ms-playwright.
+    - /home/appuser/.cache/url_seeder:uid=999,gid=999,mode=0700
+    # gunicorn 26+ opens a control socket under $HOME/.gunicorn by default;
+    # give it a writable dir (or pass --no-control-socket to disable it).
+    - /home/appuser/.gunicorn:uid=999,gid=999,mode=0700
   deploy:
     resources:
       limits:


### PR DESCRIPTION
## Summary

Fixes #2027

The v0.9.0 secure-by-default Docker Compose config runs read-only as the non-root `appuser`, but the container fails to boot — the gunicorn worker crash-loops and nothing binds `:11235` (the host sees a connection reset).

Two real gaps cause it:
- **`~/.crawl4ai` is never mounted**, so crawl4ai's import-time `makedirs` raises on the read-only rootfs and the worker dies on boot (the primary cause).
- **`/var/lib/crawl4ai/outputs` pins `mode=0700`** while the tmpfs is owned by `root`, so `appuser` (uid 999) can't write to it.

Separately, the `~/.cache` tmpfs shadows the Chromium baked into `~/.cache/ms-playwright`.

> Note: the **bare** tmpfs (`/tmp`, `/var/lib/redis`, `~/.cache`) default to mode `1777` (sticky, world-writable) and are already writable by `appuser` — they are *not* the cause. Verified: `docker run --user 999:999 --tmpfs /foo alpine touch /foo/x` succeeds, while `--tmpfs /foo:mode=0700` fails with EACCES.

## List of files changed and why

- `docker-compose.yml`:
  - add the missing `/home/appuser/.crawl4ai` tmpfs — the boot-blocking fix
  - own `/var/lib/crawl4ai/outputs` by appuser (`uid=999,gid=999`) so its `mode=0700` is writable
  - scope the cache tmpfs to `/home/appuser/.cache/url_seeder` so it no longer shadows `ms-playwright`
  - add `/home/appuser/.gunicorn` for gunicorn 26+'s control socket
  - own the already-writable redis/cache mounts by appuser at `0700` (optional hardening, not required for boot)

## How Has This Been Tested?

Built the image locally and ran `docker compose up` with this config:
- container boots healthy
- `GET /health` → 200
- a live crawl of `https://example.com` succeeds
- no read-only / permission errors in the logs

The change is mount configuration only (uid/gid/mode), so it is architecture-independent.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — N/A (compose config only; happy to update `docs/md_v2/core/docker-deployment.md` if you'd like)
- [ ] I have added/updated unit tests — N/A (config-only change, no unit-testable surface; verified via live container boot)
- [ ] New and existing unit tests pass locally — not run (config-only change; verified end-to-end via the live container above)
