### PR TITLE
fix: skip anti-bot detection for PDF responses

### DIFF
--- a/crawl4ai/async_webcrawler.py
+++ b/crawl4ai/async_webcrawler.py
@@ -408,6 +408,7 @@ class AsyncWebCrawler:
                     _block_reason = ""
                     _done = False
                     crawl_result = None
+                    _is_pdf_response = False
                     _crawl_stats = {
                         "attempts": 0,
                         "retries": 0,
@@ -458,6 +459,13 @@ class AsyncWebCrawler:
 
                                 async_response = await self.crawler_strategy.crawl(
                                     url, config=config)
+                                _is_pdf_response = any(
+                                    key.lower() == "content-type"
+                                    and "application/pdf" in str(value).lower()
+                                    for key, value in (
+                                        async_response.response_headers or {}
+                                    ).items()
+                                )
 
                                 html = sanitize_input_encode(async_response.html)
                                 screenshot_data = async_response.screenshot
@@ -505,7 +513,7 @@ class AsyncWebCrawler:
 
                                 # Check if blocked (skip for raw: URLs —
                                 # caller-provided content, anti-bot N/A)
-                                if _is_raw_url:
+                                if _is_raw_url or _is_pdf_response:
                                     _blocked = False
                                     _block_reason = ""
                                 else:
@@ -625,7 +633,12 @@ class AsyncWebCrawler:
                         # empty by design, and is_blocked() would misread "0 bytes
                         # html" as a block.
                         _has_download = bool(getattr(crawl_result, "downloaded_files", None))
-                        if not _fallback_succeeded and not _is_raw_url and not _has_download:
+                        if (
+                            not _fallback_succeeded
+                            and not _is_raw_url
+                            and not _has_download
+                            and not _is_pdf_response
+                        ):
                             _blocked, _block_reason = is_blocked(
                                 crawl_result.status_code, crawl_result.html or "")
                             if _blocked:

--- a/tests/test_issue_2135_pdf_antibot.py
+++ b/tests/test_issue_2135_pdf_antibot.py
@@ -1,0 +1,30 @@
+import pytest
+
+from crawl4ai import AsyncWebCrawler, CacheMode, CrawlerRunConfig, CrawlResult
+from crawl4ai.processors.pdf import PDFCrawlerStrategy
+
+
+@pytest.mark.asyncio
+async def test_pdf_response_skips_antibot_retries_and_fallback():
+    fallback_calls = []
+
+    async def process_html(url, html, **kwargs):
+        return CrawlResult(url=url, html=html, success=True, status_code=200)
+
+    async def fallback(url):
+        fallback_calls.append(url)
+        return "<html>fallback</html>"
+
+    crawler = AsyncWebCrawler(crawler_strategy=PDFCrawlerStrategy())
+    crawler.aprocess_html = process_html
+    result = await crawler.arun(
+        "https://example.com/document.pdf",
+        config=CrawlerRunConfig(
+            cache_mode=CacheMode.BYPASS,
+            max_retries=1,
+            fallback_fetch_function=fallback,
+        ),
+    )
+    assert result.success
+    assert result.crawl_stats["attempts"] == 1
+    assert fallback_calls == []


### PR DESCRIPTION
## Summary

Fixes #2135.

Treat responses declared as `application/pdf` like other binary content before anti-bot classification. This prevents `PDFCrawlerStrategy`'s intentional 33-byte HTML placeholder from triggering retries, fallback fetching, and the final failure veto after PDF extraction succeeds.

## List of files changed and why

- `crawl4ai/async_webcrawler.py` - detect PDF response content types and bypass HTML-specific anti-bot checks in both classification stages.
- `tests/test_issue_2135_pdf_antibot.py` - exercise the real `PDFCrawlerStrategy` through `AsyncWebCrawler.arun()` and verify one attempt, success, and no fallback.

## How Has This Been Tested?

- `.venv/bin/python -m pytest tests/test_issue_2135_pdf_antibot.py -q` - 1 passed.
- `.venv/bin/python tests/proxy/test_antibot_detector.py` - 47 passed, 0 failed.
- `.venv/bin/ruff check --isolated --select E9,F63,F7,F82 --ignore F821 crawl4ai/async_webcrawler.py tests/test_issue_2135_pdf_antibot.py` - passed.
- `.venv/bin/black --check --target-version py312 --fast tests/test_issue_2135_pdf_antibot.py` - passed.
- `.venv/bin/python -m compileall -q crawl4ai/async_webcrawler.py tests/test_issue_2135_pdf_antibot.py` - passed.
- `git diff --check upstream/develop...HEAD` - passed.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas - N/A; the PDF-response condition is explicit and covered by a focused regression test.
- [ ] I have made corresponding changes to the documentation - N/A; this fixes the implementation to match the existing PDF parsing documentation.
- [x] I have added/updated unit tests that prove my fix is effective or that my feature works
- [x] New and existing relevant tests pass locally with my changes
