### PR TITLE
fix(content-filter): honor preserve whitelist for excluded tags

### DIFF
--- a/crawl4ai/content_filter_strategy.py
+++ b/crawl4ai/content_filter_strategy.py
@@ -580,8 +580,10 @@ class PruningContentFilter(RelevantContentFilter):
             min_word_threshold (int): Minimum word threshold for filtering (optional).
             threshold_type (str): Threshold type for dynamic threshold (default: 'fixed').
             threshold (float): Fixed threshold value (default: 0.48).
-            preserve_classes (list): CSS class names to always keep regardless of score (optional).
-            preserve_tags (list): HTML tag names to always keep regardless of score (optional).
+            preserve_classes (list): CSS class names to always keep, regardless of score
+                or of the element being an excluded tag (optional).
+            preserve_tags (list): HTML tag names to always keep, regardless of score
+                or of the tag being excluded by default (optional).
         """
         super().__init__(None)
         self.min_word_threshold = min_word_threshold
@@ -683,9 +685,9 @@ class PruningContentFilter(RelevantContentFilter):
             element.extract()
 
     def _remove_unwanted_tags(self, soup):
-        """Removes unwanted tags"""
-        for tag in self.excluded_tags:
-            for element in soup.find_all(tag):
+        """Removes unwanted tags, except the ones on the preserve whitelist"""
+        for element in soup.find_all(list(self.excluded_tags)):
+            if not self._is_preserved(element):
                 element.decompose()
 
     def _is_preserved(self, node):

--- a/tests/test_pruning_preserve_whitelist_1900.py
+++ b/tests/test_pruning_preserve_whitelist_1900.py
@@ -201,14 +201,20 @@ class TestCombined:
         assert "alice" in combined
         assert "Apr 6, 2026" in combined
 
-    def test_whitelist_does_not_override_excluded_tags(self):
-        """Nav/footer/header are removed before pruning — whitelist can't save them."""
+    def test_whitelist_overrides_excluded_tags(self):
+        """A whitelisted tag survives even when it is in excluded_tags."""
         f = PruningContentFilter(preserve_tags=["nav"])
-        result = f.filter_content(GITHUB_COMMENT_HTML)
-        combined = " ".join(result)
-        # nav is in excluded_tags and removed before pruning runs
-        # preserve_tags only affects the pruning phase
-        # This is expected — excluded_tags are structural boilerplate
+        combined = " ".join(f.filter_content(GITHUB_COMMENT_HTML))
+        assert "About" in combined
+        # non-whitelisted excluded tags are still dropped
+        assert "Copyright 2026" not in combined
+
+    def test_whitelisted_class_on_excluded_tag(self):
+        """A whitelisted class saves an excluded tag too."""
+        f = PruningContentFilter(preserve_classes=["site-footer"])
+        combined = " ".join(f.filter_content(GITHUB_COMMENT_HTML))
+        assert "Copyright 2026" in combined
+        assert "About" not in combined
 
 
 # ── _is_preserved method ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Fixes #2125

`_remove_unwanted_tags` decomposed by tag name, so `preserve_tags` and `preserve_classes` never reached elements whose tag is in `excluded_tags`.
It now iterates elements and skips the ones `_is_preserved()` matches, so both whitelists go through the guard that already existed.

This changes semantics for `script` and `style`, which are in `excluded_tags` too: `preserve_tags=["script"]` now really keeps them.
A user has to name the tag to get that, so I did not special-case it.

## List of files changed and why
- `crawl4ai/content_filter_strategy.py` - filter by element instead of tag name in `_remove_unwanted_tags` so the whitelist is consulted; docstring updated to say the whitelist also overrides `excluded_tags`.
- `tests/test_pruning_preserve_whitelist_1900.py` - the old `test_whitelist_does_not_override_excluded_tags` asserted nothing and documented the bug as expected, so I inverted it, and added a case for a whitelisted class on an excluded tag.

## How Has This Been Tested?
`pytest tests/test_pruning_preserve_whitelist_1900.py` - 21 passed.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added/updated unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
