### PR TITLE
fix(config): make body visibility timeout configurable

### DIFF
--- a/crawl4ai/async_configs.py
+++ b/crawl4ai/async_configs.py
@@ -244,6 +244,7 @@ UNTRUSTED_FIELD_ALLOWLIST = {
         "fetch_ssl_certificate",
         # timing / waiting
         "wait_until", "page_timeout", "wait_for", "wait_for_timeout",
+        "body_visibility_timeout",
         "wait_for_images", "delay_before_return_html", "mean_delay", "max_range",
         # scrolling / rendering
         "ignore_body_visibility", "scan_full_page", "scroll_delay",
@@ -1463,6 +1464,8 @@ class CrawlerRunConfig():
                         Default: False.
         ignore_body_visibility (bool): If True, ignore whether the body is visible before proceeding.
                                        Default: True.
+        body_visibility_timeout (int): Maximum time in ms to wait for the body to become visible.
+                                       Default: 30000.
         scan_full_page (bool): If True, scroll through the entire page to load all content.
                                Default: False.
         scroll_delay (float): Delay in seconds between scroll steps if scan_full_page is True.
@@ -1640,6 +1643,7 @@ class CrawlerRunConfig():
         c4a_script: Union[str, List[str]] = None,
         js_only: bool = False,
         ignore_body_visibility: bool = True,
+        body_visibility_timeout: int = 30000,
         scan_full_page: bool = False,
         scroll_delay: float = 0.2,
         max_scroll_steps: Optional[int] = None,
@@ -1770,6 +1774,7 @@ class CrawlerRunConfig():
         self.c4a_script = c4a_script
         self.js_only = js_only
         self.ignore_body_visibility = ignore_body_visibility
+        self.body_visibility_timeout = body_visibility_timeout
         self.scan_full_page = scan_full_page
         self.scroll_delay = scroll_delay
         self.max_scroll_steps = max_scroll_steps
@@ -2137,6 +2142,7 @@ class CrawlerRunConfig():
             "js_code_before_wait": self.js_code_before_wait,
             "js_only": self.js_only,
             "ignore_body_visibility": self.ignore_body_visibility,
+            "body_visibility_timeout": self.body_visibility_timeout,
             "scan_full_page": self.scan_full_page,
             "scroll_delay": self.scroll_delay,
             "max_scroll_steps": self.max_scroll_steps,

--- a/crawl4ai/async_configs.py
+++ b/crawl4ai/async_configs.py
@@ -300,7 +300,7 @@ def _clamp_untrusted(type_name: str, params: dict) -> dict:
         return min(int(v), _MAX_TIMEOUT_MS)
 
     if type_name == "CrawlerRunConfig":
-        for f in ("page_timeout", "wait_for_timeout"):
+        for f in ("page_timeout", "wait_for_timeout", "body_visibility_timeout"):
             if f in params:
                 params[f] = _cap_timeout(params[f])
         if isinstance(params.get("max_scroll_steps"), int):
@@ -1774,6 +1774,12 @@ class CrawlerRunConfig():
         self.c4a_script = c4a_script
         self.js_only = js_only
         self.ignore_body_visibility = ignore_body_visibility
+        if (
+            not isinstance(body_visibility_timeout, (int, float))
+            or isinstance(body_visibility_timeout, bool)
+            or body_visibility_timeout <= 0
+        ):
+            raise ValueError("body_visibility_timeout must be a positive number")
         self.body_visibility_timeout = body_visibility_timeout
         self.scan_full_page = scan_full_page
         self.scroll_delay = scroll_delay

--- a/crawl4ai/async_crawler_strategy.py
+++ b/crawl4ai/async_crawler_strategy.py
@@ -823,7 +823,7 @@ class AsyncPlaywrightCrawlerStrategy(AsyncCrawlerStrategy):
                                         style.opacity !== '0';
                         return isVisible;
                     }""",
-                    timeout=30000,
+                    timeout=config.body_visibility_timeout,
                 )
 
                 if not is_visible and not config.ignore_body_visibility:

--- a/docs/md_v2/api/parameters.md
+++ b/docs/md_v2/api/parameters.md
@@ -159,6 +159,7 @@ Use these for controlling whether you read or write from a local content cache. 
 | **`c4a_script`**           | `str or list[str]` (None)      | C4A script that compiles to JavaScript. Alternative to writing raw JS.                                                                 |
 | **`js_only`**              | `bool` (False)                 | If `True`, indicates we're reusing an existing session and only applying JS. No full reload.                                           |
 | **`ignore_body_visibility`** | `bool` (True)                | Skip checking if `<body>` is visible. Usually best to keep `True`.                                                                     |
+| **`body_visibility_timeout`** | `int` (30000)               | Maximum time in milliseconds to wait for `<body>` to become visible. Must be positive.                                                  |
 | **`scan_full_page`**       | `bool` (False)                 | If `True`, auto-scroll the page to load dynamic content (infinite scroll).                                                              |
 | **`scroll_delay`**         | `float` (0.2)                  | Delay between scroll steps when scanning the full page (`scan_full_page=True`) or capturing full-page screenshots. |
 | **`max_scroll_steps`**     | `int or None` (None)           | Maximum number of scroll steps during full page scan. If None, scrolls until entire page is loaded.                                     |

--- a/docs/md_v2/complete-sdk-reference.md
+++ b/docs/md_v2/complete-sdk-reference.md
@@ -1791,6 +1791,7 @@ run_cfg = CrawlerRunConfig(
 | **`js_code_before_wait`**  | `str or list[str]` (None)      | JavaScript to run **before** `wait_for`. Use for triggering loading that `wait_for` then checks.                                       |
 | **`js_only`**              | `bool` (False)                 | If `True`, indicates we're reusing an existing session and only applying JS. No full reload.                                           |
 | **`ignore_body_visibility`** | `bool` (True)                | Skip checking if `<body>` is visible. Usually best to keep `True`.                                                                     |
+| **`body_visibility_timeout`** | `int` (30000)               | Maximum time in milliseconds to wait for `<body>` to become visible. Must be positive.                                                  |
 | **`scan_full_page`**       | `bool` (False)                 | If `True`, auto-scroll the page to load dynamic content (infinite scroll).                                                              |
 | **`scroll_delay`**         | `float` (0.2)                  | Delay between scroll steps when scanning the full page (`scan_full_page=True`) or capturing full-page screenshots. |
 | **`process_iframes`**      | `bool` (False)                 | Inlines iframe content for single-page extraction.                                                                                     |

--- a/tests/test_config_defaults.py
+++ b/tests/test_config_defaults.py
@@ -226,13 +226,17 @@ class TestDumpLoad:
         assert loaded.headless is False
 
     def test_crawler_run_config_dump_load(self):
-        CrawlerRunConfig.set_defaults(verbose=False, scan_full_page=True)
+        assert CrawlerRunConfig().body_visibility_timeout == 30000
+        CrawlerRunConfig.set_defaults(
+            verbose=False, scan_full_page=True, body_visibility_timeout=2000
+        )
         cfg = CrawlerRunConfig()
         data = cfg.dump()
         CrawlerRunConfig.reset_defaults()
         loaded = CrawlerRunConfig.load(data)
         assert loaded.verbose is False
         assert loaded.scan_full_page is True
+        assert loaded.body_visibility_timeout == 2000
 
     def test_to_dict_includes_user_default_values(self):
         BrowserConfig.set_defaults(headless=False)

--- a/tests/test_config_defaults.py
+++ b/tests/test_config_defaults.py
@@ -1,7 +1,12 @@
 """Tests for BrowserConfig.set_defaults / CrawlerRunConfig.set_defaults."""
 
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
+
 from crawl4ai.async_configs import BrowserConfig, CrawlerRunConfig
+from crawl4ai.async_crawler_strategy import AsyncPlaywrightCrawlerStrategy
 
 
 @pytest.fixture(autouse=True)
@@ -237,6 +242,46 @@ class TestDumpLoad:
         assert loaded.verbose is False
         assert loaded.scan_full_page is True
         assert loaded.body_visibility_timeout == 2000
+
+    @pytest.mark.parametrize("timeout", [None, 0, -1, "1000", True])
+    def test_body_visibility_timeout_must_be_positive_number(self, timeout):
+        with pytest.raises(ValueError, match="must be a positive number"):
+            CrawlerRunConfig(body_visibility_timeout=timeout)
+
+    def test_untrusted_body_visibility_timeout_is_clamped(self):
+        from crawl4ai.async_configs import Provenance
+
+        config = CrawlerRunConfig.load(
+            {"body_visibility_timeout": 500_000}, provenance=Provenance.UNTRUSTED
+        )
+        assert config.body_visibility_timeout == 60_000
+
+    @pytest.mark.asyncio
+    async def test_body_visibility_timeout_reaches_wait(self):
+        page = MagicMock()
+        page.evaluate = AsyncMock()
+        page.set_content = AsyncMock()
+        page.wait_for_selector = AsyncMock()
+        page.content = AsyncMock(return_value="<body>visible</body>")
+
+        strategy = AsyncPlaywrightCrawlerStrategy.__new__(
+            AsyncPlaywrightCrawlerStrategy
+        )
+        strategy.browser_config = SimpleNamespace(
+            use_persistent_context=False, accept_downloads=False, text_mode=True
+        )
+        strategy.browser_manager = SimpleNamespace(
+            get_page=AsyncMock(return_value=(page, MagicMock()))
+        )
+        strategy.execute_hook = AsyncMock()
+        strategy.csp_compliant_wait = AsyncMock(return_value=True)
+
+        config = CrawlerRunConfig(
+            session_id="body-timeout-test", body_visibility_timeout=1234
+        )
+        await strategy._crawl_web("raw:<body>visible</body>", config)
+
+        assert strategy.csp_compliant_wait.await_args.kwargs["timeout"] == 1234
 
     def test_to_dict_includes_user_default_values(self):
         BrowserConfig.set_defaults(headless=False)


### PR DESCRIPTION
## Summary

Fixes #2129.

Add `CrawlerRunConfig.body_visibility_timeout`, defaulting to the existing 30-second behavior, and use it for the body visibility check. This lets callers lower the ceiling for pages whose body remains hidden without changing the default crawl behavior. The value is included in config serialization and the untrusted-config allowlist, validated as a positive number, and capped at 60 seconds for untrusted Docker input.

## List of files changed and why

- `crawl4ai/async_configs.py` - define, document, serialize, validate, allow, and cap the new configuration field.
- `crawl4ai/async_crawler_strategy.py` - pass the configured timeout to the body visibility wait.
- `docs/md_v2/api/parameters.md` and `docs/md_v2/complete-sdk-reference.md` - document the new public option.
- `tests/test_config_defaults.py` - cover the default and round trip, invalid values, the untrusted cap, and propagation into `csp_compliant_wait`.

## How Has This Been Tested?

- `/tmp/crawl4ai-followup-venv/bin/python -m pytest tests/test_config_defaults.py -q` — 40 passed, 1 existing warning.
- `/tmp/crawl4ai-followup-venv/bin/python -m pytest deploy/docker/tests/test_security_trust_boundary.py -q` — 38 passed, 4 existing warnings.
- `/tmp/crawl4ai-followup-venv/bin/ruff check --isolated --select E9,F63,F7,F82 --ignore F821 crawl4ai/async_configs.py crawl4ai/async_crawler_strategy.py tests/test_config_defaults.py` — passed. (`F821` is excluded because of the existing `VirtualScrollConfig` forward-reference finding in `async_crawler_strategy.py`.)
- `/tmp/crawl4ai-followup-venv/bin/python -m compileall -q crawl4ai/async_configs.py crawl4ai/async_crawler_strategy.py tests/test_config_defaults.py` — passed.
- `git diff --check` — passed.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas — N/A; no complex logic was introduced.
- [x] I have made corresponding changes to the documentation
- [x] I have added/updated unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
