### PR TITLE
fix(html2text): thread escape_backslash into escape_md_section() call

### DIFF
--- a/crawl4ai/html2text/__init__.py
+++ b/crawl4ai/html2text/__init__.py
@@ -952,6 +952,7 @@ class HTML2Text(html.parser.HTMLParser):
             data = escape_md_section(
                 data,
                 snob=self.escape_snob,
+                escape_backslash=self.escape_backslash,
                 escape_dot=self.escape_dot,
                 escape_plus=self.escape_plus,
                 escape_dash=self.escape_dash,

--- a/tests/unit/test_html2text_escape_backslash.py
+++ b/tests/unit/test_html2text_escape_backslash.py
@@ -1,0 +1,35 @@
+"""Unit tests for CustomHTML2Text's escape_backslash config flag.
+
+escape_backslash is threaded from config.py -> HTML2Text.__init__ -> instance
+attribute, and sibling flags (escape_dot/escape_plus/escape_dash) are all
+forwarded into escape_md_section() at its call site in handle_data(). This
+tests that escape_backslash is forwarded the same way, so that setting it to
+False actually disables backslash escaping in the generated markdown.
+"""
+from crawl4ai.html2text import CustomHTML2Text
+
+
+def _convert(html: str, escape_backslash: bool) -> str:
+    h = CustomHTML2Text()
+    h.body_width = 0
+    h.escape_backslash = escape_backslash
+    return h.handle(html)
+
+
+# RE_MD_BACKSLASH_MATCHER (html2text/config.py) only fires on a backslash
+# followed by a markdown-special char (`*_{}[]()#+-.!), so the repro text
+# must contain a literal backslash immediately before one of those chars.
+HTML_WITH_BACKSLASH = r"<p>Use \* for multiplication</p>"
+
+
+class TestEscapeBackslashConfig:
+    def test_escape_backslash_false_leaves_backslashes_alone(self):
+        """escape_backslash=False must not double the literal backslash."""
+        out = _convert(HTML_WITH_BACKSLASH, escape_backslash=False)
+        assert r"\*" in out
+        assert r"\\*" not in out
+
+    def test_escape_backslash_true_still_escapes(self):
+        """escape_backslash=True (the escape_md_section default) must still escape."""
+        out = _convert(HTML_WITH_BACKSLASH, escape_backslash=True)
+        assert r"\\*" in out


### PR DESCRIPTION
## Summary
`escape_backslash` is never forwarded into `escape_md_section()` at its call site in `HTML2Text.handle_data()` (`crawl4ai/html2text/__init__.py`), unlike its sibling flags `escape_dot`/`escape_plus`/`escape_dash`, which are all threaded through correctly. Because `escape_md_section()` has its own hardcoded default of `escape_backslash=True`, that default always wins — backslashes get escaped/doubled in the generated markdown regardless of what the instance (or `CustomHTML2Text`'s own `escape_backslash=False` default, which is what the default markdown-generation pipeline actually uses) configures.

Fixes: n/a (no existing issue filed for this)

## List of files changed and why
- `crawl4ai/html2text/__init__.py` — pass `escape_backslash=self.escape_backslash` into the `escape_md_section()` call in `handle_data()`, the same way `escape_dot`/`escape_plus`/`escape_dash` are already passed.
- `tests/unit/test_html2text_escape_backslash.py` — new unit test covering both `escape_backslash=False` (must not double backslashes) and `escape_backslash=True` (must still escape), using `CustomHTML2Text` directly.

## How Has This Been Tested?
- Added a failing test first (TDD): with `escape_backslash=False` explicitly set, converting `<p>Use \* for multiplication</p>` produced `Use \\* for multiplication` (doubled) instead of the expected `Use \* for multiplication` — confirmed red against current code.
- After the fix, the same test goes green, and a companion test confirms `escape_backslash=True` still escapes as before (no default-behavior flip).
- Ran the full non-browser test subset (`tests/unit/`, `tests/deep_crawling/`, `tests/regression/test_reg_extraction.py -m "not network"`, `tests/test_source_sibling_selector.py`, `tests/general/test_strip_markdown_fences.py`, `tests/general/test_async_markdown_generator.py`): same pass/fail counts before and after the change (verified via `git stash`/`git stash pop` A-B comparison) — the only failures present are pre-existing environment failures unrelated to this diff (missing local Playwright browser binary, `BrowserType.launch: Executable doesn't exist`), not caused by this change.
- `python -m py_compile` on both changed files: clean.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added/updated unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## AI disclosure
This fix was found, implemented, and verified with Claude (Anthropic) assistance in a human-in-the-loop workflow: I reviewed the exact code path, wrote/ran the failing test myself before the fix, confirmed the fix goes green, and ran the broader test subset before submitting. Commit includes a `Co-Authored-By: Claude Opus 4.8` trailer for transparency.