### PR TITLE
Fix: Widen lxml dependency ceiling (resolves #2019)fix: widen lxml dependency ceiling to allow lxml>=6.x, fixing scrapli…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "aiohttp>=3.11.11",
     "aiosqlite~=0.20",
     "anyio>=4.0.0",
-    "lxml~=5.3",
+    "lxml>=5.3,<7",
     "unclecode-litellm==1.81.13",
     "numpy>=1.26.0,<3",
     "pillow>=10.4",

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ aiofiles>=24.1.0
 aiohttp>=3.11.11
 aiosqlite~=0.20
 anyio>=4.0.0
-lxml~=5.3
+lxml>=5.3,<7
 unclecode-litellm==1.81.13
 numpy>=1.26.0,<3
 pillow>=10.4


### PR DESCRIPTION
Fixes #2019

## Root Cause
Currently, `crawl4ai` pins `lxml` to `~=5.3` (resolving to `>=5.3,<6.0`). However, packages commonly co-installed alongside it, such as `scrapling` (used for bypassing bot detection), require `lxml>=6.1.1`.

Because these two ranges have zero overlap:
1. **Poetry** dependency resolution fails outright with `version solving failed`.
2. **Pip** installs `lxml 5.4.0` last, silently breaking whichever package expected `6.x` API compatibility.

In addition, the rigid `<6.0` pin causes build failures on Python 3.14 (`#1903`) where prebuilt wheels for 5.x are not available and compiling from source fails, whereas `lxml>=6.0.2` has been confirmed to work.

## Proposed Changes
We widen the constraint to `lxml>=5.3,<7`. This sets a safe upper ceiling under version 7.0 while allowing `6.x` versions to be successfully resolved.

### Dependency Diff
```diff
# pyproject.toml / requirements.txt
-lxml~=5.3
+lxml>=5.3,<7
```

## Verification & Testing

**Pip Co-installation:** Verified in a clean virtual environment:
```bash
pip install -e .
pip install scrapling
python -c "import lxml; from lxml import etree, html; print(lxml.__version__)"
# Output: 6.1.1 (Successful co-installation and load)
```

**Poetry Resolution:** Verified in a clean Poetry project:
```bash
poetry init
poetry add scrapling
poetry add <local-crawl4ai-path>
# Successfully resolved and wrote lockfile without conflicts.
```

**Test Suite:** Ran the regression extraction strategies and GFM table parsing tests to ensure no APIs broke between lxml 5.x and 6.x:
```bash
pytest tests/regression/test_reg_extraction.py   # 20 passed
pytest tests/test_table_gfm_compliance.py        # 13 passed
```

Note: This change may also resolve or mitigate Python 3.14 build issues described in #1903 by allowing the compiler/resolver to pick a newer lxml wheel, though this has not been independently verified on Python 3.14.