### PR TITLE
fix: await dispatcher cleanup in arun_many streams

### DIFF
--- a/crawl4ai/async_webcrawler.py
+++ b/crawl4ai/async_webcrawler.py
@@ -9,7 +9,7 @@ import json
 import asyncio
 
 # from contextlib import nullcontext, asynccontextmanager
-from contextlib import asynccontextmanager
+from contextlib import aclosing, asynccontextmanager
 from .models import (
     CrawlResult,
     MarkdownGenerationResult,
@@ -1108,10 +1108,13 @@ class AsyncWebCrawler:
         if stream:
             async def result_transformer():
                 try:
-                    async for task_result in dispatcher.run_urls_stream(
-                        crawler=self, urls=urls, config=config
-                    ):
-                        yield transform_result(task_result)
+                    async with aclosing(
+                        dispatcher.run_urls_stream(
+                            crawler=self, urls=urls, config=config
+                        )
+                    ) as task_results:
+                        async for task_result in task_results:
+                            yield transform_result(task_result)
                 finally:
                     # Auto-release session after streaming completes
                     await maybe_release_session()

--- a/tests/async/test_arun_many_stream_cleanup.py
+++ b/tests/async/test_arun_many_stream_cleanup.py
@@ -1,0 +1,34 @@
+from types import SimpleNamespace
+
+import pytest
+
+from crawl4ai import AsyncWebCrawler, CrawlerRunConfig
+
+
+class ClosingDispatcher:
+    closed = False
+
+    async def run_urls_stream(self, **kwargs):
+        try:
+            yield SimpleNamespace(
+                result=SimpleNamespace(),
+                task_id="task",
+                memory_usage=0,
+                peak_memory=0,
+                start_time=0,
+                end_time=0,
+                error_message="",
+            )
+        finally:
+            self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_arun_many_closes_dispatcher_stream():
+    dispatcher = ClosingDispatcher()
+    stream = await AsyncWebCrawler().arun_many(
+        ["url"], config=CrawlerRunConfig(stream=True), dispatcher=dispatcher
+    )
+    await stream.__anext__()
+    await stream.aclose()
+    assert dispatcher.closed


### PR DESCRIPTION
## Summary

Fixes #2083.

Make the public `AsyncWebCrawler.arun_many(..., stream=True)` wrapper explicitly own and close the dispatcher stream. Closing the public stream now completes dispatcher cleanup before proxy-session release and before `aclose()` returns.

## List of files changed and why

- `crawl4ai/async_webcrawler.py` - close the inner dispatcher async generator with `contextlib.aclosing()`.
- `tests/async/test_arun_many_stream_cleanup.py` - verify that closing the public wrapper synchronously closes its dispatcher stream.

## How Has This Been Tested?

- `.venv/bin/python -m pytest tests/async/test_arun_many_stream_cleanup.py tests/async/test_dispatchers.py::TestDispatchStrategies::test_memory_adaptive_stream_closure_cleans_up_tasks -q` - 2 passed.
- `.venv/bin/ruff check --isolated --select E9,F63,F7,F82 --ignore F821 crawl4ai/async_webcrawler.py tests/async/test_arun_many_stream_cleanup.py` - passed.
- `.venv/bin/black --check --target-version py312 --fast tests/async/test_arun_many_stream_cleanup.py` - passed.
- `.venv/bin/python -m compileall -q crawl4ai/async_webcrawler.py tests/async/test_arun_many_stream_cleanup.py` - passed.
- `git diff --check upstream/develop...HEAD` - passed.

The full legacy `tests/async/test_dispatchers.py` module produced 10 passes and one unrelated pre-existing failure: `test_monitor_integration` still passes removed `CrawlerMonitor(max_visible_rows=..., display_mode=...)` arguments.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas - N/A; the ownership boundary is expressed directly with `aclosing()`.
- [ ] I have made corresponding changes to the documentation - N/A; this restores the documented async-generator cleanup contract.
- [x] I have added/updated unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes - the relevant new and existing cleanup tests pass; one unrelated pre-existing test in the broader module fails as noted above.
