### PR TITLE
fix(docker): playground config type + monitor websocket auth dep

### DIFF
--- a/deploy/docker/server.py
+++ b/deploy/docker/server.py
@@ -482,8 +482,12 @@ def _config_from_json(data: dict) -> dict:
 app.include_router(init_job_router(redis, config, token_dep))
 
 # ── monitor router ──────────────────────────────────────────
+# Do not attach token_dep at router level: it is HTTP Request-only and breaks
+# the WebSocket upgrade on /monitor/ws (TypeError: _principal() missing 'request').
+# AuthGateMiddleware already authenticates HTTP + WS; destructive monitor
+# actions keep their own Depends(require_admin).
 from monitor_routes import router as monitor_router
-app.include_router(monitor_router, dependencies=[Depends(token_dep)])
+app.include_router(monitor_router)
 
 logger = logging.getLogger(__name__)
 

--- a/deploy/docker/static/playground/index.html
+++ b/deploy/docker/static/playground/index.html
@@ -563,10 +563,13 @@
             const code = cm.getValue().trim();
             if (!code) return {};
 
+            // Server requires `type` alongside `code` (CrawlerRunConfig | BrowserConfig).
+            // The UI already tracks this in #cfg-type; omitting it always 400s Advanced Config.
+            const cfgType = document.getElementById('cfg-type').value;
             const res = await authFetch('/config/dump', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ code }),
+                body: JSON.stringify({ type: cfgType, code }),
             });
 
             const statusEl = document.getElementById('cfg-status');
@@ -652,9 +655,12 @@
         // Detect if stream is requested inside payload
         function shouldUseStream(payload) {
             const toBool = (v) => v === true || (typeof v === 'string' && v.toLowerCase() === 'true');
-            const fromCrawler = payload && payload.crawler_config && payload.crawler_config.params && payload.crawler_config.params.stream;
+            // Successful /config/dump returns { type, params: { stream, ... } }
+            const fromCrawlerParams = payload && payload.crawler_config && payload.crawler_config.params && payload.crawler_config.params.stream;
+            // Fallback / minimal shapes may set stream at the crawler_config top level
+            const fromCrawlerTop = payload && payload.crawler_config && payload.crawler_config.stream;
             const direct = payload && payload.stream;
-            return toBool(fromCrawler) || toBool(direct);
+            return toBool(fromCrawlerParams) || toBool(fromCrawlerTop) || toBool(direct);
         }
 
         // Main run function
@@ -676,8 +682,8 @@
                 const streamFlag = /stream\s*=\s*True/i.test(codeText);
                 const isCrawlEndpoint = document.getElementById('endpoint').value === 'crawl';
                 if (isCrawlEndpoint && streamFlag) {
-                    // Fallback: proceed with minimal config only for stream
-                    advConfig = { crawler_config: { stream: true } };
+                    // Fallback: minimal dump-shaped config so shouldUseStream + server load agree
+                    advConfig = { crawler_config: { type: 'CrawlerRunConfig', params: { stream: true } } };
                 } else {
                     updateStatus('error');
                     document.querySelector('#response-content code').textContent =


### PR DESCRIPTION
## Summary

Two Docker UI server bugs with confirmed root causes on `develop`.

### Fixes #2059 — Playground Advanced Config always 400

`pyConfigToJson()` POSTed `{ code }` to `/config/dump`, but the server requires `type` (`CrawlerRunConfig` | `BrowserConfig`). Every custom Advanced Config failed with:

```json
{"detail":"type must be 'CrawlerRunConfig' or 'BrowserConfig'"}
```

**Change:** send `type` from `#cfg-type` with the code.

Also tightens the related stream-path follow-up from the issue:

- Fallback minimal config uses dump-shaped `{ type, params: { stream: true } }`
- `shouldUseStream()` reads both `crawler_config.params.stream` and top-level `crawler_config.stream`

### Fixes #2060 — Dashboard `/monitor/ws` 500

```python
app.include_router(monitor_router, dependencies=[Depends(token_dep)])
```

`token_dep` is HTTP `Request`-only. FastAPI applies router-level deps to the WebSocket route; inject fails with:

```text
TypeError: _principal() missing 1 required positional argument: 'request'
```

The WS handler already documents that `AuthGateMiddleware` owns auth; destructive routes keep `Depends(require_admin)`.

**Change:** `app.include_router(monitor_router)` without the HTTP-only dependency.

## Test plan

- [ ] Playground: expand Advanced Config (default `CrawlerRunConfig`), Run → `/config/dump` returns 200 and crawl succeeds
- [ ] Playground: switch type to `BrowserConfig` template → dump + run succeed
- [ ] Playground: intentional bad Python in Advanced Config still surfaces config error
- [ ] Dashboard: with valid token, `/monitor/ws` upgrades (101) and streams health/requests JSON
- [ ] Dashboard: unauthenticated WS still rejected by middleware
- [ ] Monitor admin actions still require admin scope

## Notes

- Targets `develop` (collaborator convention).
- Minimal, focused diff: 2 files.
