### PR TITLE
Fix builtin browser failing to start with 'NoneType' object has no attribute 'browser_type'

### DIFF
--- a/crawl4ai/browser_manager.py
+++ b/crawl4ai/browser_manager.py
@@ -159,6 +159,19 @@ class ManagedBrowser:
             cdp_url (str or None): CDP URL to connect to the browser. Default: None.
             browser_config (BrowserConfig): Configuration object containing all browser settings. Default: None.
         """
+        if browser_config is None:
+            # The legacy keyword arguments above are still part of this
+            # signature and are documented in the docstring; honour them
+            # instead of raising an opaque AttributeError on ``None``.
+            browser_config = BrowserConfig(
+                browser_type=browser_type,
+                user_data_dir=user_data_dir,
+                headless=headless,
+                host=host,
+                debugging_port=debugging_port,
+                cdp_url=cdp_url,
+            )
+
         self.browser_type = browser_config.browser_type
         self.user_data_dir = browser_config.user_data_dir
         self.headless = browser_config.headless

--- a/crawl4ai/browser_profiler.py
+++ b/crawl4ai/browser_profiler.py
@@ -1202,12 +1202,15 @@ class BrowserProfiler:
         os.makedirs(user_data_dir, exist_ok=True)
         
         # Create managed browser instance
-        managed_browser = ManagedBrowser(
+        browser_config = BrowserConfig(
             browser_type=browser_type,
             user_data_dir=user_data_dir,
             headless=headless,
+            debugging_port=debugging_port,
+        )
+        managed_browser = ManagedBrowser(
+            browser_config=browser_config,
             logger=self.logger,
-            debugging_port=debugging_port
         )
         
         try:


### PR DESCRIPTION
### Summary

`crwl browser start` and `BrowserProfiler.launch_builtin_browser()` fail unconditionally with:

```
Error starting builtin browser: 'NoneType' object has no attribute 'browser_type'
```

`ManagedBrowser.__init__` still declares — and documents — the legacy keyword
arguments (`browser_type`, `user_data_dir`, `headless`, `host`, `debugging_port`,
`cdp_url`), but its body reads every value from `browser_config`, which defaults
to `None`:

```python
def __init__(self, browser_type="chromium", user_data_dir=None, headless=False,
             logger=None, host="localhost", debugging_port=9222,
             cdp_url=None, browser_config: Optional[BrowserConfig] = None):
    ...
    self.browser_type = browser_config.browser_type   # AttributeError when None
```

`launch_builtin_browser()` is the one caller that still passes only the legacy
kwargs, so it raises every time. The two other call sites in the same file were
already migrated to `browser_config=` (the old kwargs are still sitting there
commented out), which suggests this one was simply missed during the refactor.

### Fix

Two small changes:

1. `browser_profiler.py` — `launch_builtin_browser()` now builds a `BrowserConfig`
   and passes it, matching the two sibling call sites in the same file.
2. `browser_manager.py` — `ManagedBrowser.__init__` falls back to the documented
   legacy keyword arguments when `browser_config is None`, instead of raising an
   opaque `AttributeError`. This keeps the published signature honest and protects
   any third-party code still calling it the old way.

### Reproduction

Before:

```console
$ crwl browser start
Error starting builtin browser: 'NoneType' object has no attribute 'browser_type'
```

After:

```console
$ crwl browser start
[BUILTIN]. ℹ Builtin browser launched at CDP URL: http://localhost:9222
╭─────────────────────── Builtin Browser Start ───────────────────────╮
│ Builtin browser started successfully                                │
│ CDP URL: http://localhost:9222                                      │
╰─────────────────────────────────────────────────────────────────────╯
```

`crwl browser status` / `crwl browser stop` and `BrowserConfig(browser_mode="builtin")`
work against the started instance afterwards.

Also verified that constructing `ManagedBrowser(...)` with only the legacy kwargs
no longer raises, and that passing `browser_config=` behaves exactly as before.

### Related issues

- #1139 — "error while starting browser service", same error message, reported
  against 0.6.3 via `crwl browser start`. Closed, but the failure still reproduces
  on `main`.
- #1142 — closed as a duplicate of #1139.

Verified against `main` at the time of writing: both the missing `browser_config`
in `launch_builtin_browser()` and the unconditional `browser_config.*` reads in
`ManagedBrowser.__init__` are still present.
