### PR TITLE
fix(docker): cap mcp below 2 to keep the v1 low-level API used by mcp_bridge

### DIFF
--- a/deploy/docker/requirements.txt
+++ b/deploy/docker/requirements.txt
@@ -11,6 +11,6 @@ pydantic>=2.11
 rank-bm25==0.2.2
 anyio==4.9.0
 PyJWT==2.10.1
-mcp>=1.18.0
+mcp>=1.18.0,<2
 websockets>=15.0.1
 httpx[http2]>=0.27.2


### PR DESCRIPTION
Fixes #2147

## Summary
The `mcp` Python SDK released **v2.0.0** (2026-07-28), which removed the v1 low-level `Server.list_tools/call_tool/list_resources/read_resource/list_resource_templates` decorator API. `deploy/docker/mcp_bridge.py` still uses that API, and `deploy/docker/requirements.txt` pins `mcp>=1.18.0` with no upper bound, so a fresh install resolves `mcp==2.0.0` and the server crashes at boot:

```
AttributeError: 'Server' object has no attribute 'list_tools'
```

`server.py` calls `attach_mcp()` at module import time, so `uvicorn server:app` fails to start, and `.github/workflows/security.yml` (which installs the same requirements) is broken too.

## Fix
Cap mcp below 2, exactly as the mcp v2 release notes recommend for projects that have not migrated yet ("If your project is not ready to migrate, keep a `<2` upper bound on your requirement"):

```diff
- mcp>=1.18.0
+ mcp>=1.18.0,<2
```

A proper migration of `mcp_bridge.py` to the v2 low-level API can be done as a follow-up.

## Verification
- With `mcp==2.0.0`: `attach_mcp()` raises `AttributeError: 'Server' object has no attribute 'list_tools'`.
- With `mcp==1.18.0` (satisfies `>=1.18.0,<2`): the MCP SSE handshake at `/mcp/sse` completes successfully (tested with the `mcp` client `sse_client` + `ClientSession.initialize()`).