### PR TITLE
fix(docker-api): apply base_config to fields the client did not send

### DIFF
--- a/deploy/docker/api.py
+++ b/deploy/docker/api.py
@@ -644,6 +644,19 @@ def _normalize_and_validate_seeds(urls: List[str]) -> List[str]:
     return urls
 
 
+def _apply_base_config(cfg, base_config: dict, raw: Optional[dict]) -> None:
+    """Apply the server-side base_config to fields absent from the raw payload.
+
+    Only the raw keys tell "omitted" apart from "sent, equal to the default" —
+    a default of False or 0 is indistinguishable from unset once loaded. The
+    payload is either a flat dict or {"type": ..., "params": {...}}.
+    """
+    provided = set(raw.get("params", raw)) if raw else set()
+    for key, value in base_config.items():
+        if key not in provided and hasattr(cfg, key):
+            setattr(cfg, key, value)
+
+
 async def handle_crawl_request(
     urls: List[str],
     browser_config: dict,
@@ -671,6 +684,7 @@ async def handle_crawl_request(
 
     try:
         urls = _normalize_and_validate_seeds(urls)
+        raw_crawler_config = crawler_config
         browser_config = BrowserConfig.load(browser_config, provenance=Provenance.UNTRUSTED)
         crawler_config = CrawlerRunConfig.load(crawler_config, provenance=Provenance.UNTRUSTED)
         from egress_broker import enforce_egress
@@ -700,20 +714,12 @@ async def handle_crawl_request(
         if crawler_configs and len(urls) > 1:
             # Per-URL config list: deserialize each and apply base_config
             config_list = [CrawlerRunConfig.load(cc, provenance=Provenance.UNTRUSTED) for cc in crawler_configs]
-            for cfg in config_list:
-                for key, value in base_config.items():
-                    if hasattr(cfg, key):
-                        current_value = getattr(cfg, key)
-                        if current_value is None or current_value == "":
-                            setattr(cfg, key, value)
+            for cfg, raw in zip(config_list, crawler_configs):
+                _apply_base_config(cfg, base_config, raw)
             effective_config = config_list
         else:
             # Single config (original behavior)
-            for key, value in base_config.items():
-                if hasattr(crawler_config, key):
-                    current_value = getattr(crawler_config, key)
-                    if current_value is None or current_value == "":
-                        setattr(crawler_config, key, value)
+            _apply_base_config(crawler_config, base_config, raw_crawler_config)
             effective_config = crawler_config
 
         results = []

--- a/tests/test_base_config_defaults.py
+++ b/tests/test_base_config_defaults.py
@@ -1,0 +1,37 @@
+"""Regression tests: crawler.base_config must apply to fields the client omitted.
+
+The old guard treated only None/"" as "not provided", so any base_config key
+whose CrawlerRunConfig default is False or 0 (simulate_user, magic,
+override_navigator, check_robots_txt, ...) was silently dropped.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'deploy', 'docker'))
+
+from crawl4ai import CrawlerRunConfig
+from crawl4ai.async_configs import Provenance
+from api import _apply_base_config
+
+
+def test_boolean_base_config_applies_when_client_omits():
+    cfg = CrawlerRunConfig()
+    _apply_base_config(cfg, {"simulate_user": True}, None)
+    assert cfg.simulate_user is True
+
+
+def test_client_value_wins():
+    """#1505: an explicitly sent value must not be clobbered by base_config.
+
+    Uses check_robots_txt because simulate_user is forbidden on untrusted
+    bodies — base_config is the only way that one is ever set.
+    """
+    raw = {"type": "CrawlerRunConfig", "params": {"check_robots_txt": False}}
+    cfg = CrawlerRunConfig.load(raw, provenance=Provenance.UNTRUSTED)
+    _apply_base_config(cfg, {"check_robots_txt": True}, raw)
+    assert cfg.check_robots_txt is False
+
+    flat = CrawlerRunConfig()
+    _apply_base_config(flat, {"check_robots_txt": True}, {"check_robots_txt": False})
+    assert flat.check_robots_txt is False

--- a/tests/test_issue_1837_config_list.py
+++ b/tests/test_issue_1837_config_list.py
@@ -105,7 +105,7 @@ class TestConfigListLogic:
         """Base config should be applied to each config in the list."""
         with open("deploy/docker/api.py") as f:
             source = f.read()
-        assert "for cfg in config_list:" in source
+        assert "for cfg, raw in zip(config_list, crawler_configs):" in source
 
 
 # -- Server endpoint passes crawler_configs --


### PR DESCRIPTION
## Summary

Fixes #2121

`crawler.base_config` never applies to a field whose `CrawlerRunConfig` default is `False` or `0`.
The guard from a1950af (#1505) reads "the client didn't send this" as "the loaded attribute is `None` or `""`":

```python
current_value = getattr(crawler_config, key)
if current_value is None or current_value == "":   # api.py:715
    setattr(crawler_config, key, value)
```

`simulate_user` defaults to `False`, so the `setattr` is skipped and the stock image has never honored its own `config.yml`.
Same for `magic`, `override_navigator`, `check_robots_txt`, `remove_overlay_elements`, `page_timeout`.

Dropping the guard would bring #1505 back.
After `CrawlerRunConfig.load()` nothing tells "omitted" apart from "sent, equal to the default".
Only the raw request dict still knows, so the fix reads the keys the client actually sent:

```python
def _apply_base_config(cfg, base_config: dict, raw: Optional[dict]) -> None:
    provided = set(raw.get("params", raw)) if raw else set()
    for key, value in base_config.items():
        if key not in provided and hasattr(cfg, key):
            setattr(cfg, key, value)
```

This handles both payload shapes, the flat dict and `{"type": ..., "params": {...}}`, without sniffing the type: `CrawlerRunConfig` has no field named `params`.
Both call sites now share the helper instead of duplicating the guard.

Behavior change: the stock image now runs with `simulate_user` on for the first time, so crawls get slower.
That is what `config.yml` has always asked for, but existing deployments will feel it.
Happy to drop `simulate_user` from the shipped default config in this PR if you'd rather it land with no visible change.

## List of files changed and why
- `deploy/docker/api.py`: the fix. Adds `_apply_base_config()`, captures the raw dict before `CrawlerRunConfig.load()` overwrites the name, and replaces both copies of the guard.
- `tests/test_base_config_defaults.py` (new): a regression test for the boolean case plus a non-regression test for #1505 (client value still wins), covering both payload shapes.
  No browser or server needed.
- `tests/test_issue_1837_config_list.py`: it greps `api.py` for the literal `"for cfg in config_list:"`, which becomes `for cfg, raw in zip(config_list, crawler_configs):`, so I updated the string.
  `config_list` is a 1:1 comprehension over `crawler_configs`, so the zip is safe.

## How Has This Been Tested?
```bash
pytest tests/test_base_config_defaults.py tests/test_issue_1837_config_list.py
# 16 passed
```

Also against a local Docker build with the stock `config.yml`: `POST /crawl` with `{"urls": ["https://example.com"]}` and no `crawler_config` gives `effective_config.simulate_user == False` before the fix and `True` after.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added/updated unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
