### PR TITLE
fix(deep-crawling): allow single-label hostnames in can_process_url validation

### DIFF
--- a/crawl4ai/deep_crawling/bff_strategy.py
+++ b/crawl4ai/deep_crawling/bff_strategy.py
@@ -83,8 +83,8 @@ class BestFirstCrawlingStrategy(DeepCrawlStrategy):
                 raise ValueError("Missing scheme or netloc")
             if parsed.scheme not in ("http", "https"):
                 raise ValueError("Invalid scheme")
-            if "." not in parsed.netloc:
-                raise ValueError("Invalid domain")
+            # Single-label hostnames (intranet hosts, localhost, service names)
+            # are valid targets; do not require a dot in the netloc.
         except Exception as e:
             self.logger.warning(f"Invalid URL: {url}, error: {e}")
             return False

--- a/crawl4ai/deep_crawling/bfs_strategy.py
+++ b/crawl4ai/deep_crawling/bfs_strategy.py
@@ -70,8 +70,8 @@ class BFSDeepCrawlStrategy(DeepCrawlStrategy):
                 raise ValueError("Missing scheme or netloc")
             if parsed.scheme not in ("http", "https"):
                 raise ValueError("Invalid scheme")
-            if "." not in parsed.netloc:
-                raise ValueError("Invalid domain")
+            # Single-label hostnames (intranet hosts, localhost, service names)
+            # are valid targets; do not require a dot in the netloc.
         except Exception as e:
             self.logger.warning(f"Invalid URL: {url}, error: {e}")
             return False

--- a/tests/deep_crawling/test_can_process_url.py
+++ b/tests/deep_crawling/test_can_process_url.py
@@ -1,0 +1,68 @@
+"""
+Test Suite: can_process_url URL validation for deep crawl strategies
+
+Covers:
+1. Single-label (dot-less) hostnames such as intranet hosts, localhost and
+   Docker service names are accepted for http(s) URLs.
+2. Regular hostnames, IP literals and ports keep working.
+3. URLs without a scheme/netloc and non-http(s) schemes are still rejected.
+4. The filter chain still applies for depth > 0, while depth 0 bypasses it.
+"""
+
+import pytest
+
+from crawl4ai.deep_crawling import (
+    BFSDeepCrawlStrategy,
+    BestFirstCrawlingStrategy,
+)
+from crawl4ai.deep_crawling.filters import DomainFilter, FilterChain
+
+
+@pytest.mark.parametrize(
+    "strategy",
+    [
+        pytest.param(BFSDeepCrawlStrategy(max_depth=1), id="bfs"),
+        pytest.param(BestFirstCrawlingStrategy(max_depth=1), id="bff"),
+    ],
+)
+class TestCanProcessUrl:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://intranet/xyz/",
+            "http://name/xyz",
+            "https://localhost:8000/docs",
+            "http://10.0.0.5:8080/",
+            "https://example.com/blog/post1",
+        ],
+    )
+    async def test_accepts_valid_urls(self, strategy, url):
+        assert await strategy.can_process_url(url, 0) is True
+        assert await strategy.can_process_url(url, 1) is True
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "intranet/xyz",  # missing scheme
+            "https:///xyz",  # empty netloc
+            "ftp://example.com/file",  # unsupported scheme
+        ],
+    )
+    async def test_rejects_invalid_urls(self, strategy, url):
+        assert await strategy.can_process_url(url, 0) is False
+        assert await strategy.can_process_url(url, 1) is False
+
+    @pytest.mark.asyncio
+    async def test_filter_chain_still_applied_for_deeper_depths(self, strategy):
+        strategy.filter_chain = FilterChain(
+            [DomainFilter(allowed_domains=["intranet"])]
+        )
+
+        # Single-label host inside the allowed domain passes.
+        assert await strategy.can_process_url("https://intranet/xyz", 1) is True
+        # Host outside the allowed domain is rejected by the filter chain.
+        assert await strategy.can_process_url("https://other/xyz", 1) is False
+        # Depth 0 bypasses filtering.
+        assert await strategy.can_process_url("https://other/xyz", 0) is True


### PR DESCRIPTION
## Summary

Fixes #2079

`BFSDeepCrawlStrategy.can_process_url()` and `BestFirstCrawlingStrategy.can_process_url()` rejected any URL whose netloc contains no dot (`Invalid domain`), silently dropping valid internal targets such as intranet hosts, `localhost` (with or without a port) and Docker service names during deep crawls. The error was raised before the configured `FilterChain` was ever applied.

The scheme (`http`/`https`) and non-empty netloc checks are kept; only the dot heuristic is removed, so `https://name/xyz` now passes validation and reaches the filter chain.

## List of files changed and why

- `crawl4ai/deep_crawling/bfs_strategy.py` - Remove the dot requirement from URL validation in `can_process_url`.
- `crawl4ai/deep_crawling/bff_strategy.py` - Same fix for the best-first strategy.
- `tests/deep_crawling/test_can_process_url.py` - New parametrized tests covering single-label hosts, localhost with port, IP literals, rejection of missing scheme/netloc and non-http(s) schemes, and filter-chain behavior at depth > 0.

## How Has This Been Tested?

- `pytest tests/deep_crawling/test_can_process_url.py -v` → **18 passed**
- `pytest tests/deep_crawling/` → 85 passed; the 2 failures in `test_deep_crawl_resume_integration.py` are pre-existing environment issues (they require launching a real Playwright Chromium, which is not available in this dev venv) and fail identically on unmodified `develop`
- `ruff check --select E9,F63,F7,F82` on the changed files → clean
- `python -m py_compile` on the changed files → clean

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added/updated unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes