### PR TITLE
fix: restore upstream LiteLLM dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "aiosqlite~=0.20",
     "anyio>=4.0.0",
     "lxml>=5.3,<7",
-    "unclecode-litellm==1.81.13",
+    "litellm>=1.83.0,<1.92.0",
     "numpy>=1.26.0,<3",
     "pillow>=10.4",
     "playwright>=1.49.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ aiohttp>=3.11.11
 aiosqlite~=0.20
 anyio>=4.0.0
 lxml>=5.3,<7
-unclecode-litellm==1.81.13
+litellm>=1.83.0,<1.92.0
 numpy>=1.26.0,<3
 pillow>=10.4
 playwright>=1.49.0


### PR DESCRIPTION
## Summary

Fixes #2098.

Replace the `unclecode-litellm` fork with the upstream `litellm` distribution. The lower bound starts after the removed compromised releases, and the temporary `<1.92.0` bound keeps installs on the last universal wheel release; LiteLLM 1.92+ does not currently publish macOS wheels and otherwise requires a local Rust build.

## List of files changed and why

- `pyproject.toml` - Declare the safe upstream LiteLLM range in package metadata.
- `requirements.txt` - Keep development/install requirements synchronized with package metadata.

## How Has This Been Tested?

- `uvx --with 'packaging>=24.2' --from validate-pyproject validate-pyproject pyproject.toml`
- `uv pip compile pyproject.toml --no-deps --quiet` (resolves `litellm==1.91.4`)
- `uv run --python 3.12 --with toml python tests/check_dependencies.py`
- Imported both `crawl4ai` and upstream `litellm` from the resolved project environment.
- Built the wheel and verified its `Requires-Dist` metadata contains only `litellm<1.92.0,>=1.83.0`.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code is commented, particularly in hard-to-understand areas — N/A: no executable code changed
- [ ] I have made corresponding changes to the documentation — N/A: the dependency declarations are the affected configuration
- [ ] I have added/updated unit tests that prove my fix is effective or that my feature works — N/A: this is package metadata; wheel metadata and a resolved import were tested directly
- [x] New and existing relevant tests pass locally with my changes
