### PR TITLE
Docker: Chain egress proxy through upstream HTTP(S)_PROXY

### DIFF
--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -116,6 +116,17 @@ EOL
 
 > The server will be available at `http://localhost:11235`. Visit `/playground` to access the interactive testing interface.
 
+*   **Behind a corporate proxy:** if the host reaches the internet only through
+    an HTTP proxy, set the standard `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY`
+    env vars (Docker's `proxies` config injects them automatically) — the
+    server's egress proxy chains through it while keeping its SSRF protections
+    (the upstream is asked to CONNECT to an already-validated, pinned IP).
+    `CRAWL4AI_UPSTREAM_PROXY` overrides the env vars. Basic auth via
+    `http://user:pass@proxy:port` is supported; for NTLM/Kerberos proxies,
+    front them with a local translator (e.g. `cntlm`, `px`) and point
+    `CRAWL4AI_UPSTREAM_PROXY` at it. Proxies that refuse CONNECT-to-an-IP, or
+    containers with no DNS at all, are not yet supported.
+
 #### 4. Stopping the Container
 
 ```bash

--- a/deploy/docker/egress_proxy.py
+++ b/deploy/docker/egress_proxy.py
@@ -13,13 +13,21 @@ TLS stays end-to-end (we tunnel ciphertext; Chromium verifies the cert/SNI
 against the real host - no MITM).
 
 Bound to 127.0.0.1 on an ephemeral port; started at server boot.
+
+If HTTP_PROXY/HTTPS_PROXY (or CRAWL4AI_UPSTREAM_PROXY) is set, we still
+resolve-and-pin locally but dial via the upstream proxy, asking it to CONNECT
+to the PINNED IP — never the hostname — so the rebinding guarantee holds.
+NO_PROXY bypasses it; with no proxy env set, behavior is unchanged.
 """
 
 from __future__ import annotations
 
 import asyncio
+import base64
+import ipaddress
 import logging
-from urllib.parse import urlsplit
+import os
+from urllib.parse import unquote, urlsplit
 
 from egress_broker import EgressBlocked, resolve_and_pin
 
@@ -29,6 +37,63 @@ _CONNECT_OK = b"HTTP/1.1 200 Connection established\r\n\r\n"
 _BLOCKED = b"HTTP/1.1 403 Forbidden\r\nContent-Length: 11\r\n\r\nURL blocked"
 _BAD = b"HTTP/1.1 400 Bad Request\r\nContent-Length: 11\r\n\r\nBad Request"
 _MAX_HEADER_BYTES = 64 * 1024
+
+
+def _env(*names: str) -> str:
+    return next((os.environ[n] for n in names if os.environ.get(n)), "")
+
+
+def upstream_proxy(scheme: str = "https"):
+    """(host, port, auth_header_bytes|None) of the upstream proxy, or None.
+
+    Read per-call (not at import) so operators and tests see env changes.
+    The target scheme picks HTTP(S)_PROXY per convention, falling back to
+    the other pair when only one is set.
+    """
+    order = ("HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy") if scheme == "http" \
+        else ("HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy")
+    raw = _env("CRAWL4AI_UPSTREAM_PROXY", *order).strip()
+    if not raw:
+        return None
+    sp = urlsplit(raw if "://" in raw else "http://" + raw)
+    if not sp.hostname:
+        return None
+    auth = None
+    if sp.username:
+        cred = f"{unquote(sp.username)}:{unquote(sp.password or '')}".encode("utf-8")
+        auth = b"Proxy-Authorization: Basic " + base64.b64encode(cred) + b"\r\n"
+    return sp.hostname, sp.port or 80, auth
+
+
+def _no_proxy_match(host: str, ip: str) -> bool:
+    """True if NO_PROXY says this target must bypass the upstream proxy."""
+    entries = [e.strip() for e in _env("NO_PROXY", "no_proxy").split(",") if e.strip()]
+    for entry in entries:
+        if entry == "*":
+            return True
+        try:
+            if ipaddress.ip_address(ip) in ipaddress.ip_network(entry, strict=False):
+                return True
+            continue
+        except ValueError:
+            pass
+        suffix = entry.lower().lstrip(".")
+        low = host.lower()
+        if low == suffix or low.endswith("." + suffix):
+            return True
+    return False
+
+
+def _use_upstream(pin):
+    """The upstream (host, port, auth) to route `pin` through, or None for direct."""
+    up = upstream_proxy(pin.scheme)
+    if up is None or _no_proxy_match(pin.host, pin.ip):
+        return None
+    return up
+
+
+def _bracket(ip: str) -> str:
+    return f"[{ip}]" if ":" in ip else ip
 
 
 class PinningProxy:
@@ -52,6 +117,12 @@ class PinningProxy:
         sock = self._server.sockets[0]
         self.bound_host, self.bound_port = sock.getsockname()[:2]
         logger.info("egress pinning proxy listening on %s", self.url)
+        up = upstream_proxy()
+        if up is not None:
+            logger.info(
+                "egress pinning proxy chaining through upstream proxy %s:%s",
+                up[0], up[1],
+            )
         return self.url
 
     async def stop(self) -> None:
@@ -101,9 +172,7 @@ class PinningProxy:
         await self._drain_headers(client_reader)
 
         try:
-            up_reader, up_writer = await asyncio.wait_for(
-                asyncio.open_connection(pin.ip, int(port_s)), timeout=30
-            )
+            up_reader, up_writer = await self._dial(pin, int(port_s))
         except Exception:
             await self._reply(client_writer, _BLOCKED)
             return
@@ -129,15 +198,31 @@ class PinningProxy:
         path = sp.path or "/"
         if sp.query:
             path += "?" + sp.query
+        upstream = _use_upstream(pin)
+        dst = (upstream[0], upstream[1]) if upstream else (pin.ip, port)
         try:
             up_reader, up_writer = await asyncio.wait_for(
-                asyncio.open_connection(pin.ip, port), timeout=30
+                asyncio.open_connection(*dst), timeout=30
             )
         except Exception:
             await self._reply(client_writer, _BLOCKED)
             return
-        # Re-issue in origin form with Host preserved.
-        out = f"{method} {path} HTTP/1.1\r\n".encode("latin-1")
+        # Re-issue with Host preserved: origin form when dialing the pinned IP
+        # directly, absolute form against the pinned IP when going through the
+        # upstream proxy (which then needs no DNS lookup of its own).
+        if upstream is None:
+            out = f"{method} {path} HTTP/1.1\r\n".encode("latin-1")
+        else:
+            out = f"{method} http://{_bracket(pin.ip)}:{port}{path} HTTP/1.1\r\n".encode("latin-1")
+            if upstream[2]:
+                out += upstream[2]
+            # One validated request per upstream connection: only this first
+            # request is pinned/rewritten, so force close to keep a reused
+            # client connection from smuggling unvalidated requests upstream.
+            headers = b"".join(
+                ln + b"\r\n" for ln in headers.split(b"\r\n")
+                if ln and not ln.lower().startswith(b"connection:")
+            ) + b"Connection: close\r\n"
         out += b"Host: " + sp.hostname.encode("latin-1")
         if sp.port:
             out += f":{sp.port}".encode("latin-1")
@@ -147,6 +232,39 @@ class PinningProxy:
         await self._splice(client_reader, client_writer, up_reader, up_writer)
 
     # ─────────────────────────── helpers ───────────────────────────
+    async def _dial(self, pin, port: int):
+        """Open a byte pipe to the pinned IP: direct, or tunneled through the
+        upstream proxy via CONNECT-to-the-pinned-IP (no upstream DNS lookup)."""
+        upstream = _use_upstream(pin)
+        if upstream is None:
+            return await asyncio.wait_for(
+                asyncio.open_connection(pin.ip, port), timeout=30
+            )
+        p_host, p_port, auth = upstream
+        reader, writer = await asyncio.wait_for(
+            asyncio.open_connection(p_host, p_port), timeout=30
+        )
+        try:
+            dst = f"{_bracket(pin.ip)}:{port}"
+            req = f"CONNECT {dst} HTTP/1.1\r\nHost: {dst}\r\n".encode("latin-1")
+            if auth:
+                req += auth
+            req += b"\r\n"
+            writer.write(req)
+            await writer.drain()
+            status = await asyncio.wait_for(reader.readline(), timeout=30)
+            parts = status.split()
+            if len(parts) < 2 or parts[1] != b"200":
+                logger.warning("upstream proxy refused CONNECT: %r", status[:64])
+                raise ConnectionError("upstream proxy refused CONNECT")
+            # Drain the upstream's response headers so none of them leak into
+            # the tunneled byte stream.
+            await self._drain_headers(reader)
+        except Exception:
+            await self._safe_close(writer)
+            raise
+        return reader, writer
+
     async def _drain_headers(self, reader):
         read = 0
         while True:

--- a/deploy/docker/egress_proxy.py
+++ b/deploy/docker/egress_proxy.py
@@ -39,35 +39,39 @@ _BAD = b"HTTP/1.1 400 Bad Request\r\nContent-Length: 11\r\n\r\nBad Request"
 _MAX_HEADER_BYTES = 64 * 1024
 
 
-def _env(*names: str) -> str:
-    return next((os.environ[n] for n in names if os.environ.get(n)), "")
-
-
 def upstream_proxy(scheme: str = "https"):
     """(host, port, auth_header_bytes|None) of the upstream proxy, or None.
 
     Read per-call (not at import) so operators and tests see env changes.
-    The target scheme picks HTTP(S)_PROXY per convention, falling back to
-    the other pair when only one is set.
+    The target scheme picks HTTP(S)_PROXY per convention; the first
+    candidate that parses wins, so junk values fall through to a fallback.
     """
     order = ("HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy") if scheme == "http" \
         else ("HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy")
-    raw = _env("CRAWL4AI_UPSTREAM_PROXY", *order).strip()
-    if not raw:
-        return None
-    sp = urlsplit(raw if "://" in raw else "http://" + raw)
-    if not sp.hostname:
-        return None
-    auth = None
-    if sp.username:
-        cred = f"{unquote(sp.username)}:{unquote(sp.password or '')}".encode("utf-8")
-        auth = b"Proxy-Authorization: Basic " + base64.b64encode(cred) + b"\r\n"
-    return sp.hostname, sp.port or 80, auth
+    for name in ("CRAWL4AI_UPSTREAM_PROXY", *order):
+        raw = (os.environ.get(name) or "").strip()
+        if not raw:
+            continue
+        sp = urlsplit(raw if "://" in raw else "http://" + raw)
+        if not sp.hostname:
+            logger.warning("ignoring %s: unparseable proxy URL", name)
+            continue
+        if sp.scheme != "http":
+            # We only speak plaintext HTTP to the upstream (no TLS/socks dial).
+            logger.warning("ignoring %s: unsupported proxy scheme %r", name, sp.scheme)
+            continue
+        auth = None
+        if sp.username:
+            cred = f"{unquote(sp.username)}:{unquote(sp.password or '')}".encode("utf-8")
+            auth = b"Proxy-Authorization: Basic " + base64.b64encode(cred) + b"\r\n"
+        return sp.hostname, sp.port or 80, auth
+    return None
 
 
 def _no_proxy_match(host: str, ip: str) -> bool:
     """True if NO_PROXY says this target must bypass the upstream proxy."""
-    entries = [e.strip() for e in _env("NO_PROXY", "no_proxy").split(",") if e.strip()]
+    raw = os.environ.get("NO_PROXY") or os.environ.get("no_proxy") or ""
+    entries = [e.strip() for e in raw.split(",") if e.strip()]
     for entry in entries:
         if entry == "*":
             return True
@@ -78,6 +82,9 @@ def _no_proxy_match(host: str, ip: str) -> bool:
         except ValueError:
             pass
         suffix = entry.lower().lstrip(".")
+        head, sep, port_part = suffix.rpartition(":")
+        if sep and port_part.isdigit():
+            suffix = head
         low = host.lower()
         if low == suffix or low.endswith("." + suffix):
             return True

--- a/deploy/docker/tests/test_security_egress_proxy.py
+++ b/deploy/docker/tests/test_security_egress_proxy.py
@@ -20,6 +20,18 @@ from egress_proxy import PinningProxy
 
 pytestmark = pytest.mark.posture
 
+_PROXY_ENV = (
+    "CRAWL4AI_UPSTREAM_PROXY", "HTTP_PROXY", "http_proxy",
+    "HTTPS_PROXY", "https_proxy", "NO_PROXY", "no_proxy",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_proxy_env(monkeypatch):
+    # Keep the suite deterministic on dev machines that sit behind a proxy.
+    for name in _PROXY_ENV:
+        monkeypatch.delenv(name, raising=False)
+
 
 async def _fake_upstream():
     async def handle(reader, writer):
@@ -119,6 +131,150 @@ class TestPinningProxy:
             w.close()
         finally:
             await proxy.stop()
+
+
+async def _fake_corporate_proxy(seen):
+    """Minimal HTTP proxy: records the CONNECT request line, replies 200, then
+    answers any tunneled bytes with TUNNEL-OK."""
+    async def handle(reader, writer):
+        line = await reader.readline()
+        seen.append(line)
+        while True:  # drain CONNECT headers
+            h = await reader.readline()
+            if h in (b"\r\n", b"\n", b""):
+                break
+        writer.write(b"HTTP/1.1 200 Connection established\r\nVia: fake\r\n\r\n")
+        await writer.drain()
+        await reader.read(65536)
+        writer.write(b"TUNNEL-OK")
+        await writer.drain()
+        writer.close()
+    server = await asyncio.start_server(handle, "127.0.0.1", 0)
+    return server, server.sockets[0].getsockname()[1]
+
+
+@pytest.mark.asyncio
+class TestUpstreamChaining:
+    async def test_chained_connect_pins_ip_and_blocks_before_upstream(self, monkeypatch):
+        """The chained-CONNECT security contract: the upstream receives the
+        PINNED IP (never a hostname to resolve), its response headers do not
+        leak into the tunnel, and a blocked target produces an opaque 403
+        with zero upstream traffic."""
+        seen = []
+        corp, corp_port = await _fake_corporate_proxy(seen)
+        monkeypatch.setenv("HTTPS_PROXY", f"http://127.0.0.1:{corp_port}")
+
+        def fake_pin(url):
+            if "internal.example" in url:
+                raise EgressBlocked()
+            return PinnedTarget("https", "good.example", 443, "203.0.113.7")
+        monkeypatch.setattr(egress_proxy, "resolve_and_pin", fake_pin)
+
+        proxy = PinningProxy()
+        await proxy.start()
+        try:
+            r, w = await asyncio.open_connection(proxy.bound_host, proxy.bound_port)
+            w.write(b"CONNECT good.example:443 HTTP/1.1\r\n\r\n")
+            await w.drain()
+            status = await asyncio.wait_for(r.readline(), timeout=5)
+            assert b"200" in status
+            await r.readline()  # blank line after the 200
+            w.write(b"hello")
+            await w.drain()
+            body = await asyncio.wait_for(r.read(100), timeout=5)
+            # Upstream's Via header must NOT leak into the tunnel.
+            assert body == b"TUNNEL-OK"
+            w.close()
+
+            r, w = await asyncio.open_connection(proxy.bound_host, proxy.bound_port)
+            w.write(b"CONNECT internal.example:443 HTTP/1.1\r\n\r\n")
+            await w.drain()
+            status = await asyncio.wait_for(r.readline(), timeout=5)
+            assert b"403" in status
+            w.close()
+        finally:
+            await proxy.stop()
+            corp.close()
+        # The upstream saw ONLY the pinned IP of the allowed target.
+        assert seen == [b"CONNECT 203.0.113.7:443 HTTP/1.1\r\n"]
+
+    async def test_chained_plain_http_pinned_absolute_form_no_smuggling(self, monkeypatch):
+        """Plain HTTP via upstream: the request is re-issued in absolute form
+        against the PINNED IP (no name for the upstream to resolve), carries
+        Connection: close, and a reused client connection cannot smuggle a
+        second, unvalidated request upstream."""
+        lines = []
+
+        async def handle(reader, writer):
+            req = b""
+            while b"\r\n\r\n" not in req:
+                req += await reader.read(4096)
+            lines.append(req)
+            writer.write(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nhi")
+            await writer.drain()
+            writer.close()
+        corp = await asyncio.start_server(handle, "127.0.0.1", 0)
+        corp_port = corp.sockets[0].getsockname()[1]
+        monkeypatch.setenv("HTTP_PROXY", f"http://127.0.0.1:{corp_port}")
+
+        def fake_pin(url):
+            return PinnedTarget("http", "plain.example", 80, "203.0.113.7")
+        monkeypatch.setattr(egress_proxy, "resolve_and_pin", fake_pin)
+
+        proxy = PinningProxy()
+        await proxy.start()
+        try:
+            r, w = await asyncio.open_connection(proxy.bound_host, proxy.bound_port)
+            w.write(b"GET http://plain.example/ HTTP/1.1\r\n"
+                    b"Host: plain.example\r\nConnection: keep-alive\r\n\r\n")
+            await w.drain()
+            first = await asyncio.wait_for(r.read(200), timeout=5)
+            assert b"200" in first
+            # Attempt to smuggle an unvalidated request on the same connection.
+            w.write(b"GET http://rebind.evil/ HTTP/1.1\r\nHost: rebind.evil\r\n\r\n")
+            await w.drain()
+            leftover = await asyncio.wait_for(r.read(200), timeout=5)
+            assert leftover == b""  # upstream closed; nothing came back
+            w.close()
+        finally:
+            await proxy.stop()
+            corp.close()
+        sent = b"".join(lines)
+        assert sent.startswith(b"GET http://203.0.113.7:80/ HTTP/1.1\r\n")
+        assert b"Connection: close" in sent
+        assert b"keep-alive" not in sent
+        assert b"rebind.evil" not in sent  # the smuggled request never got upstream
+
+
+def test_upstream_proxy_env_parsing(monkeypatch):
+    assert egress_proxy.upstream_proxy() is None
+    monkeypatch.setenv("HTTP_PROXY", "http://192.168.180.254:56560")
+    assert egress_proxy.upstream_proxy() == ("192.168.180.254", 56560, None)
+    monkeypatch.setenv("HTTPS_PROXY", "http://user:p%40ss@10.0.0.1:8080")
+    host, port, auth = egress_proxy.upstream_proxy()
+    assert (host, port) == ("10.0.0.1", 8080)
+    import base64
+    assert base64.b64decode(auth.split(b" ")[-1].strip()) == b"user:p@ss"
+    # scheme-aware selection: http targets prefer HTTP_PROXY
+    assert egress_proxy.upstream_proxy("http") == ("192.168.180.254", 56560, None)
+    monkeypatch.setenv("CRAWL4AI_UPSTREAM_PROXY", "proxy.corp:3128")
+    assert egress_proxy.upstream_proxy() == ("proxy.corp", 3128, None)
+    # whitespace-only env var means unset, not a proxy named "   "
+    monkeypatch.setenv("CRAWL4AI_UPSTREAM_PROXY", "   ")
+    monkeypatch.delenv("HTTP_PROXY")
+    monkeypatch.delenv("HTTPS_PROXY")
+    assert egress_proxy.upstream_proxy() is None
+    # non-latin-1 credentials must not raise (encoded as UTF-8)
+    monkeypatch.delenv("CRAWL4AI_UPSTREAM_PROXY")
+    monkeypatch.setenv("HTTPS_PROXY", "http://u:%E5%AF%86%E7%A0%81@10.0.0.1:8080")
+    assert egress_proxy.upstream_proxy()[2] is not None
+    # NO_PROXY routing: suffix and CIDR entries force a direct dial
+    pin = PinnedTarget("https", "site.corp.example", 443, "203.0.113.7")
+    assert egress_proxy._use_upstream(pin) is not None
+    monkeypatch.setenv("NO_PROXY", ".corp.example")
+    assert egress_proxy._use_upstream(pin) is None
+    monkeypatch.setenv("NO_PROXY", "203.0.113.0/24")
+    assert egress_proxy._use_upstream(pin) is None
 
 
 class TestEnforceEgressWiring:

--- a/deploy/docker/tests/test_security_egress_proxy.py
+++ b/deploy/docker/tests/test_security_egress_proxy.py
@@ -264,8 +264,16 @@ def test_upstream_proxy_env_parsing(monkeypatch):
     monkeypatch.delenv("HTTP_PROXY")
     monkeypatch.delenv("HTTPS_PROXY")
     assert egress_proxy.upstream_proxy() is None
-    # non-latin-1 credentials must not raise (encoded as UTF-8)
+    # a junk/unsupported candidate falls through to a valid fallback
+    monkeypatch.setenv("HTTP_PROXY", "http://good:3128")
+    monkeypatch.setenv("HTTPS_PROXY", "http://")
+    assert egress_proxy.upstream_proxy() == ("good", 3128, None)
+    monkeypatch.setenv("HTTPS_PROXY", "https://tls-proxy.corp")  # unsupported scheme
+    assert egress_proxy.upstream_proxy() == ("good", 3128, None)
     monkeypatch.delenv("CRAWL4AI_UPSTREAM_PROXY")
+    monkeypatch.delenv("HTTP_PROXY")
+    assert egress_proxy.upstream_proxy() is None  # https:// alone -> refused, not mis-dialed
+    # non-latin-1 credentials must not raise (encoded as UTF-8)
     monkeypatch.setenv("HTTPS_PROXY", "http://u:%E5%AF%86%E7%A0%81@10.0.0.1:8080")
     assert egress_proxy.upstream_proxy()[2] is not None
     # NO_PROXY routing: suffix and CIDR entries force a direct dial
@@ -274,6 +282,8 @@ def test_upstream_proxy_env_parsing(monkeypatch):
     monkeypatch.setenv("NO_PROXY", ".corp.example")
     assert egress_proxy._use_upstream(pin) is None
     monkeypatch.setenv("NO_PROXY", "203.0.113.0/24")
+    assert egress_proxy._use_upstream(pin) is None
+    monkeypatch.setenv("NO_PROXY", "site.corp.example:443")  # host:port form
     assert egress_proxy._use_upstream(pin) is None
 
 


### PR DESCRIPTION
## Summary
Since 0.9.0, the Docker server's egress pinning proxy dials target IPs directly (`asyncio.open_connection`), ignoring `HTTP_PROXY`/`HTTPS_PROXY`. On hosts that can only reach the internet through a corporate proxy, every crawl fails with `Page.goto: net::ERR_TIMED_OUT` — this worked in 0.8.x. Reported in discussion #2041.

This PR teaches the pinning proxy to chain through the upstream proxy **without weakening the SSRF/rebinding guarantees**: validation (`resolve_and_pin`) still runs locally *before* the upstream is ever contacted, and the upstream is asked to `CONNECT <pinned-ip>:<port>` — never a hostname — so it performs no DNS resolution of its own and the pin holds.

**Behavior:**
- Reads standard `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY` (both cases; scheme-aware selection with fallback); `CRAWL4AI_UPSTREAM_PROXY` overrides them.
- `NO_PROXY` supports domain-suffix (`.corp.lan`) and IP/CIDR (`192.168.0.0/16`) entries — internal targets should be listed there to dial direct.
- Basic auth via `http://user:pass@proxy:port` (percent-decoded, UTF-8) sent preemptively; on the CONNECT path a `407`/non-`200` from the upstream fails fast with the existing opaque `403` plus a server-side log line, while on plain HTTP the upstream's error response is relayed to the browser as-is.
- Plain-HTTP requests are re-issued to the upstream in absolute form against the pinned IP with `Connection: close` forced, so a reused client connection cannot smuggle unvalidated requests past the pin.
- With no proxy env vars set, the dial path is byte-identical to current behavior — zero change for existing deployments.

**Known limitations (documented in the README):**
- Proxies that refuse CONNECT-to-an-IP (hostname/domain ACLs) and containers with no DNS at all are not supported yet (a future opt-in hostname mode could cover them).
- NTLM/Kerberos/SPNEGO proxies are not supported — front them with a local translator (e.g. `cntlm`, `px`) and point `CRAWL4AI_UPSTREAM_PROXY` at it.

## List of files changed and why
- `deploy/docker/egress_proxy.py` — upstream detection (`upstream_proxy()`, `_no_proxy_match()`, `_use_upstream()`), the chained `_dial()` (CONNECT-to-pinned-IP, auth, header drain so upstream headers never leak into the tunnel), absolute-form + `Connection: close` for chained plain HTTP, startup/refusal log lines.
- `deploy/docker/tests/test_security_egress_proxy.py` — 3 new tests covering the security contract: chained CONNECT carries only the pinned IP and blocked targets produce zero upstream traffic; plain-HTTP absolute-form + anti-smuggling; env parsing (precedence, scheme selection, credentials, `NO_PROXY` routing). Plus an autouse fixture clearing proxy env vars so the suite is deterministic on dev machines behind proxies.
- `deploy/docker/README.md` — "Behind a corporate proxy" note in the Run the Container section (env vars, auth support, limitations).

## How Has This Been Tested?
- Full Docker security suite: **319 passed, 1 xfailed** (includes the 0.9 hardening contract tests, all unchanged).
- Library regression suite (`tests/regression/`, non-network): **293 passed**; the single failure (`test_cosine_basic`, missing optional `transformers`) was verified pre-existing by re-running on the unmodified tree.
- Adversarial pass (32 targeted tests, real sockets, no mocking): env parsing edge cases (malformed/whitespace URLs, non-latin-1 passwords), `NO_PROXY` matching (anchored suffixes, CIDR, the exact list from #2041), dead/407/garbage upstreams (fast opaque 403, no hang), IPv6 pin bracketing, 8 concurrent tunnels with no cross-talk, and the smuggling regression.
- End-to-end: real Chromium → pinning proxy → a real forwarding "corporate" proxy → origin server, reproducing the #2041 topology — page + subresources each arrive as separate validated pinned-IP requests.
- Proxy-auth probe: preemptive Basic accepted first-try by an auth-requiring proxy; wrong/missing creds and NTLM-only proxies fail fast (single attempt, opaque 403, warning logged).

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added/updated unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
