### PR TITLE
fix: gate GPU-disabling flags on enable_stealth in _build_browser_args

### DIFF
--- a/crawl4ai/browser_manager.py
+++ b/crawl4ai/browser_manager.py
@@ -1057,9 +1057,6 @@ class BrowserManager:
     def _build_browser_args(self) -> dict:
         """Build browser launch arguments from config."""
         args = [
-            "--disable-gpu",
-            "--disable-gpu-compositing",
-            "--disable-software-rasterizer",
             "--no-sandbox",
             "--disable-dev-shm-usage",
             "--no-first-run",
@@ -1082,6 +1079,16 @@ class BrowserManager:
             # "--single-process",
             f"--window-size={self.config.viewport_width},{self.config.viewport_height}",
         ]
+
+        # GPU flags disable WebGL which anti-bot sensors detect as headless.
+        # Keep WebGL working (via SwiftShader) when stealth mode is active,
+        # matching build_browser_flags().
+        if not self.config.enable_stealth:
+            args.extend([
+                "--disable-gpu",
+                "--disable-gpu-compositing",
+                "--disable-software-rasterizer",
+            ])
 
         if self.config.memory_saving_mode:
             args.extend([


### PR DESCRIPTION
## Summary

`BrowserManager._build_browser_args()` unconditionally adds `--disable-gpu`, `--disable-gpu-compositing` and `--disable-software-rasterizer`, while its sibling `build_browser_flags()` gates exactly these three flags on `config.enable_stealth` (with the comment "GPU flags disable WebGL which anti-bot sensors detect as headless").

Disabling the GPU kills WebGL, and a missing/blank WebGL vendor/renderer is one of the louder headless signals anti-bot scripts check — so launching with `enable_stealth=True` through `_build_browser_args()` currently undermines the stealth mode it was asked for.

## Change

Mirror the sibling's conditional in `_build_browser_args()`: the three GPU flags are added only when `enable_stealth` is off. With stealth on, WebGL keeps rendering via SwiftShader. No change for non-stealth launches — they get the same flags as before.

## Testing

- With `enable_stealth=True`, a WebGL fingerprint probe (`webgl_vendor` / `webgl_renderer` via `WEBGL_debug_renderer_info`) returns a populated renderer string instead of failing; with `enable_stealth=False` the flag set is unchanged from current behavior.
- We have been running this patch in a production fork since April 2026 with no regressions.
