### PR TITLE
fix(docker): handle Kubernetes service-link port env

### DIFF
--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -23,10 +23,22 @@ if [[ -z "${CRAWL4AI_API_TOKEN:-}" && -f /run/secrets/api_token ]]; then
 fi
 
 # --- Bind resolution: loopback unless a credential is present. ---------------
-PORT="${CRAWL4AI_PORT:-11235}"
+DEFAULT_PORT="11235"
+PORT="${CRAWL4AI_PORT:-$DEFAULT_PORT}"
+if [[ ! "$PORT" =~ ^[0-9]+$ ]]; then
+    if [[ "$PORT" == *"://"* ]]; then
+        echo "entrypoint: ignoring non-numeric CRAWL4AI_PORT='${PORT}' " \
+             "(looks like a Kubernetes service link); using ${DEFAULT_PORT}." >&2
+        PORT="$DEFAULT_PORT"
+    else
+        echo "entrypoint: CRAWL4AI_PORT must be numeric, got '${PORT}'." >&2
+        exit 1
+    fi
+fi
+
 if [[ -n "${CRAWL4AI_API_TOKEN:-}" || "${CRAWL4AI_JWT_ENABLED:-false}" == "true" ]]; then
     # A credential is configured -> the operator may expose all interfaces.
-    GUNICORN_BIND="${GUNICORN_BIND:-[::]:${PORT}}"
+    GUNICORN_BIND="${GUNICORN_BIND:-0.0.0.0:${PORT}}"
 else
     # No credential -> refuse to expose; serve loopback only.
     GUNICORN_BIND="127.0.0.1:${PORT}"

--- a/deploy/docker/tests/test_security_container_posture.py
+++ b/deploy/docker/tests/test_security_container_posture.py
@@ -10,6 +10,8 @@ and is tracked as build-gated; it is out of scope for this offline suite.
 
 import os
 import re
+import stat
+import subprocess
 
 import pytest
 
@@ -109,6 +111,65 @@ class TestEntrypoint:
         src = _read(os.path.join(DOCKER_DIR, "entrypoint.sh"))
         assert "GUNICORN_BIND" in src and "REDIS_PASSWORD" in src
         assert "127.0.0.1" in src  # loopback default when no credential
+
+    def _run_entrypoint(self, tmp_path, extra_env):
+        fake_supervisord = tmp_path / "supervisord"
+        fake_supervisord.write_text(
+            "#!/usr/bin/env sh\n"
+            "echo \"GUNICORN_BIND=${GUNICORN_BIND}\"\n"
+            "echo \"REDIS_PASSWORD_SET=${REDIS_PASSWORD:+yes}\"\n",
+            encoding="utf-8",
+        )
+        fake_supervisord.chmod(
+            fake_supervisord.stat().st_mode | stat.S_IXUSR
+        )
+
+        env = os.environ.copy()
+        for key in (
+            "CRAWL4AI_API_TOKEN",
+            "CRAWL4AI_JWT_ENABLED",
+            "CRAWL4AI_PORT",
+            "GUNICORN_BIND",
+            "REDIS_PASSWORD",
+        ):
+            env.pop(key, None)
+        env.update(extra_env)
+        env["PATH"] = f"{tmp_path}{os.pathsep}{env['PATH']}"
+
+        return subprocess.run(
+            ["bash", os.path.join(DOCKER_DIR, "entrypoint.sh")],
+            cwd=DOCKER_DIR,
+            env=env,
+            text=True,
+            capture_output=True,
+            timeout=10,
+            check=False,
+        )
+
+    def test_entrypoint_uses_ipv4_wildcard_when_token_allows_exposure(self, tmp_path):
+        result = self._run_entrypoint(
+            tmp_path,
+            {
+                "CRAWL4AI_API_TOKEN": "test-token",
+                "CRAWL4AI_JWT_ENABLED": "false",
+                "CRAWL4AI_PORT": "11235",
+            },
+        )
+        assert result.returncode == 0, result.stderr
+        assert "GUNICORN_BIND=0.0.0.0:11235" in result.stdout
+
+    def test_entrypoint_ignores_kubernetes_service_link_port_env(self, tmp_path):
+        result = self._run_entrypoint(
+            tmp_path,
+            {
+                "CRAWL4AI_API_TOKEN": "test-token",
+                "CRAWL4AI_JWT_ENABLED": "false",
+                "CRAWL4AI_PORT": "tcp://10.0.101.25:80",
+            },
+        )
+        assert result.returncode == 0, result.stderr
+        assert "GUNICORN_BIND=0.0.0.0:11235" in result.stdout
+        assert "ignoring non-numeric CRAWL4AI_PORT" in result.stderr
 
 
 class TestSandboxOptOut:


### PR DESCRIPTION
## Summary

Addresses the Kubernetes service-link bind failure discussed in #2023.

This keeps the existing secure-by-default auth posture intact, but fixes two entrypoint-level deployment issues:

- use `0.0.0.0:<port>` as the default exposed bind when `CRAWL4AI_API_TOKEN` or JWT is configured, instead of `[::]:<port>`
- ignore Kubernetes-style service-link values such as `CRAWL4AI_PORT=tcp://10.0.101.25:80` and fall back to the Docker server default port `11235`

This does not add an insecure-bind opt-out and does not allow unauthenticated non-loopback exposure.

## List of files changed and why

- `deploy/docker/entrypoint.sh` - Normalize `CRAWL4AI_PORT`, reject invalid non-numeric ports, tolerate Kubernetes service-link URL values, and default credentialed exposure to IPv4 wildcard bind.
- `deploy/docker/tests/test_security_container_posture.py` - Add entrypoint execution tests using a fake `supervisord` to verify bind resolution without requiring a Docker build.

## How Has This Been Tested?

- `uv run --no-project --with pytest pytest deploy/docker/tests/test_security_container_posture.py -q -k 'TestEntrypoint or TestDockerfile or TestSupervisord or TestCompose'`
  - 18 passed, 2 deselected
- `bash -n deploy/docker/entrypoint.sh`
- `git diff --check`

I also attempted the full posture test with editable project dependencies, but local dependency setup failed while building `scipy==1.13.1` because no Fortran compiler is installed. The targeted entrypoint/static posture tests above pass.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added/updated unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
