### PR TITLE
fix(docker): remove build artifacts from image layers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -175,15 +175,16 @@ RUN pip install --no-cache-dir --upgrade pip && \
 
 RUN crawl4ai-setup
 
-RUN playwright install --with-deps
-
-RUN mkdir -p /home/appuser/.cache/ms-playwright \
+RUN playwright install --with-deps \
+    && mkdir -p /home/appuser/.cache/ms-playwright \
     && cp -r /root/.cache/ms-playwright/chromium-* \
         /root/.cache/ms-playwright/chromium_headless_shell-* \
         /home/appuser/.cache/ms-playwright/ \
-    && chown -R appuser:appuser /home/appuser/.cache/ms-playwright
+    && chown -R appuser:appuser /home/appuser/.cache/ms-playwright \
+    && rm -rf /root/.cache/ms-playwright
 
-RUN crawl4ai-doctor
+RUN crawl4ai-doctor \
+    && find "${APP_HOME}" -maxdepth 1 -type f -name '*.core' -delete
 
 # Ensure all cache directories belong to appuser
 # This fixes permission issues with .cache/url_seeder and other runtime cache dirs

--- a/Dockerfile
+++ b/Dockerfile
@@ -173,17 +173,15 @@ RUN pip install --no-cache-dir --upgrade pip && \
     python -c "import crawl4ai; print('✅ crawl4ai is ready to rock!')" && \
     python -c "from playwright.sync_api import sync_playwright; print('✅ Playwright is feeling dramatic!')"
 
-RUN crawl4ai-setup
-
-RUN playwright install --with-deps \
+RUN crawl4ai-setup \
+    && playwright install --with-deps chromium \
+    && crawl4ai-doctor \
     && mkdir -p /home/appuser/.cache/ms-playwright \
     && cp -r /root/.cache/ms-playwright/chromium-* \
         /root/.cache/ms-playwright/chromium_headless_shell-* \
         /home/appuser/.cache/ms-playwright/ \
     && chown -R appuser:appuser /home/appuser/.cache/ms-playwright \
-    && rm -rf /root/.cache/ms-playwright
-
-RUN crawl4ai-doctor \
+    && rm -rf /root/.cache/ms-playwright \
     && find "${APP_HOME}" -maxdepth 1 -type f -name '*.core' -delete
 
 # Ensure all cache directories belong to appuser

--- a/deploy/docker/tests/test_security_container_posture.py
+++ b/deploy/docker/tests/test_security_container_posture.py
@@ -46,8 +46,9 @@ class TestDockerfile:
             stripped = line.strip()
             if stripped.startswith("#"):
                 continue
-            assert not re.match(r"EXPOSE\s+.*\b6379\b", stripped), \
-                "redis port 6379 must not be EXPOSEd"
+            assert not re.match(
+                r"EXPOSE\s+.*\b6379\b", stripped
+            ), "redis port 6379 must not be EXPOSEd"
 
     def test_app_dir_root_owned_readonly(self, dockerfile):
         assert "chown -R root:root ${APP_HOME}" in dockerfile
@@ -66,9 +67,26 @@ class TestDockerfile:
             dockerfile,
             re.DOTALL,
         )
-        assert cache_copy, "Dockerfile must copy Playwright artifacts into appuser's cache"
+        assert (
+            cache_copy
+        ), "Dockerfile must copy Playwright artifacts into appuser's cache"
         assert "chromium-*" in cache_copy.group("artifacts")
         assert "chromium_headless_shell-*" in cache_copy.group("artifacts")
+
+    def test_build_artifacts_removed_before_layer_commit(self, dockerfile):
+        for command, cleanup in (
+            ("playwright install --with-deps", "rm -rf /root/.cache/ms-playwright"),
+            ("crawl4ai-doctor", "-name '*.core' -delete"),
+        ):
+            layer = re.search(
+                rf"^RUN {re.escape(command)}(?P<body>(?:(?!^[A-Z]+\s).)*)",
+                dockerfile,
+                re.MULTILINE | re.DOTALL,
+            )
+            assert layer, f"Dockerfile must run {command}"
+            assert cleanup in layer.group(
+                "body"
+            ), f"{cleanup} must run in the {command} layer"
 
     def test_runs_as_non_root(self, dockerfile):
         assert re.search(r"^USER\s+appuser", dockerfile, re.MULTILINE)

--- a/deploy/docker/tests/test_security_container_posture.py
+++ b/deploy/docker/tests/test_security_container_posture.py
@@ -74,19 +74,25 @@ class TestDockerfile:
         assert "chromium_headless_shell-*" in cache_copy.group("artifacts")
 
     def test_build_artifacts_removed_before_layer_commit(self, dockerfile):
-        for command, cleanup in (
-            ("playwright install --with-deps", "rm -rf /root/.cache/ms-playwright"),
-            ("crawl4ai-doctor", "-name '*.core' -delete"),
+        layer = re.search(
+            r"^RUN crawl4ai-setup(?P<body>(?:(?!^[A-Z]+\s).)*)",
+            dockerfile,
+            re.MULTILINE | re.DOTALL,
+        )
+        assert layer, "Dockerfile must run crawl4ai-setup"
+        positions = []
+        for command in (
+            "playwright install --with-deps chromium",
+            "crawl4ai-doctor",
+            "cp -r /root/.cache/ms-playwright/chromium-*",
+            "rm -rf /root/.cache/ms-playwright",
+            "-name '*.core' -delete",
         ):
-            layer = re.search(
-                rf"^RUN {re.escape(command)}(?P<body>(?:(?!^[A-Z]+\s).)*)",
-                dockerfile,
-                re.MULTILINE | re.DOTALL,
-            )
-            assert layer, f"Dockerfile must run {command}"
-            assert cleanup in layer.group(
+            assert command in layer.group(
                 "body"
-            ), f"{cleanup} must run in the {command} layer"
+            ), f"{command} must run in the crawl4ai-setup layer"
+            positions.append(layer.group("body").index(command))
+        assert positions == sorted(positions), "Docker build steps must remain ordered"
 
     def test_runs_as_non_root(self, dockerfile):
         assert re.search(r"^USER\s+appuser", dockerfile, re.MULTILINE)


### PR DESCRIPTION
## Summary

Fixes #2092.

Keep Playwright installation, runtime-cache copying, and root-cache cleanup in one Docker layer so the superseded root-owned browser cache is not committed to the image. Remove QEMU core dumps immediately after `crawl4ai-doctor`, before that layer is committed.

## List of files changed and why

- `Dockerfile` - clean duplicate Playwright data and doctor core dumps in the same layers that create them.
- `deploy/docker/tests/test_security_container_posture.py` - enforce both same-layer cleanup guarantees.

## How Has This Been Tested?

- `docker buildx build --check --progress plain .` — check complete, no warnings found.
- `.venv/bin/python -m pytest deploy/docker/tests/test_security_*.py -q` — 317 passed, 1 xfailed.
- `.venv/bin/black --check --target-version py312 deploy/docker/tests/test_security_container_posture.py` — passed.
- `.venv/bin/ruff check deploy/docker/tests/test_security_container_posture.py` — passed.
- `git diff --check` — passed.

A full multi-architecture image build was not run locally; the focused posture test verifies that each cleanup remains in the Docker layer that creates its artifact.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas — N/A; the cleanup commands and focused assertions are self-explanatory.
- [ ] I have made corresponding changes to the documentation — N/A; this changes image contents without changing user-facing behavior.
- [x] I have added/updated unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
