### PR TITLE
fix(dispatcher): clean up closed stream tasks

### DIFF
--- a/crawl4ai/async_dispatcher.py
+++ b/crawl4ai/async_dispatcher.py
@@ -534,6 +534,7 @@ class MemoryAdaptiveDispatcher(BaseDispatcher):
         config: Union[CrawlerRunConfig, List[CrawlerRunConfig]],
     ) -> AsyncGenerator[CrawlerTaskResult, None]:
         self.crawler = crawler
+        active_tasks = []
         
         # Start the memory monitor task
         memory_monitor = asyncio.create_task(self._memory_monitor_task())
@@ -550,7 +551,6 @@ class MemoryAdaptiveDispatcher(BaseDispatcher):
                 # Add to queue with initial priority 0, retry count 0, and current time
                 await self.task_queue.put((0, (url, task_id, 0, time.time())))
                 
-            active_tasks = []
             completed_count = 0
             total_urls = len(urls)
 
@@ -614,8 +614,24 @@ class MemoryAdaptiveDispatcher(BaseDispatcher):
                 await self._update_queue_priorities()
                 
         finally:
-            # Clean up
+            # Cancel and await every task owned by this stream before returning
+            # control to the caller. Otherwise a closed stream can leave crawls
+            # using browser pages and contexts in the background.
+            for task in active_tasks:
+                if not task.done():
+                    task.cancel()
+            if active_tasks:
+                await asyncio.gather(*active_tasks, return_exceptions=True)
+
+            # Discard URLs that were queued by this stream but never started.
+            while True:
+                try:
+                    self.task_queue.get_nowait()
+                except asyncio.QueueEmpty:
+                    break
+
             memory_monitor.cancel()
+            await asyncio.gather(memory_monitor, return_exceptions=True)
             if self.monitor:
                 self.monitor.stop()
                 

--- a/tests/async/test_dispatchers.py
+++ b/tests/async/test_dispatchers.py
@@ -1,5 +1,8 @@
-import pytest
+import asyncio
 import time
+from types import SimpleNamespace
+
+import pytest
 from crawl4ai import (
     AsyncWebCrawler,
     BrowserConfig,
@@ -62,6 +65,45 @@ class TestDispatchStrategies:
             )
             assert len(results) == len(test_urls)
             assert all(r.success for r in results)
+
+    async def test_memory_adaptive_stream_closure_cleans_up_tasks(self, run_config):
+        class BlockingCrawler:
+            async def arun(self, url, config=None, session_id=None):
+                if url == "fast":
+                    return SimpleNamespace(
+                        success=True,
+                        status_code=200,
+                        error_message="",
+                    )
+                await asyncio.Event().wait()
+
+        class TrackingDispatcher(MemoryAdaptiveDispatcher):
+            def __init__(self):
+                super().__init__(max_session_permit=3)
+                self.tasks = {}
+
+            async def crawl_url(self, url, config, task_id, retry_count=0):
+                self.tasks[url] = asyncio.current_task()
+                return await super().crawl_url(url, config, task_id, retry_count)
+
+        dispatcher = TrackingDispatcher()
+        stream = dispatcher.run_urls_stream(
+            ["fast", "blocked-1", "blocked-2", "queued"],
+            BlockingCrawler(),
+            run_config,
+        )
+
+        first = await asyncio.wait_for(stream.__anext__(), timeout=1)
+        assert first.url == "fast"
+
+        await asyncio.wait_for(stream.aclose(), timeout=1)
+
+        assert set(dispatcher.tasks) == {"fast", "blocked-1", "blocked-2"}
+        assert all(task.done() for task in dispatcher.tasks.values())
+        assert dispatcher.tasks["blocked-1"].cancelled()
+        assert dispatcher.tasks["blocked-2"].cancelled()
+        assert dispatcher.concurrent_sessions == 0
+        assert dispatcher.task_queue.empty()
 
     async def test_semaphore_basic(self, browser_config, run_config, test_urls):
         async with AsyncWebCrawler(config=browser_config) as crawler:


### PR DESCRIPTION
## Summary
- cancel and await active crawl tasks when a `MemoryAdaptiveDispatcher` stream closes
- discard URLs queued by the closed stream before the dispatcher can be reused
- await memory-monitor cancellation and add a deterministic regression test

## Root cause
`run_urls_stream()` created per-URL tasks but its `finally` block only cancelled the memory monitor. Closing or cancelling the generator therefore left active crawls and queued URLs owned by the old stream alive, allowing them to overlap a later crawl on the same dispatcher and browser.

Fixes #2071.

## Validation
- dependency-light async regression harness covering active-task cancellation, queue cleanup, session-count restoration, and absence of background tasks
- `python -m py_compile crawl4ai/async_dispatcher.py tests/async/test_dispatchers.py`
- `git diff --check`

Focused pytest was not run because pytest and the project runtime dependencies are not installed in this workspace.