### PR TITLE
Updated Docker README.md versions

### DIFF
--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -63,7 +63,7 @@ Our latest stable release is `0.9.2`. Images are built with multi-arch manifests
 
 ```bash
 # Pull the latest stable version (0.9.2)
-docker pull unclecode/crawl4ai:0.8.6
+docker pull unclecode/crawl4ai:0.9.2
 
 # Or use the latest tag
 docker pull unclecode/crawl4ai:latest
@@ -100,7 +100,7 @@ EOL
       -p 11235:11235 \
       --name crawl4ai \
       --shm-size=1g \
-      unclecode/crawl4ai:0.8.6
+      unclecode/crawl4ai:latest
     ```
 
 *   **With LLM support:**
@@ -111,7 +111,7 @@ EOL
       --name crawl4ai \
       --env-file .llm.env \
       --shm-size=1g \
-      unclecode/crawl4ai:0.8.6
+      unclecode/crawl4ai:latest
     ```
 
 > The server will be available at `http://localhost:11235`. Visit `/playground` to access the interactive testing interface.
@@ -184,7 +184,7 @@ The `docker-compose.yml` file in the project root provides a simplified approach
     ```bash
     # Pulls and runs the release candidate from Docker Hub
     # Automatically selects the correct architecture
-    IMAGE=unclecode/crawl4ai:0.8.6 docker compose up -d
+    IMAGE=unclecode/crawl4ai:latest docker compose up -d
     ```
 
 *   **Build and Run Locally:**


### PR DESCRIPTION
## Summary

A couple of places in the docker deployment README.md did not have correct version numbers. For examples that showcase exact versions, I updated them to the latest version number, for examples that showcase something else, I defaulted to using latest tag to avoid this issue in the future.

## List of files changed and why
deploy/docker/README.md - Doc was inconsistent with version numbers.

## How Has This Been Tested?
No, the only changes were to the documentation file.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added/updated unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
