### PR TITLE
fix(crawler): await dispatcher stream aclose in arun_many

### DIFF
--- a/crawl4ai/async_webcrawler.py
+++ b/crawl4ai/async_webcrawler.py
@@ -1107,13 +1107,19 @@ class AsyncWebCrawler:
 
         if stream:
             async def result_transformer():
+                # Hold an explicit reference so aclose() on the public generator
+                # always awaits dispatcher-owned task cleanup (#2083). Relying
+                # only on async-for teardown can release the proxy session while
+                # crawl tasks from the closed stream are still running.
+                stream_gen = dispatcher.run_urls_stream(
+                    crawler=self, urls=urls, config=config
+                )
                 try:
-                    async for task_result in dispatcher.run_urls_stream(
-                        crawler=self, urls=urls, config=config
-                    ):
+                    async for task_result in stream_gen:
                         yield transform_result(task_result)
                 finally:
-                    # Auto-release session after streaming completes
+                    await stream_gen.aclose()
+                    # Auto-release session after dispatcher cleanup finishes
                     await maybe_release_session()
 
             return result_transformer()


### PR DESCRIPTION
## Summary
#2072 made `MemoryAdaptiveDispatcher.run_urls_stream()` clean up when *that* generator is closed. The public API path `AsyncWebCrawler.arun_many(..., stream=True)` still only wrapped it in an `async for` + proxy-session release, so early `aclose()` on the public generator could release the session while dispatcher-owned tasks were still running.

## Change
- Keep an explicit reference to the dispatcher stream
- Always `await stream_gen.aclose()` in `finally` before proxy-session auto-release

## Test plan
- Existing dispatcher stream-aclose tests (`tests/async/test_dispatchers.py`) remain the unit-level guarantee for the underlying generator
- Manual: `async for` + early generator close on `arun_many(..., stream=True)` should no longer leave crawl tasks alive

Fixes #2083.
