### PR TITLE
fix(docker): make read-only tmpfs writable

### DIFF
--- a/deploy/docker/tests/test_security_container_posture.py
+++ b/deploy/docker/tests/test_security_container_posture.py
@@ -93,6 +93,16 @@ class TestCompose:
     def test_pids_limit(self, compose):
         assert "pids_limit" in compose
 
+    def test_read_only_runtime_tmpfs_are_appuser_owned(self, compose):
+        assert "/var/lib/redis:uid=999,gid=999,mode=0700" in compose
+        assert "/var/lib/crawl4ai/outputs:uid=999,gid=999,mode=0700" in compose
+        assert "/home/appuser/.crawl4ai:uid=999,gid=999,mode=0700" in compose
+        assert "/home/appuser/.gunicorn:uid=999,gid=999,mode=0700" in compose
+
+    def test_playwright_cache_is_not_shadowed(self, compose):
+        assert "/home/appuser/.cache\n" not in compose
+        assert "/home/appuser/.cache/url_seeder:uid=999,gid=999,mode=0700" in compose
+
 
 class TestEntrypoint:
     def test_entrypoint_exists_and_resolves_bind(self):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,9 +29,12 @@ x-base-config: &base-config
   read_only: true
   tmpfs:
     - /tmp
-    - /var/lib/redis
-    - /var/lib/crawl4ai/outputs:mode=0700
-    - /home/appuser/.cache
+    - /var/lib/redis:uid=999,gid=999,mode=0700
+    - /var/lib/crawl4ai/outputs:uid=999,gid=999,mode=0700
+    - /home/appuser/.crawl4ai:uid=999,gid=999,mode=0700
+    # Keep the baked Playwright browser under ~/.cache/ms-playwright visible.
+    - /home/appuser/.cache/url_seeder:uid=999,gid=999,mode=0700
+    - /home/appuser/.gunicorn:uid=999,gid=999,mode=0700
   deploy:
     resources:
       limits:


### PR DESCRIPTION
## Summary
Fixes #2027

Updates the secure-by-default Docker Compose tmpfs mounts so the non-root `appuser` can write required runtime state while keeping the baked Playwright browser cache visible.

## List of files changed and why
- `docker-compose.yml` - add appuser-owned tmpfs options for Redis/artifacts/runtime state, mount missing `~/.crawl4ai`, avoid shadowing `~/.cache/ms-playwright`, and add a writable gunicorn control-socket directory.
- `deploy/docker/tests/test_security_container_posture.py` - add static posture checks for the read-only-rootfs tmpfs layout.

## How Has This Been Tested?
- `python3 -m pytest deploy/docker/tests/test_security_container_posture.py -q -k 'not SandboxOptOut'` (16 passed, 2 deselected; the deselected tests import the Docker server and need local `OpenSSL` installed)
- `python3` YAML check that validates the required tmpfs entries and confirms `~/.cache` is not mounted wholesale
- `git diff --check`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (N/A: deployment config/test change only)
- [x] I have added/updated unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
