### PR TITLE
fix(deep_crawling): allow single-label hostnames

### DIFF
--- a/crawl4ai/deep_crawling/bfs_strategy.py
+++ b/crawl4ai/deep_crawling/bfs_strategy.py
@@ -70,8 +70,6 @@ class BFSDeepCrawlStrategy(DeepCrawlStrategy):
                 raise ValueError("Missing scheme or netloc")
             if parsed.scheme not in ("http", "https"):
                 raise ValueError("Invalid scheme")
-            if "." not in parsed.netloc:
-                raise ValueError("Invalid domain")
         except Exception as e:
             self.logger.warning(f"Invalid URL: {url}, error: {e}")
             return False

--- a/tests/deep_crawling/test_deep_crawl_resume.py
+++ b/tests/deep_crawling/test_deep_crawl_resume.py
@@ -629,6 +629,14 @@ class TestBFSRegressions:
         assert await strategy.can_process_url("https://other.com/blog/post1", 1) == False
 
     @pytest.mark.asyncio
+    async def test_single_label_hostname_is_valid(self):
+        """Single-label hostnames can reach the configured filter chain."""
+        filter_chain = FilterChain([DomainFilter(allowed_domains=["intranet"])])
+        strategy = BFSDeepCrawlStrategy(max_depth=1, filter_chain=filter_chain)
+
+        assert await strategy.can_process_url("https://intranet/docs", 1) is True
+
+    @pytest.mark.asyncio
     async def test_url_scorer_still_works(self):
         """URL scoring integration unchanged."""
         scorer = KeywordRelevanceScorer(keywords=["python", "tutorial"], weight=1.0)


### PR DESCRIPTION
## Summary

Fixes #2079.

Allow `BFSDeepCrawlStrategy` to process valid HTTP(S) URLs whose host is a single label, such as internal DNS names. The existing scheme and non-empty netloc validation continues to reject malformed URLs.

## List of files changed and why

- `crawl4ai/deep_crawling/bfs_strategy.py` - Remove the overly strict requirement that every hostname contain a dot.
- `tests/deep_crawling/test_deep_crawl_resume.py` - Add a regression test proving a single-label hostname reaches and passes the configured domain filter.

## How Has This Been Tested?

- `.venv/bin/pytest -q tests/deep_crawling/test_deep_crawl_resume.py` — 33 passed.
- `.venv/bin/black --check crawl4ai/deep_crawling/bfs_strategy.py tests/deep_crawling/test_deep_crawl_resume.py` — run; the command reports existing whole-file formatting drift also present on the upstream baseline. The changed lines were reviewed against Black's diff and introduce no new formatting changes.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas — N/A; the validation removal is self-explanatory.
- [ ] I have made corresponding changes to the documentation — N/A; this is a narrow bug fix with no public API change.
- [x] I have added/updated unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
