### PR TITLE
fix(docker): handle unlimited cgroup v2 memory

### DIFF
--- a/deploy/docker/tests/test_utils_memory.py
+++ b/deploy/docker/tests/test_utils_memory.py
@@ -1,0 +1,32 @@
+from types import SimpleNamespace
+
+import psutil
+import pytest
+
+import utils
+
+
+def test_unlimited_cgroup_v2_uses_container_usage(monkeypatch):
+    values = {
+        "/sys/fs/cgroup/memory.current": "805306368\n",
+        "/sys/fs/cgroup/memory.max": "max\n",
+    }
+
+    class FakeCgroupPath:
+        def __init__(self, path):
+            self.path = path
+
+        def exists(self):
+            return self.path in values
+
+        def read_text(self):
+            return values[self.path]
+
+    monkeypatch.setattr(utils, "Path", FakeCgroupPath)
+    monkeypatch.setattr(
+        psutil,
+        "virtual_memory",
+        lambda: SimpleNamespace(total=16 * 1024**3, percent=50.3),
+    )
+
+    assert utils.get_container_memory_percent() == pytest.approx(4.6875)

--- a/deploy/docker/utils.py
+++ b/deploy/docker/utils.py
@@ -420,12 +420,17 @@ def get_container_memory_percent() -> float:
             limit_path = Path("/sys/fs/cgroup/memory/memory.limit_in_bytes")
 
         usage = int(usage_path.read_text())
-        limit = int(limit_path.read_text())
+        raw_limit = limit_path.read_text().strip()
 
         # Handle unlimited (v2: "max", v1: > 1e18)
-        if limit > 1e18:
+        if raw_limit == "max":
             import psutil
             limit = psutil.virtual_memory().total
+        else:
+            limit = int(raw_limit)
+            if limit > 1e18:
+                import psutil
+                limit = psutil.virtual_memory().total
 
         return (usage / limit) * 100
     except:


### PR DESCRIPTION
## Summary

Fixes #2123.

Handle cgroup v2's `memory.max` sentinel before integer conversion. Unlimited cgroup-v2 containers now report their own memory usage as a percentage of host capacity instead of falling through to the unrelated host-wide usage percentage. The existing finite-limit and cgroup-v1 paths remain unchanged.

## List of files changed and why

- `deploy/docker/utils.py` - parse the cgroup-v2 `max` sentinel explicitly and preserve numeric cgroup limit handling.
- `deploy/docker/tests/test_utils_memory.py` - add a focused regression test for an unlimited cgroup-v2 container.

## How Has This Been Tested?

- Installed the Docker test dependencies from `deploy/docker/requirements.txt` into a Python 3.12 environment.
- `.venv/bin/python -m pytest deploy/docker/tests/test_utils_memory.py -q` — 1 passed.
- `uvx ruff check --select E9,F63,F7,F82 --ignore F821 deploy/docker/utils.py deploy/docker/tests/test_utils_memory.py` — passed.
- `uvx ruff format --check deploy/docker/tests/test_utils_memory.py` — passed.
- `.venv/bin/python -m compileall -q deploy/docker/utils.py deploy/docker/tests/test_utils_memory.py` — passed.
- `git diff --check` — passed.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas — N/A; no complex logic was introduced.
- [ ] I have made corresponding changes to the documentation — N/A; this corrects behavior already described by the existing docstring.
- [x] I have added/updated unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
