### PR TITLE
fix(docker): handle Kubernetes service-link port env

### DIFF
--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -23,12 +23,31 @@ if [[ -z "${CRAWL4AI_API_TOKEN:-}" && -f /run/secrets/api_token ]]; then
 fi
 
 # --- Bind resolution: loopback unless a credential is present. ---------------
-PORT="${CRAWL4AI_PORT:-11235}"
+DEFAULT_PORT="11235"
+resolve_port() {
+    local port="${CRAWL4AI_PORT:-$DEFAULT_PORT}"
+    if [[ ! "$port" =~ ^[0-9]+$ ]]; then
+        if [[ "$port" == tcp://* ]]; then
+            echo "entrypoint: ignoring non-numeric CRAWL4AI_PORT='${port}' " \
+                 "(looks like a Kubernetes service link); using ${DEFAULT_PORT}." >&2
+            port="$DEFAULT_PORT"
+        else
+            echo "entrypoint: CRAWL4AI_PORT must be numeric, got '${port}'." >&2
+            exit 1
+        fi
+    fi
+    printf '%s\n' "$port"
+}
+
 if [[ -n "${CRAWL4AI_API_TOKEN:-}" || "${CRAWL4AI_JWT_ENABLED:-false}" == "true" ]]; then
     # A credential is configured -> the operator may expose all interfaces.
-    GUNICORN_BIND="${GUNICORN_BIND:-[::]:${PORT}}"
+    if [[ -z "${GUNICORN_BIND:-}" ]]; then
+        PORT="$(resolve_port)"
+        GUNICORN_BIND="[::]:${PORT}"
+    fi
 else
     # No credential -> refuse to expose; serve loopback only.
+    PORT="$(resolve_port)"
     GUNICORN_BIND="127.0.0.1:${PORT}"
     echo "entrypoint: no CRAWL4AI_API_TOKEN set; binding loopback only (${GUNICORN_BIND})." >&2
 fi

--- a/deploy/docker/tests/test_security_container_posture.py
+++ b/deploy/docker/tests/test_security_container_posture.py
@@ -10,6 +10,8 @@ and is tracked as build-gated; it is out of scope for this offline suite.
 
 import os
 import re
+import stat
+import subprocess
 
 import pytest
 
@@ -109,6 +111,102 @@ class TestEntrypoint:
         src = _read(os.path.join(DOCKER_DIR, "entrypoint.sh"))
         assert "GUNICORN_BIND" in src and "REDIS_PASSWORD" in src
         assert "127.0.0.1" in src  # loopback default when no credential
+
+    def _run_entrypoint(self, tmp_path, extra_env):
+        fake_supervisord = tmp_path / "supervisord"
+        fake_supervisord.write_text(
+            "#!/usr/bin/env sh\n"
+            "echo \"GUNICORN_BIND=${GUNICORN_BIND}\"\n"
+            "echo \"REDIS_PASSWORD_SET=${REDIS_PASSWORD:+yes}\"\n",
+            encoding="utf-8",
+        )
+        fake_supervisord.chmod(
+            fake_supervisord.stat().st_mode | stat.S_IXUSR
+        )
+
+        env = os.environ.copy()
+        for key in (
+            "CRAWL4AI_API_TOKEN",
+            "CRAWL4AI_JWT_ENABLED",
+            "CRAWL4AI_PORT",
+            "GUNICORN_BIND",
+            "REDIS_PASSWORD",
+        ):
+            env.pop(key, None)
+        env.update(extra_env)
+        env["PATH"] = f"{tmp_path}{os.pathsep}{env['PATH']}"
+
+        return subprocess.run(
+            ["bash", os.path.join(DOCKER_DIR, "entrypoint.sh")],
+            cwd=DOCKER_DIR,
+            env=env,
+            text=True,
+            capture_output=True,
+            timeout=10,
+            check=False,
+        )
+
+    def test_entrypoint_preserves_ipv6_wildcard_when_token_allows_exposure(self, tmp_path):
+        result = self._run_entrypoint(
+            tmp_path,
+            {
+                "CRAWL4AI_API_TOKEN": "test-token",
+                "CRAWL4AI_JWT_ENABLED": "false",
+                "CRAWL4AI_PORT": "11235",
+            },
+        )
+        assert result.returncode == 0, result.stderr
+        assert "GUNICORN_BIND=[::]:11235" in result.stdout
+
+    def test_entrypoint_ignores_kubernetes_service_link_port_env(self, tmp_path):
+        result = self._run_entrypoint(
+            tmp_path,
+            {
+                "CRAWL4AI_API_TOKEN": "test-token",
+                "CRAWL4AI_JWT_ENABLED": "false",
+                "CRAWL4AI_PORT": "tcp://10.0.101.25:80",
+            },
+        )
+        assert result.returncode == 0, result.stderr
+        assert "GUNICORN_BIND=[::]:11235" in result.stdout
+        assert "ignoring non-numeric CRAWL4AI_PORT" in result.stderr
+
+    def test_entrypoint_ignores_service_link_port_env_without_token(self, tmp_path):
+        result = self._run_entrypoint(
+            tmp_path,
+            {
+                "CRAWL4AI_JWT_ENABLED": "false",
+                "CRAWL4AI_PORT": "tcp://10.0.101.25:80",
+            },
+        )
+        assert result.returncode == 0, result.stderr
+        assert "GUNICORN_BIND=127.0.0.1:11235" in result.stdout
+        assert "ignoring non-numeric CRAWL4AI_PORT" in result.stderr
+
+    def test_entrypoint_preserves_explicit_gunicorn_bind(self, tmp_path):
+        result = self._run_entrypoint(
+            tmp_path,
+            {
+                "CRAWL4AI_API_TOKEN": "test-token",
+                "CRAWL4AI_JWT_ENABLED": "false",
+                "CRAWL4AI_PORT": "not-a-port",
+                "GUNICORN_BIND": "0.0.0.0:9999",
+            },
+        )
+        assert result.returncode == 0, result.stderr
+        assert "GUNICORN_BIND=0.0.0.0:9999" in result.stdout
+
+    def test_entrypoint_rejects_other_non_numeric_port_env(self, tmp_path):
+        result = self._run_entrypoint(
+            tmp_path,
+            {
+                "CRAWL4AI_API_TOKEN": "test-token",
+                "CRAWL4AI_JWT_ENABLED": "false",
+                "CRAWL4AI_PORT": "http://10.0.101.25:80",
+            },
+        )
+        assert result.returncode == 1
+        assert "CRAWL4AI_PORT must be numeric" in result.stderr
 
 
 class TestSandboxOptOut:


### PR DESCRIPTION
## Summary

Fixes a Docker entrypoint failure mode in Kubernetes clusters where service-link environment variables can inject a non-numeric `CRAWL4AI_PORT` value such as `tcp://10.0.101.25:80`.

This keeps the existing secure-by-default Docker bind posture intact:

- no credential -> loopback-only `127.0.0.1:<port>`
- credential/JWT enabled -> existing dual-stack `[::]:<port>` default
- explicit `GUNICORN_BIND` in credentialed mode is preserved and does not force `CRAWL4AI_PORT` parsing

The only behavior change is port normalization before the entrypoint composes its own default bind address. Numeric `CRAWL4AI_PORT` values still work as before; Kubernetes-style `tcp://...` service-link values are ignored with a warning and fall back to `11235`; other non-numeric values fail fast with a clear error.

I also checked current open PRs for overlap using Kubernetes/k8s/GUNICORN_BIND/CRAWL4AI_PORT/service-link/entrypoint/bind search terms and did not find another PR covering this entrypoint service-link collision.

## List of files changed and why

- `deploy/docker/entrypoint.sh` - add narrow `CRAWL4AI_PORT` normalization for Kubernetes `tcp://...` service-link collisions while preserving the existing `[::]` default and explicit `GUNICORN_BIND` override behavior.
- `deploy/docker/tests/test_security_container_posture.py` - add entrypoint regression tests for the dual-stack credentialed bind, service-link fallback with and without credentials, explicit `GUNICORN_BIND` preservation, and invalid non-service-link port values.

## How Has This Been Tested?

- `uv run --no-project --with pytest pytest deploy/docker/tests/test_security_container_posture.py -q -k 'TestEntrypoint or TestDockerfile or TestSupervisord or TestCompose'` (`21 passed, 2 deselected`)
- `bash -n deploy/docker/entrypoint.sh`
- `git diff --check`

I also attempted the editable project test command, but local dependency setup failed while building `scipy==1.13.1` because this machine does not have a Fortran compiler (`gfortran`) installed.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (N/A: entrypoint behavior is covered by regression tests)
- [x] I have added/updated unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
