### PR TITLE
Fix LinkPreview dropping links by truncating before deduplication

### DIFF
--- a/crawl4ai/link_preview.py
+++ b/crawl4ai/link_preview.py
@@ -154,24 +154,27 @@ class LinkPreview:
             self._log("debug", "After exclude patterns: {count} links remain",
                       params={"count": len(filtered_urls)})
         
-        # Limit number of links
-        max_links = link_config.max_links
-        if max_links > 0 and len(filtered_urls) > max_links:
-            filtered_urls = filtered_urls[:max_links]
-            self._log("debug", "Limited to {max_links} links",
-                      params={"max_links": max_links})
-        
-        # Remove duplicates while preserving order
+        # Remove duplicates while preserving order. This must run BEFORE the
+        # max_links limit: truncating first spends the budget on duplicate
+        # copies of the same URL (common for repeated nav/footer links), so the
+        # subsequent dedup would yield far fewer than max_links unique URLs.
         seen = set()
         unique_urls = []
         for url in filtered_urls:
             if url not in seen:
                 seen.add(url)
                 unique_urls.append(url)
-        
+
+        # Limit number of links (counting distinct URLs)
+        max_links = link_config.max_links
+        if max_links > 0 and len(unique_urls) > max_links:
+            unique_urls = unique_urls[:max_links]
+            self._log("debug", "Limited to {max_links} links",
+                      params={"max_links": max_links})
+
         self._log("debug", "Final filtered URLs: {count} unique links",
                   params={"count": len(unique_urls)})
-        
+
         return unique_urls
     
     async def _extract_heads_parallel(

--- a/tests/test_merge_head_data_scoring.py
+++ b/tests/test_merge_head_data_scoring.py
@@ -10,6 +10,7 @@ Regression tests for https://github.com/unclecode/crawl4ai/issues/1749
 import pytest
 from unittest.mock import MagicMock
 
+from crawl4ai.async_configs import LinkPreviewConfig
 from crawl4ai.models import Link, Links
 from crawl4ai.link_preview import LinkPreview
 from crawl4ai.utils import calculate_total_score
@@ -181,3 +182,37 @@ class TestMergeHeadDataScoring:
         updated = preview._merge_head_data(links, head_results, config)
 
         assert updated.internal[0].total_score == 5.0
+
+
+class TestFilterLinksDeduplication:
+    """_filter_links must deduplicate BEFORE applying max_links, so the limit
+    counts distinct URLs instead of being spent on duplicate copies.
+
+    Regression for the truncate-before-dedup bug: with duplicate links at the
+    head of the list, the old code sliced [:max_links] first and then collapsed
+    the duplicates, returning far fewer than max_links unique URLs.
+    """
+
+    @staticmethod
+    def _internal(hrefs):
+        return Links(internal=[Link(href=h) for h in hrefs], external=[])
+
+    def test_dedup_runs_before_max_links(self):
+        # First three entries are duplicates of "a"; max_links=3 must still
+        # yield three DISTINCT urls, not collapse to one.
+        hrefs = ["https://x.com/a"] * 3 + ["https://x.com/b", "https://x.com/c", "https://x.com/d"]
+        cfg = LinkPreviewConfig(include_internal=True, include_external=False, max_links=3)
+        result = LinkPreview()._filter_links(self._internal(hrefs), cfg)
+        assert result == ["https://x.com/a", "https://x.com/b", "https://x.com/c"]
+
+    def test_keeps_all_when_uniques_below_max(self):
+        hrefs = ["https://x.com/a", "https://x.com/a", "https://x.com/b"]
+        cfg = LinkPreviewConfig(include_internal=True, include_external=False, max_links=3)
+        result = LinkPreview()._filter_links(self._internal(hrefs), cfg)
+        assert result == ["https://x.com/a", "https://x.com/b"]
+
+    def test_caps_distinct_urls_at_max(self):
+        hrefs = [f"https://x.com/{i}" for i in range(5)]
+        cfg = LinkPreviewConfig(include_internal=True, include_external=False, max_links=3)
+        result = LinkPreview()._filter_links(self._internal(hrefs), cfg)
+        assert result == ["https://x.com/0", "https://x.com/1", "https://x.com/2"]


### PR DESCRIPTION
## Summary

`LinkPreview._filter_links` applies the `max_links` limit **before**
deduplicating, so the limit is spent on duplicate copies of the same URL
instead of distinct URLs.

```python
# Limit number of links
if max_links > 0 and len(filtered_urls) > max_links:
    filtered_urls = filtered_urls[:max_links]      # truncate first ...

# Remove duplicates while preserving order
seen = set(); unique_urls = []
for url in filtered_urls:                            # ... then dedup
    ...
```

Link extraction routinely produces the same `href` many times (repeated
nav / footer / CTA links), so the `[:max_links]` slice keeps duplicate copies
and the later dedup collapses them — yielding **far fewer than `max_links`**
unique URLs.

### Example

Internal hrefs `["a", "a", "a", "b", "c", "d"]` with `max_links=3`:

| | result |
|---|---|
| expected | `["a", "b", "c"]` (3 distinct) |
| actual (before fix) | `["a"]` (slice takes the 3 `a`s, dedup → 1) |

## Fix

Deduplicate first, then apply `max_links`, so the limit counts **distinct**
URLs. Order is still preserved, and cases where the unique count is already
below `max_links` are unchanged.

## Testing

Adds `TestFilterLinksDeduplication` to `tests/test_merge_head_data_scoring.py`:

```text
$ pytest tests/test_merge_head_data_scoring.py -q
13 passed
```

The dedup-before-limit case **fails on the current code** and **passes with the
fix**; the "fewer uniques than the limit" and "cap distinct URLs" cases are
preserved.
