### PR TITLE
fix: only treat the base domain and its subdomains as internal

### DIFF
--- a/crawl4ai/utils.py
+++ b/crawl4ai/utils.py
@@ -2552,12 +2552,18 @@ def is_external_url(url: str, base_domain: str) -> bool:
         if not parsed.netloc:  # Relative URL
             return False
 
-        # Strip port and 'www.' from both domains for comparison
-        url_domain = parsed.netloc.lower().split(":")[0].replace("www.", "")
-        base = base_domain.lower().split(":")[0].replace("www.", "")
+        # Strip port and a leading 'www.' from both domains for comparison.
+        # removeprefix (not replace) so a host containing 'www.' somewhere
+        # other than the front is left untouched.
+        url_domain = parsed.netloc.lower().split(":")[0].removeprefix("www.")
+        base = base_domain.lower().split(":")[0].removeprefix("www.")
 
-        # Check if URL domain ends with base domain
-        return not url_domain.endswith(base)
+        # Internal means the base domain itself or one of its subdomains. A
+        # bare endswith(base) also matches look-alike domains that merely end
+        # with the base string (notexample.com for example.com), which are
+        # genuinely different sites an attacker can register.
+        is_internal = url_domain == base or url_domain.endswith(f".{base}")
+        return not is_internal
     except Exception:
         return False
 

--- a/tests/regression/test_reg_utils.py
+++ b/tests/regression/test_reg_utils.py
@@ -15,6 +15,7 @@ from crawl4ai.utils import (
     efficient_normalize_url_for_deep_crawl,
     sanitize_input_encode,
     generate_content_hash,
+    is_external_url,
 )
 from crawl4ai.cache_context import CacheContext, CacheMode
 
@@ -498,3 +499,48 @@ class TestImageScoring:
         """IMAGE_DESCRIPTION_MIN_WORD_THRESHOLD should exist."""
         from crawl4ai.config import IMAGE_DESCRIPTION_MIN_WORD_THRESHOLD
         assert isinstance(IMAGE_DESCRIPTION_MIN_WORD_THRESHOLD, (int, float))
+
+
+# ===================================================================
+# is_external_url
+# ===================================================================
+
+class TestIsExternalUrl:
+    """Verify is_external_url only treats the base domain and its subdomains
+    as internal, and does not mistake look-alike domains for internal ones."""
+
+    def test_base_domain_is_internal(self):
+        """The base domain itself is internal."""
+        assert is_external_url("http://example.com", "example.com") is False
+
+    def test_subdomain_is_internal(self):
+        """A real subdomain of the base domain is internal."""
+        assert is_external_url("http://blog.example.com", "example.com") is False
+
+    def test_www_is_internal(self):
+        """A leading www. is stripped, so www.example.com is internal."""
+        assert is_external_url("http://www.example.com", "example.com") is False
+
+    def test_prefixed_lookalike_is_external(self):
+        """A host that merely ends with the base string is a different site."""
+        assert is_external_url("http://malicious-example.com", "example.com") is True
+
+    def test_bare_lookalike_is_external(self):
+        """notexample.com is not a subdomain of example.com."""
+        assert is_external_url("http://notexample.com/path", "example.com") is True
+
+    def test_base_as_prefix_is_external(self):
+        """The base domain appearing as a prefix is a different site."""
+        assert is_external_url("http://example.com.evil.com", "example.com") is True
+
+    def test_unrelated_domain_is_external(self):
+        """An unrelated domain is external."""
+        assert is_external_url("http://other.org", "example.com") is True
+
+    def test_relative_url_is_internal(self):
+        """A relative URL has no netloc and is treated as internal."""
+        assert is_external_url("/path/page", "example.com") is False
+
+    def test_mailto_is_external(self):
+        """Non-http schemes such as mailto: are external."""
+        assert is_external_url("mailto:hi@example.com", "example.com") is True


### PR DESCRIPTION
is_external_url decided membership with a bare url_domain.endswith(base), so any host that merely ends with the base string was classified as internal: notexample.com and malicious-example.com both counted as part of example.com. base_domain comes from get_base_domain(), so those are genuinely different sites an attacker can register, and the result feeds link classification and the deep-crawl scope check - a crawl scoped to one domain could follow links onto look-alike domains.

Match what deep_crawling/filters.py and domain_mapper.py already do: internal means equal to the base domain or a dot-separated subdomain of it. Real subdomains (blog.example.com) and relative URLs are unchanged. The www. strip also moves from .replace("www.", "") to .removeprefix("www."), so a host with www. somewhere other than the front is not silently rewritten.

Adds TestIsExternalUrl to tests/regression/test_reg_utils.py covering the base domain, a subdomain, www., the two look-alike cases, the base domain as a prefix, an unrelated domain, a relative URL, and a mailto: link.

## Summary
Please include a summary of the change and/or which issues are fixed.

eg: `Fixes #123` (Tag GitHub issue numbers in this format, so it automatically links the issues with your PR)

## List of files changed and why
eg: quickstart.py - To update the example as per new changes

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added/updated unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
