### PR TITLE
fix(docker): tolerate unavailable IPv6 loopback

### DIFF
--- a/deploy/docker/supervisord.conf
+++ b/deploy/docker/supervisord.conf
@@ -6,7 +6,7 @@ logfile_maxbytes=0
 [program:redis]
 ; Loopback-only and password-protected. REDIS_PASSWORD is exported by
 ; entrypoint.sh from the mounted secret; the app must supply it to connect.
-command=/usr/bin/redis-server --loglevel notice --bind 127.0.0.1 ::1 --requirepass "%(ENV_REDIS_PASSWORD)s" --dir /var/lib/redis
+command=/usr/bin/redis-server --loglevel notice --bind 127.0.0.1 -::1 --requirepass "%(ENV_REDIS_PASSWORD)s" --dir /var/lib/redis
 user=appuser                    ; Run redis as our non-root user
 autorestart=true
 priority=10

--- a/deploy/docker/tests/test_security_container_posture.py
+++ b/deploy/docker/tests/test_security_container_posture.py
@@ -78,8 +78,8 @@ class TestSupervisord:
     def test_redis_requires_password(self, supervisord):
         assert "--requirepass" in supervisord
 
-    def test_redis_bound_loopback(self, supervisord):
-        assert "--bind 127.0.0.1" in supervisord
+    def test_redis_bound_loopback_with_optional_ipv6(self, supervisord):
+        assert "--bind 127.0.0.1 -::1" in supervisord
 
     def test_gunicorn_bind_is_env_driven(self, supervisord):
         # entrypoint.sh resolves GUNICORN_BIND (loopback unless a credential).


### PR DESCRIPTION
## Summary

Fixes #2078.

Make Redis's IPv6 loopback bind optional while retaining mandatory IPv4 loopback binding. Redis therefore starts on IPv4-only hosts instead of aborting when `::1` is unavailable, while continuing to listen on IPv6 loopback where supported.

## List of files changed and why

- `deploy/docker/supervisord.conf` - Prefix the IPv6 loopback address with Redis's optional-address marker.
- `deploy/docker/tests/test_security_container_posture.py` - Require the IPv4 loopback plus optional IPv6 bind form in the container posture test.

## How Has This Been Tested?

- `PYTHONPATH=. pytest -q deploy/docker/tests/test_security_container_posture.py` — 19 passed.
- `PYTHONPATH=. pytest -q deploy/docker/tests/test_security_*.py` — 316 passed, 1 expected xfail.
- `black --check --target-version py312 --line-ranges 77-84 deploy/docker/tests/test_security_container_posture.py` — passed.
- `git diff --check` — passed.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas — N/A; the existing comment already describes the loopback-only Redis binding.
- [ ] I have made corresponding changes to the documentation — N/A; this corrects container startup behavior without changing the documented interface.
- [x] I have added/updated unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
