### PR TITLE
fix(docker): preserve single-url crawl failure details

### DIFF
--- a/deploy/docker/api.py
+++ b/deploy/docker/api.py
@@ -92,6 +92,15 @@ import psutil, time
 
 logger = logging.getLogger(__name__)
 
+
+def _raise_for_crawl_failure(result):
+    if not result.success:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=result.error_message,
+        )
+
+
 # --- Helper to get memory ---
 def _get_memory_mb():
     try:
@@ -147,11 +156,7 @@ async def handle_llm_qa(
         enforce_egress(browser_cfg)
         crawler = await get_crawler(browser_cfg)
         result = await crawler.arun(url)
-        if not result.success:
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail=result.error_message
-            )
+        _raise_for_crawl_failure(result)
         content = result.markdown.fit_markdown or result.markdown.raw_markdown
 
         # Create prompt and get LLM response
@@ -179,6 +184,8 @@ async def handle_llm_qa(
         )
 
         return response.choices[0].message.content
+    except HTTPException:
+        raise
     except LLMProviderNotAllowed as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
@@ -389,11 +396,7 @@ async def handle_markdown_request(
             )
         )
 
-        if not result.success:
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail=result.error_message
-            )
+        _raise_for_crawl_failure(result)
 
         return (result.markdown.raw_markdown
                if filter_type == FilterType.RAW

--- a/deploy/docker/tests/test_api_crawl_failures.py
+++ b/deploy/docker/tests/test_api_crawl_failures.py
@@ -1,10 +1,9 @@
-import inspect
 from types import SimpleNamespace
 
 import pytest
 from fastapi import HTTPException
 
-from api import _raise_for_crawl_failure, handle_llm_qa, handle_markdown_request
+from api import _raise_for_crawl_failure
 
 
 def test_crawl_failure_is_reported_as_bad_gateway():
@@ -17,8 +16,43 @@ def test_crawl_failure_is_reported_as_bad_gateway():
     assert raised.value.detail == result.error_message
 
 
-@pytest.mark.parametrize("handler", [handle_llm_qa, handle_markdown_request])
-def test_single_url_handlers_use_crawl_failure_mapping(handler):
-    source = inspect.getsource(handler)
-    assert "_raise_for_crawl_failure(result)" in source
-    assert handler is not handle_llm_qa or "except HTTPException:" in source
+@pytest.mark.parametrize(
+    ("method", "path", "payload"),
+    [
+        ("post", "/md", {"url": "https://example.com", "f": "raw"}),
+        ("get", "/llm/example.com?q=summarize", None),
+    ],
+)
+def test_single_url_crawl_failure_reaches_client(
+    stock_client, server_module, monkeypatch, method, path, payload
+):
+    error_message = "Blocked by anti-bot protection: challenge"
+    failed_result = SimpleNamespace(success=False, error_message=error_message)
+
+    class FailedCrawler:
+        async def arun(self, *args, **kwargs):
+            return failed_result
+
+    async def get_failed_crawler(*args, **kwargs):
+        return FailedCrawler()
+
+    async def release_crawler(*args, **kwargs):
+        return None
+
+    import api
+    import crawler_pool
+    from auth import create_access_token
+
+    monkeypatch.setattr(api, "validate_url_destination", lambda url: None)
+    monkeypatch.setattr(crawler_pool, "get_crawler", get_failed_crawler)
+    monkeypatch.setattr(crawler_pool, "release_crawler", release_crawler)
+
+    token = create_access_token({"sub": "test@example.com"})
+    request = getattr(stock_client, method)
+    kwargs = {"json": payload} if payload is not None else {}
+    response = request(
+        path, headers={"Authorization": f"Bearer {token}"}, **kwargs
+    )
+
+    assert response.status_code == 502
+    assert response.json() == {"detail": error_message}

--- a/deploy/docker/tests/test_api_crawl_failures.py
+++ b/deploy/docker/tests/test_api_crawl_failures.py
@@ -1,0 +1,24 @@
+import inspect
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from api import _raise_for_crawl_failure, handle_llm_qa, handle_markdown_request
+
+
+def test_crawl_failure_is_reported_as_bad_gateway():
+    result = SimpleNamespace(success=False, error_message="Blocked by anti-bot protection: challenge")
+
+    with pytest.raises(HTTPException) as raised:
+        _raise_for_crawl_failure(result)
+
+    assert raised.value.status_code == 502
+    assert raised.value.detail == result.error_message
+
+
+@pytest.mark.parametrize("handler", [handle_llm_qa, handle_markdown_request])
+def test_single_url_handlers_use_crawl_failure_mapping(handler):
+    source = inspect.getsource(handler)
+    assert "_raise_for_crawl_failure(result)" in source
+    assert handler is not handle_llm_qa or "except HTTPException:" in source


### PR DESCRIPTION
## Summary

Fixes #2116

Treat unsuccessful crawls from the single-URL `/md` and `/llm/{url}` handlers as upstream failures (`502 Bad Gateway`) so the existing exception handler preserves `error_message` instead of replacing it with an opaque internal-server-error response. The LLM handler now also preserves deliberate `HTTPException` statuses. This changes those two failure responses from HTTP 500 to HTTP 502.

## List of files changed and why

- `deploy/docker/api.py` - centralize unsuccessful crawl handling and return a detail-preserving 502 from both single-URL handlers.
- `deploy/docker/tests/test_api_crawl_failures.py` - verify the helper mapping and exercise authenticated `/md` and `/llm/{url}` requests through the real FastAPI app, with a mocked failing crawler.

## How Has This Been Tested?

- `/tmp/crawl4ai-followup-venv/bin/python -m pytest deploy/docker/tests/test_api_crawl_failures.py deploy/docker/tests/test_security_headers_xss.py::TestErrorSanitization -q` — 5 passed, 4 existing warnings.
- `/tmp/crawl4ai-followup-venv/bin/ruff check --isolated --select E9,F63,F7,F82 deploy/docker/api.py deploy/docker/tests/test_api_crawl_failures.py` — passed.
- `/tmp/crawl4ai-followup-venv/bin/python -m compileall -q deploy/docker/api.py deploy/docker/tests/test_api_crawl_failures.py` — passed.
- `git diff --check` — passed.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (N/A: no complex logic was introduced)
- [x] I have made corresponding changes to the documentation (N/A: the behavioral status change is called out in this PR description)
- [x] I have added/updated unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
