### PR TITLE
Fix compute_head_fingerprint folding case-only title/meta changes

### DIFF
--- a/crawl4ai/utils.py
+++ b/crawl4ai/utils.py
@@ -2920,11 +2920,15 @@ def compute_head_fingerprint(head_html: str) -> str:
     if not head_html:
         return ""
 
-    head_lower = head_html.lower()
     signals = []
 
+    # Match tags/attributes case-insensitively, but extract values from the
+    # ORIGINAL head: lowercasing the whole head first would fold a case-only
+    # title/meta change (e.g. "iPhone" -> "IPHONE") to the same fingerprint, so
+    # the cache validator would treat a genuinely changed page as unchanged.
+
     # Extract title
-    title_match = re.search(r'<title[^>]*>(.*?)</title>', head_lower, re.DOTALL)
+    title_match = re.search(r'<title[^>]*>(.*?)</title>', head_html, re.DOTALL | re.IGNORECASE)
     if title_match:
         signals.append(title_match.group(1).strip())
 
@@ -2946,7 +2950,7 @@ def compute_head_fingerprint(head_html: str) -> str:
             rf'<meta[^>]*content=["\']([^"\']*)["\'][^>]*{attr_type}=["\']{re.escape(attr_value)}["\']',
         ]
         for pattern in patterns:
-            match = re.search(pattern, head_lower)
+            match = re.search(pattern, head_html, re.IGNORECASE)
             if match:
                 signals.append(match.group(1).strip())
                 break  # Found this tag, move to next

--- a/tests/cache_validation/test_head_fingerprint.py
+++ b/tests/cache_validation/test_head_fingerprint.py
@@ -95,3 +95,26 @@ class TestHeadFingerprint:
         assert fp != ""
         # Should be deterministic
         assert fp == compute_head_fingerprint(head)
+
+    def test_value_case_change_changes_fingerprint(self):
+        """A case-only change in a title/meta *value* must change the
+        fingerprint, otherwise the cache validator treats a genuinely updated
+        page as unchanged and serves stale content. Regression."""
+        assert compute_head_fingerprint(
+            "<head><title>iPhone</title></head>"
+        ) != compute_head_fingerprint("<head><title>IPHONE</title></head>")
+        assert compute_head_fingerprint(
+            '<head><meta name="description" content="Buy Now"></head>'
+        ) != compute_head_fingerprint(
+            '<head><meta name="description" content="BUY NOW"></head>'
+        )
+
+    def test_tag_and_attribute_case_does_not_change_fingerprint(self):
+        """Tag/attribute case is still matched case-insensitively; only the
+        markup case (not the values) differing yields the same fingerprint."""
+        assert compute_head_fingerprint(
+            "<HEAD><TITLE>Hello</TITLE></HEAD>"
+        ) == compute_head_fingerprint("<head><title>Hello</title></head>")
+        assert compute_head_fingerprint(
+            '<head><META NAME="description" CONTENT="Hi"></head>'
+        ) == compute_head_fingerprint('<head><meta name="description" content="Hi"></head>')


### PR DESCRIPTION
## Summary

`compute_head_fingerprint` lowercases the entire `<head>` before extracting signals:

```python
head_lower = head_html.lower()
title_match = re.search(r'<title[^>]*>(.*?)</title>', head_lower, re.DOTALL)   # value is lowercased
...
match = re.search(pattern, head_lower)                                          # value is lowercased
```

So the captured **values** are lowercased, not just the tag/attribute matching. Two heads that differ only in the **case** of a title or meta value hash to the same fingerprint:

```python
compute_head_fingerprint("<head><title>iPhone</title></head>")
  == compute_head_fingerprint("<head><title>IPHONE</title></head>")   # ❌ same hash
```

`CacheValidator` treats an equal fingerprint as "unchanged", so a genuinely updated page is reported **FRESH** and stale cached content is served.

## Fix

Match tags/attributes case-insensitively with `re.IGNORECASE` against the **original** head, so extracted values keep their case. Tag/attribute case-insensitivity is preserved (e.g. `<TITLE>` / `META NAME=...CONTENT=` still parse), and identical content still hashes identically.

## Testing

```text
$ pytest tests/cache_validation/test_head_fingerprint.py -q
14 passed
```

Adds two regression tests:
- `test_value_case_change_changes_fingerprint` — a case-only value change now changes the fingerprint (**fails on the current code**).
- `test_tag_and_attribute_case_does_not_change_fingerprint` — markup-only case differences still yield the same fingerprint.