### PR TITLE
fix(deep_crawling): BFS/DFS/BestFirst strategies share one default FilterChain instance

### DIFF
--- a/crawl4ai/deep_crawling/bff_strategy.py
+++ b/crawl4ai/deep_crawling/bff_strategy.py
@@ -36,7 +36,7 @@ class BestFirstCrawlingStrategy(DeepCrawlStrategy):
     def __init__(
         self,
         max_depth: int,
-        filter_chain: FilterChain = FilterChain(),
+        filter_chain: Optional[FilterChain] = None,
         url_scorer: Optional[URLScorer] = None,
         include_external: bool = False,
         score_threshold: float = -infinity,
@@ -49,7 +49,7 @@ class BestFirstCrawlingStrategy(DeepCrawlStrategy):
         should_cancel: Optional[Callable[[], Union[bool, Awaitable[bool]]]] = None,
     ):
         self.max_depth = max_depth
-        self.filter_chain = filter_chain
+        self.filter_chain = filter_chain if filter_chain is not None else FilterChain()
         self.url_scorer = url_scorer
         self.include_external = include_external
         self.score_threshold = score_threshold

--- a/crawl4ai/deep_crawling/bfs_strategy.py
+++ b/crawl4ai/deep_crawling/bfs_strategy.py
@@ -25,7 +25,7 @@ class BFSDeepCrawlStrategy(DeepCrawlStrategy):
     def __init__(
         self,
         max_depth: int,
-        filter_chain: FilterChain = FilterChain(),
+        filter_chain: Optional[FilterChain] = None,
         url_scorer: Optional[URLScorer] = None,
         include_external: bool = False,
         score_threshold: float = -infinity,
@@ -38,7 +38,7 @@ class BFSDeepCrawlStrategy(DeepCrawlStrategy):
         should_cancel: Optional[Callable[[], Union[bool, Awaitable[bool]]]] = None,
     ):
         self.max_depth = max_depth
-        self.filter_chain = filter_chain
+        self.filter_chain = filter_chain if filter_chain is not None else FilterChain()
         self.url_scorer = url_scorer
         self.include_external = include_external
         self.score_threshold = score_threshold

--- a/tests/deep_crawling/test_default_filter_chain_isolation.py
+++ b/tests/deep_crawling/test_default_filter_chain_isolation.py
@@ -1,0 +1,42 @@
+"""Regression tests for the mutable-default-argument bug in deep-crawl strategy
+constructors: filter_chain defaulted to a single FilterChain() instance shared
+across every strategy created without an explicit filter_chain=, leaking
+FilterChain.stats counters and add_filter() mutations across unrelated
+strategy instances.
+"""
+
+from crawl4ai.deep_crawling.bff_strategy import BestFirstCrawlingStrategy
+from crawl4ai.deep_crawling.bfs_strategy import BFSDeepCrawlStrategy
+from crawl4ai.deep_crawling.dfs_strategy import DFSDeepCrawlStrategy
+
+
+def test_bfs_strategy_instances_get_independent_default_filter_chains():
+    a = BFSDeepCrawlStrategy(max_depth=2)
+    b = BFSDeepCrawlStrategy(max_depth=3)
+    assert a.filter_chain is not b.filter_chain
+
+
+def test_dfs_strategy_instances_get_independent_default_filter_chains():
+    a = DFSDeepCrawlStrategy(max_depth=2)
+    b = DFSDeepCrawlStrategy(max_depth=3)
+    assert a.filter_chain is not b.filter_chain
+
+
+def test_best_first_strategy_instances_get_independent_default_filter_chains():
+    a = BestFirstCrawlingStrategy(max_depth=2)
+    b = BestFirstCrawlingStrategy(max_depth=3)
+    assert a.filter_chain is not b.filter_chain
+
+
+def test_adding_a_filter_to_one_default_chain_does_not_leak_to_another_instance():
+    a = BFSDeepCrawlStrategy(max_depth=2)
+    b = BFSDeepCrawlStrategy(max_depth=3)
+
+    class _DummyFilter:
+        def apply(self, url):
+            return True
+
+    a.filter_chain.add_filter(_DummyFilter())
+
+    assert len(a.filter_chain.filters) == 1
+    assert len(b.filter_chain.filters) == 0


### PR DESCRIPTION
## Summary

`BFSDeepCrawlStrategy.__init__` and `BestFirstCrawlingStrategy.__init__` both default `filter_chain` to `FilterChain()` — a classic Python mutable-default-argument bug. The default object is instantiated once at function-definition time, not per call, so every strategy instance created without an explicit `filter_chain=` argument shares the exact same `FilterChain` object. `DFSDeepCrawlStrategy` inherits BFS's `__init__` unchanged, so it's affected too.

`FilterChain` is genuinely stateful: `FilterChain.apply()` increments `self.stats._counters` on every call, and `add_filter()` mutates `self.filters` in place. Two unrelated strategy instances (e.g. two concurrent crawls, or sequential crawls reusing default construction) silently share and corrupt each other's filter stats, and adding a filter to one instance's default chain leaks into every other instance using the default.

Confirmed via `s1.filter_chain is s2.filter_chain` == `True` for two independently-constructed `BFSDeepCrawlStrategy` instances before this fix.

## Fix

`filter_chain: Optional[FilterChain] = None`, with `self.filter_chain = filter_chain if filter_chain is not None else FilterChain()` inside `__init__`, giving each instance a fresh chain when none is explicitly provided.

## List of files changed and why

- `crawl4ai/deep_crawling/bfs_strategy.py` — fix the mutable default (covers BFS and, via inheritance, DFS).
- `crawl4ai/deep_crawling/bff_strategy.py` — same fix for `BestFirstCrawlingStrategy`.
- `tests/deep_crawling/test_default_filter_chain_isolation.py` (new) — regression coverage.

## How Has This Been Tested?

- Added tests covering BFS, DFS, and BestFirst independently (`filter_chain is not` between two instances), plus a test confirming `add_filter()` on one instance's default chain doesn't leak into another's.
- Confirmed red→green: reverting only the two source files reproduces `s1.filter_chain is s2.filter_chain == True` and the leaked-filter assertion failing; reapplying passes.
- Full `tests/deep_crawling/` suite: 73 passed.
- No lint/format tooling is configured in this repo (checked `pyproject.toml`, no `Makefile`/`.pre-commit-config.yaml`); confirmed changed files compile cleanly with `python -m py_compile`.
- xref: #1835 also touches both files but only adds a `dispatcher=` passthrough parameter, not the `filter_chain` default — no overlap.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added/updated unit tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## AI-Generated disclosure

Found via an AI-assisted code review pass (Claude Code) over `crawl4ai/deep_crawling/`. I personally confirmed the shared-instance bug with a standalone repro, verified the fix across all three affected strategy classes, and ran the relevant test suite before submitting.