### PR TITLE
fix(docker): add pypdf and honor stream scraping strategy

### DIFF
--- a/deploy/docker/api.py
+++ b/deploy/docker/api.py
@@ -865,15 +865,20 @@ async def handle_stream_crawl_request(
         # mirroring handle_crawl_request. The streaming path previously skipped
         # this, leaving /crawl/stream (and /crawl with stream=true) unguarded.
         urls = _normalize_and_validate_seeds(urls)
-        browser_config = BrowserConfig.load(browser_config, provenance=Provenance.UNTRUSTED)
+        browser_config = BrowserConfig.load(
+            browser_config, provenance=Provenance.UNTRUSTED
+        )
         # browser_config.verbose = True # Set to False or remove for production stress testing
         browser_config.verbose = False
         from egress_broker import enforce_egress
+
         enforce_egress(browser_config)
-        crawler_config = CrawlerRunConfig.load(crawler_config, provenance=Provenance.UNTRUSTED)
+        crawler_config = CrawlerRunConfig.load(
+            crawler_config, provenance=Provenance.UNTRUSTED
+        )
         from governor import clamp_deep_crawl
+
         clamp_deep_crawl(crawler_config)
-        crawler_config.scraping_strategy = LXMLWebScrapingStrategy()
         crawler_config.stream = True
 
         # Deep crawl streaming supports exactly one start URL
@@ -941,7 +946,7 @@ async def handle_stream_crawl_request(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=str(e)
         )
-        
+
 async def handle_crawl_job(
     redis,
     background_tasks: BackgroundTasks,

--- a/deploy/docker/requirements.txt
+++ b/deploy/docker/requirements.txt
@@ -14,3 +14,4 @@ PyJWT==2.10.1
 mcp>=1.18.0
 websockets>=15.0.1
 httpx[http2]>=0.27.2
+pypdf

--- a/deploy/docker/requirements.txt
+++ b/deploy/docker/requirements.txt
@@ -14,4 +14,4 @@ PyJWT==2.10.1
 mcp>=1.18.0
 websockets>=15.0.1
 httpx[http2]>=0.27.2
-pypdf
+pypdf>=6.0.0

--- a/tests/test_issue_2127_docker_pdf.py
+++ b/tests/test_issue_2127_docker_pdf.py
@@ -1,31 +1,71 @@
-import ast
+import importlib
 from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from packaging.requirements import InvalidRequirement, Requirement
+
+from crawl4ai.processors.pdf import PDFContentScrapingStrategy
 
 ROOT = Path(__file__).resolve().parent.parent
 
 
 def test_default_docker_dependencies_include_pypdf():
-    requirements = (
-        (ROOT / "deploy" / "docker" / "requirements.txt").read_text().splitlines()
-    )
+    lines = (ROOT / "deploy" / "docker" / "requirements.txt").read_text().splitlines()
+    names = set()
+    for line in lines:
+        line = line.strip()
+        if not line or line.startswith(("#", "-")):
+            continue
+        try:
+            names.add(Requirement(line).name)
+        except InvalidRequirement:
+            continue
 
-    assert "pypdf" in requirements
+    assert "pypdf" in names
 
 
-def test_stream_handler_preserves_requested_scraping_strategy():
-    tree = ast.parse((ROOT / "deploy" / "docker" / "api.py").read_text())
-    handler = next(
-        node
-        for node in tree.body
-        if isinstance(node, ast.AsyncFunctionDef)
-        and node.name == "handle_stream_crawl_request"
-    )
-    assigned_attributes = {
-        target.attr
-        for node in ast.walk(handler)
-        if isinstance(node, ast.Assign)
-        for target in node.targets
-        if isinstance(target, ast.Attribute)
+@pytest.mark.asyncio
+async def test_stream_handler_preserves_requested_scraping_strategy(monkeypatch):
+    docker_dir = ROOT / "deploy" / "docker"
+    monkeypatch.syspath_prepend(str(docker_dir))
+
+    api = importlib.import_module("api")
+    crawler_pool = importlib.import_module("crawler_pool")
+    egress_broker = importlib.import_module("egress_broker")
+    governor = importlib.import_module("governor")
+
+    crawler = MagicMock()
+    crawler.arun_many = AsyncMock(return_value=MagicMock())
+    monkeypatch.setattr(api, "_normalize_and_validate_seeds", lambda urls: urls)
+    monkeypatch.setattr(egress_broker, "enforce_egress", lambda _: None)
+    monkeypatch.setattr(governor, "clamp_deep_crawl", lambda _: None)
+    monkeypatch.setattr(crawler_pool, "get_crawler", AsyncMock(return_value=crawler))
+
+    crawler_config = {
+        "type": "CrawlerRunConfig",
+        "params": {
+            "cache_mode": "bypass",
+            "stream": False,
+            "scraping_strategy": {
+                "type": "PDFContentScrapingStrategy",
+                "params": {"extract_images": False, "batch_size": 8},
+            },
+        },
+    }
+    config = {
+        "crawler": {
+            "memory_threshold_percent": 90,
+            "rate_limiter": {"base_delay": [0.1, 0.3]},
+        }
     }
 
-    assert "scraping_strategy" not in assigned_attributes
+    await api.handle_stream_crawl_request(
+        urls=["https://example.com/document.pdf"],
+        browser_config={"type": "BrowserConfig", "params": {}},
+        crawler_config=crawler_config,
+        config=config,
+    )
+
+    effective_config = crawler.arun_many.await_args.kwargs["config"]
+    assert isinstance(effective_config.scraping_strategy, PDFContentScrapingStrategy)

--- a/tests/test_issue_2127_docker_pdf.py
+++ b/tests/test_issue_2127_docker_pdf.py
@@ -1,0 +1,31 @@
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_default_docker_dependencies_include_pypdf():
+    requirements = (
+        (ROOT / "deploy" / "docker" / "requirements.txt").read_text().splitlines()
+    )
+
+    assert "pypdf" in requirements
+
+
+def test_stream_handler_preserves_requested_scraping_strategy():
+    tree = ast.parse((ROOT / "deploy" / "docker" / "api.py").read_text())
+    handler = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.AsyncFunctionDef)
+        and node.name == "handle_stream_crawl_request"
+    )
+    assigned_attributes = {
+        target.attr
+        for node in ast.walk(handler)
+        if isinstance(node, ast.Assign)
+        for target in node.targets
+        if isinstance(target, ast.Attribute)
+    }
+
+    assert "scraping_strategy" not in assigned_attributes


### PR DESCRIPTION
## Summary

Addresses part of #2127 without closing it.

The default Docker image now installs the PDF processor dependency, and the streaming crawl handler preserves the scraping strategy supplied by the client instead of replacing it with `LXMLWebScrapingStrategy`.

This PR does not resolve the remaining Chromium navigation failure when a PDF response triggers a download. That behavior remains tracked in #2127 (and is related to #1367).

## List of files changed and why

- `deploy/docker/requirements.txt` - Install `pypdf>=6.0.0` in the default Docker image, matching the root requirement.
- `deploy/docker/api.py` - Preserve the deserialized scraping strategy for streaming crawls.
- `tests/test_issue_2127_docker_pdf.py` - Parse Docker requirement names robustly and behaviorally verify that the real stream handler passes a requested `PDFContentScrapingStrategy` to the crawler.

## How Has This Been Tested?

- `.venv/bin/pytest -q tests/test_issue_2127_docker_pdf.py tests/test_pr_1795_1798_1734.py::TestDeepCrawlStreamBranching` (7 passed)
- `.venv/bin/black --check --target-version py312 --fast tests/test_issue_2127_docker_pdf.py`
- `.venv/bin/python -m py_compile tests/test_issue_2127_docker_pdf.py deploy/docker/api.py`
- `uv pip install --dry-run --python .venv/bin/python -r deploy/docker/requirements.txt`
- `git diff --check`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas — N/A; the change is straightforward and the regression tests are named descriptively.
- [ ] I have made corresponding changes to the documentation — N/A; this restores documented Docker API behavior and explicitly leaves the remaining navigation bug tracked in the issue.
- [x] I have added/updated unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
