### PR TITLE
fix: add non-free apt sources for nvidia-cuda-toolkit on Bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,9 +90,10 @@ RUN apt-get update && apt-get dist-upgrade -y \
     && rm -rf /var/lib/apt/lists/*
 
 RUN if [ "$ENABLE_GPU" = "true" ] && [ "$TARGETARCH" = "amd64" ] ; then \
-    apt-get update && apt-get install -y --no-install-recommends \
+    echo "deb http://deb.debian.org/debian bookworm non-free" >> /etc/apt/sources.list \
+    && apt-get update && apt-get install -y --no-install-recommends \
     nvidia-cuda-toolkit \
-    && apt-get clean \ 
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/* ; \
 else \
     echo "Skipping NVIDIA CUDA Toolkit installation (unsupported platform or GPU disabled)"; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,7 @@ RUN apt-get update && apt-get dist-upgrade -y \
     && rm -rf /var/lib/apt/lists/*
 
 RUN if [ "$ENABLE_GPU" = "true" ] && [ "$TARGETARCH" = "amd64" ] ; then \
-    echo "deb http://deb.debian.org/debian bookworm non-free" >> /etc/apt/sources.list \
+    echo "deb http://deb.debian.org/debian bookworm contrib non-free" >> /etc/apt/sources.list \
     && apt-get update && apt-get install -y --no-install-recommends \
     nvidia-cuda-toolkit \
     && apt-get clean \


### PR DESCRIPTION
The `python:3.12-slim-bookworm` base image only has `main` and `non-free-firmware` components enabled. `nvidia-cuda-toolkit` lives in `non-free`, and some of its install-time dependencies resolve from `contrib`, so the GPU Docker build needs both components enabled before installing it.

This PR adds `deb http://deb.debian.org/debian bookworm contrib non-free` to `sources.list` before the GPU install block so `ENABLE_GPU=true` builds don't fail with:
```
Package nvidia-cuda-toolkit has no installation candidate
```

Also fixes a stray trailing space after `apt-get clean \`.

Fixes #2020.

Validation:
- Simulated Bookworm apt sources matching the slim image (`main non-free-firmware` + this added source).
- `apt-cache policy nvidia-cuda-toolkit` finds candidate `11.8.89~11.8.0-5~deb12u1`.
- `apt-get install -s --no-install-recommends nvidia-cuda-toolkit` resolves successfully with `contrib non-free`; it fails with `non-free` alone due missing dependencies.
