### PR TITLE
Enable PDF scraping through the Docker API 

### DIFF
--- a/crawl4ai/processors/pdf/__init__.py
+++ b/crawl4ai/processors/pdf/__init__.py
@@ -7,6 +7,8 @@ from crawl4ai.models import AsyncCrawlResponse, ScrapingResult
 from crawl4ai.content_scraping_strategy import ContentScrapingStrategy
 from .processor import NaivePDFProcessorStrategy  # Assuming your current PDF code is in pdf_processor.py
 
+MAX_PDF_DOWNLOAD_REDIRECTS = 10  # Max redirect hops to follow when downloading a PDF
+
 class PDFCrawlerStrategy(AsyncCrawlerStrategy):
     """Crawler strategy for PDF documents.
 
@@ -68,8 +70,10 @@ class PDFContentScrapingStrategy(ContentScrapingStrategy):
                  extract_images : bool = False,
                  image_save_dir : str = None,
                  batch_size: int = 4,
-                 logger: AsyncLogger = None):
+                 logger: AsyncLogger = None,
+                 url_validator=None):
         self.logger = logger
+        self.url_validator = url_validator # vets the download URL before fetch
         self.pdf_processor = NaivePDFProcessorStrategy(
             save_images_locally=save_images_locally,
             extract_images=extract_images,
@@ -164,7 +168,25 @@ class PDFContentScrapingStrategy(ContentScrapingStrategy):
                 
                 # Download PDF with streaming and timeout
                 # Connection timeout: 10s, Read timeout: 300s (5 minutes for large PDFs)
-                response = requests.get(url, stream=True, timeout=(20, 60 * 10))
+                # Redirects are followed manually so url_validator (when set) can vet every hop BEFORE it is fetched
+                from urllib.parse import urljoin
+                current_url = url
+                for _ in range(MAX_PDF_DOWNLOAD_REDIRECTS):
+                    if self.url_validator:
+                        self.url_validator(current_url)
+                    response = requests.get(current_url, stream=True, timeout=(20, 60 * 10),
+                                            allow_redirects=False)
+                    if response.is_redirect:
+                        location = response.headers.get("location")
+                        response.close()  # hop response holds its connection open (stream=True)
+                        if not location:
+                            raise RuntimeError(f"Redirect without Location header from {current_url}")
+                        current_url = urljoin(current_url, location)
+                        continue
+                    break
+                else:
+                    raise RuntimeError(
+                        f"Too many redirects (>{MAX_PDF_DOWNLOAD_REDIRECTS}) downloading PDF from {url}")
                 response.raise_for_status()
                 
                 # Get file size if available

--- a/deploy/docker/api.py
+++ b/deploy/docker/api.py
@@ -701,6 +701,8 @@ async def handle_crawl_request(
             if hooks_config:
                 # PDFCrawlerStrategy has no browser page, so hooks can't attach to it
                 raise HTTPException(status_code=400, detail="Hooks are not supported with PDFContentScrapingStrategy")
+            # SSRF protection: vet the PDF download URL and every redirect hop
+            crawler_config.scraping_strategy.url_validator = validate_url_destination
             # Use PDFCrawlerStrategy when scraping PDFs, as headless Chromium can't render PDFs inline
             crawler = AsyncWebCrawler(crawler_strategy=PDFCrawlerStrategy())
             await crawler.start()
@@ -923,6 +925,8 @@ async def handle_stream_crawl_request(
             if hooks_config:
                 # PDFCrawlerStrategy has no browser page, so hooks can't attach to it
                 raise HTTPException(status_code=400, detail="Hooks are not supported with PDFContentScrapingStrategy")
+            # SSRF protection: vet the PDF download URL and every redirect hop
+            crawler_config.scraping_strategy.url_validator = validate_url_destination
             # Use PDFCrawlerStrategy when scraping PDFs, as headless Chromium can't render PDFs inline
             crawler = AsyncWebCrawler(crawler_strategy=PDFCrawlerStrategy())
             await crawler.start()

--- a/deploy/docker/api.py
+++ b/deploy/docker/api.py
@@ -85,6 +85,7 @@ from utils import (
     get_llm_base_url,
     get_redis_task_ttl,
     validate_url_destination,
+    datetime_handler,
 )
 from webhook import WebhookDeliveryService
 
@@ -607,6 +608,7 @@ async def stream_results(crawler: AsyncWebCrawler, results_gen: AsyncGenerator) 
     import json
     from utils import datetime_handler
     from crawler_pool import release_crawler
+    from crawl4ai.processors.pdf import PDFCrawlerStrategy
 
     try:
         async for result in results_gen:
@@ -634,7 +636,10 @@ async def stream_results(crawler: AsyncWebCrawler, results_gen: AsyncGenerator) 
         logger.warning("Client disconnected during streaming")
     finally:
         if crawler:
-            await release_crawler(crawler)
+            if isinstance(crawler.crawler_strategy, PDFCrawlerStrategy):
+                await crawler.close()  # not pooled; release_crawler would be a no-op
+            else:
+                await release_crawler(crawler)
 
 
 def _normalize_and_validate_seeds(urls: List[str]) -> List[str]:
@@ -659,6 +664,7 @@ async def handle_crawl_request(
     # Track request start
     request_id = f"req_{uuid4().hex[:8]}"
     crawler = None
+    is_pdf_crawl = False
     try:
         from monitor import get_monitor
         await get_monitor().track_request_start(
@@ -689,7 +695,17 @@ async def handle_crawl_request(
         )
         
         from crawler_pool import get_crawler, release_crawler
-        crawler = await get_crawler(browser_config)
+        from crawl4ai.processors.pdf import PDFContentScrapingStrategy, PDFCrawlerStrategy
+        is_pdf_crawl = isinstance(crawler_config.scraping_strategy, PDFContentScrapingStrategy)
+        if is_pdf_crawl:
+            if hooks_config:
+                # PDFCrawlerStrategy has no browser page, so hooks can't attach to it
+                raise HTTPException(status_code=400, detail="Hooks are not supported with PDFContentScrapingStrategy")
+            # Use PDFCrawlerStrategy when scraping PDFs, as headless Chromium can't render PDFs inline
+            crawler = AsyncWebCrawler(crawler_strategy=PDFCrawlerStrategy())
+            await crawler.start()
+        else:
+            crawler = await get_crawler(browser_config)
         
         # Attach declarative hooks if provided
         hooks_status = {}
@@ -771,6 +787,10 @@ async def handle_crawl_request(
                 if result_dict.get('pdf') is not None and isinstance(result_dict.get('pdf'), bytes):
                     result_dict['pdf'] = b64encode(result_dict['pdf']).decode('utf-8')
                     
+                if is_pdf_crawl:
+                    # PDF metadata contains datetimes that JSONResponse can't serialize
+                    result_dict = json.loads(json.dumps(result_dict, default=datetime_handler))
+
                 processed_results.append(result_dict)
             except Exception as e:
                 logger.error(f"Error processing result: {e}")
@@ -851,7 +871,10 @@ async def handle_crawl_request(
         )
     finally:
         if crawler:
-            await release_crawler(crawler)
+            if is_pdf_crawl:
+                await crawler.close()  # not pooled; release_crawler would be a no-op
+            else:
+                await release_crawler(crawler)
 
 async def handle_stream_crawl_request(
     urls: List[str],
@@ -895,7 +918,16 @@ async def handle_stream_crawl_request(
             )
 
         from crawler_pool import get_crawler, release_crawler
-        crawler = await get_crawler(browser_config)
+        from crawl4ai.processors.pdf import PDFContentScrapingStrategy, PDFCrawlerStrategy
+        if isinstance(crawler_config.scraping_strategy, PDFContentScrapingStrategy):
+            if hooks_config:
+                # PDFCrawlerStrategy has no browser page, so hooks can't attach to it
+                raise HTTPException(status_code=400, detail="Hooks are not supported with PDFContentScrapingStrategy")
+            # Use PDFCrawlerStrategy when scraping PDFs, as headless Chromium can't render PDFs inline
+            crawler = AsyncWebCrawler(crawler_strategy=PDFCrawlerStrategy())
+            await crawler.start()
+        else:
+            crawler = await get_crawler(browser_config)
 
         # Attach declarative hooks if provided
         if hooks_config:

--- a/deploy/docker/api.py
+++ b/deploy/docker/api.py
@@ -603,12 +603,19 @@ def create_task_response(task: dict, task_id: str, base_url: str) -> dict:
 
     return response
 
+async def _dispose_crawler(crawler):
+    """Close a dedicated PDF crawler (not pooled) or release a pooled one."""
+    from crawl4ai.processors.pdf import PDFCrawlerStrategy
+    from crawler_pool import release_crawler
+    if isinstance(crawler.crawler_strategy, PDFCrawlerStrategy):
+        await crawler.close()
+    else:
+        await release_crawler(crawler)
+
 async def stream_results(crawler: AsyncWebCrawler, results_gen: AsyncGenerator) -> AsyncGenerator[bytes, None]:
     """Stream results with heartbeats and completion markers."""
     import json
     from utils import datetime_handler
-    from crawler_pool import release_crawler
-    from crawl4ai.processors.pdf import PDFCrawlerStrategy
 
     try:
         async for result in results_gen:
@@ -636,10 +643,7 @@ async def stream_results(crawler: AsyncWebCrawler, results_gen: AsyncGenerator) 
         logger.warning("Client disconnected during streaming")
     finally:
         if crawler:
-            if isinstance(crawler.crawler_strategy, PDFCrawlerStrategy):
-                await crawler.close()  # not pooled; release_crawler would be a no-op
-            else:
-                await release_crawler(crawler)
+            await _dispose_crawler(crawler)
 
 
 def _normalize_and_validate_seeds(urls: List[str]) -> List[str]:
@@ -727,6 +731,9 @@ async def handle_crawl_request(
                         current_value = getattr(cfg, key)
                         if current_value is None or current_value == "":
                             setattr(cfg, key, value)
+                # SSRF: per-URL PDF strategies need the validator wired too
+                if isinstance(cfg.scraping_strategy, PDFContentScrapingStrategy):
+                    cfg.scraping_strategy.url_validator = validate_url_destination
             effective_config = config_list
         else:
             # Single config (original behavior)
@@ -919,7 +926,7 @@ async def handle_stream_crawl_request(
                 ),
             )
 
-        from crawler_pool import get_crawler, release_crawler
+        from crawler_pool import get_crawler
         from crawl4ai.processors.pdf import PDFContentScrapingStrategy, PDFCrawlerStrategy
         if isinstance(crawler_config.scraping_strategy, PDFContentScrapingStrategy):
             if hooks_config:
@@ -964,21 +971,21 @@ async def handle_stream_crawl_request(
 
     except (UntrustedConfigError, HookValidationError) as e:
         if crawler:
-            await release_crawler(crawler)
+            await _dispose_crawler(crawler)
         raise HTTPException(status_code=400, detail=f"Rejected request: {e}")
 
     except HTTPException:
         # Deliberate status (e.g. 400 SSRF "URL blocked") must pass through
         # rather than be genericized to 500 by the handler below.
         if crawler:
-            await release_crawler(crawler)
+            await _dispose_crawler(crawler)
         raise
 
     except Exception as e:
-        # Release crawler on setup error (for successful streams,
-        # release happens in stream_results finally block)
+        # Dispose crawler on setup error (for successful streams,
+        # disposal happens in stream_results finally block)
         if crawler:
-            await release_crawler(crawler)
+            await _dispose_crawler(crawler)
         logger.error(f"Stream crawl error: {str(e)}", exc_info=True)
         # Raising HTTPException here will prevent streaming response
         raise HTTPException(

--- a/tests/test_docker_pdf_crawler_pairing.py
+++ b/tests/test_docker_pdf_crawler_pairing.py
@@ -13,7 +13,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from crawl4ai.processors.pdf import PDFCrawlerStrategy
+from crawl4ai.processors.pdf import PDFContentScrapingStrategy, PDFCrawlerStrategy
 
 ROOT = Path(__file__).resolve().parent.parent
 
@@ -86,6 +86,10 @@ async def test_pdf_scraping_strategy_gets_pdf_crawler(api, pool_mock, monkeypatc
     pool_mock.assert_not_awaited()
     # The dedicated PDF crawler is not pooled, so the handler must close it.
     used["crawler"].close.assert_awaited_once()
+    # SSRF protection: the handler must wire the server's URL validator into
+    # the scraping strategy so every download/redirect hop is vetted.
+    effective_config = used["crawler"].arun.await_args.kwargs["config"]
+    assert effective_config.scraping_strategy.url_validator is api.validate_url_destination
 
 
 @pytest.mark.asyncio
@@ -121,3 +125,82 @@ async def test_default_strategy_still_uses_pool(api, pool_mock):
 
     assert response["success"] is True
     pool_mock.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# PDF download redirect handling (url_validator SSRF guard)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def redirect_server():
+    """Real HTTP server: /hop redirects to /doc.pdf, which serves a tiny PDF."""
+    import http.server
+    import socket
+    import threading
+
+    pdf_bytes = (b"%PDF-1.4\n1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n"
+                 b"2 0 obj\n<< /Type /Pages /Kids [] /Count 0 >>\nendobj\n"
+                 b"xref\n0 3\n0000000000 65535 f \n0000000009 00000 n \n"
+                 b"0000000058 00000 n \ntrailer\n<< /Size 3 /Root 1 0 R >>\n"
+                 b"startxref\n110\n%%EOF\n")
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            if self.path == "/hop":
+                self.send_response(302)
+                self.send_header("Location", "/doc.pdf")
+                self.end_headers()
+            elif self.path == "/loop":
+                self.send_response(302)
+                self.send_header("Location", "/loop")
+                self.end_headers()
+            else:
+                self.send_response(200)
+                self.send_header("Content-Type", "application/pdf")
+                self.end_headers()
+                self.wfile.write(pdf_bytes)
+
+        def log_message(self, *args):
+            pass
+
+    with socket.socket() as s:
+        s.bind(("localhost", 0))
+        port = s.getsockname()[1]
+    httpd = http.server.ThreadingHTTPServer(("localhost", port), Handler)
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    yield f"http://localhost:{port}"
+    httpd.shutdown()
+
+
+def test_download_validator_vets_every_redirect_hop(redirect_server):
+    """The validator must see BOTH the original URL and the redirect target,
+    and a raising validator must abort the download before the hop is fetched."""
+    seen = []
+
+    def validator(u):
+        seen.append(u)
+        if u.endswith("/doc.pdf"):
+            raise ValueError("blocked hop")
+
+    strategy = PDFContentScrapingStrategy(url_validator=validator)
+    with pytest.raises(RuntimeError, match="Failed to download"):
+        strategy._get_pdf_path(f"{redirect_server}/hop")
+
+    assert seen == [f"{redirect_server}/hop", f"{redirect_server}/doc.pdf"]
+
+
+def test_download_redirects_still_followed_without_validator(redirect_server):
+    """Back-compat: with no validator, redirects are followed as before."""
+    strategy = PDFContentScrapingStrategy()
+    path = strategy._get_pdf_path(f"{redirect_server}/hop")
+    try:
+        assert Path(path).read_bytes().startswith(b"%PDF")
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def test_download_redirect_loop_aborts(redirect_server):
+    """An endless redirect chain must abort after the cap, not hang."""
+    strategy = PDFContentScrapingStrategy()
+    with pytest.raises(RuntimeError, match="[Tt]oo many redirects"):
+        strategy._get_pdf_path(f"{redirect_server}/loop")

--- a/tests/test_docker_pdf_crawler_pairing.py
+++ b/tests/test_docker_pdf_crawler_pairing.py
@@ -1,0 +1,123 @@
+"""Tests for the Docker API's PDF crawler pairing.
+
+When a client requests PDFContentScrapingStrategy, the crawl handlers must
+pair it with PDFCrawlerStrategy (which downloads the PDF itself) instead of a
+pooled Playwright crawler — headless Chromium cannot render PDFs inline, so
+browser navigation fails with "Page.goto: Download is starting" before the
+scraping strategy ever runs.
+"""
+
+import importlib
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from crawl4ai.processors.pdf import PDFCrawlerStrategy
+
+ROOT = Path(__file__).resolve().parent.parent
+
+CONFIG = {
+    "crawler": {
+        "memory_threshold_percent": 90,
+        "rate_limiter": {"enabled": False, "base_delay": [0.1, 0.3]},
+        "base_config": {},
+    }
+}
+
+
+def _crawler_config_payload(with_pdf_strategy):
+    params = {"cache_mode": "bypass"}
+    if with_pdf_strategy:
+        params["scraping_strategy"] = {
+            "type": "PDFContentScrapingStrategy",
+            "params": {},
+        }
+    return {"type": "CrawlerRunConfig", "params": params}
+
+
+@pytest.fixture
+def api(monkeypatch):
+    monkeypatch.syspath_prepend(str(ROOT / "deploy" / "docker"))
+    return importlib.import_module("api")
+
+
+@pytest.fixture
+def pool_mock(api, monkeypatch):
+    crawler_pool = importlib.import_module("crawler_pool")
+    egress_broker = importlib.import_module("egress_broker")
+    governor = importlib.import_module("governor")
+
+    pooled = MagicMock()
+    pooled.arun = AsyncMock(return_value=[])
+    pooled.active_requests = 1  # release_crawler decrements this int
+    mock = AsyncMock(return_value=pooled)
+    monkeypatch.setattr(crawler_pool, "get_crawler", mock)
+    monkeypatch.setattr(api, "_normalize_and_validate_seeds", lambda urls: urls)
+    monkeypatch.setattr(egress_broker, "enforce_egress", lambda _: None)
+    monkeypatch.setattr(governor, "clamp_deep_crawl", lambda _: None)
+    return mock
+
+
+@pytest.mark.asyncio
+async def test_pdf_scraping_strategy_gets_pdf_crawler(api, pool_mock, monkeypatch):
+    used = {}
+    real_crawler_cls = api.AsyncWebCrawler
+
+    def spy_crawler(*args, **kwargs):
+        crawler = real_crawler_cls(*args, **kwargs)
+        used["crawler"] = crawler
+        used["crawler_strategy"] = crawler.crawler_strategy
+        crawler.arun = AsyncMock(return_value=[])
+        crawler.close = AsyncMock(wraps=crawler.close)
+        return crawler
+
+    monkeypatch.setattr(api, "AsyncWebCrawler", spy_crawler)
+
+    response = await api.handle_crawl_request(
+        urls=["https://example.com/document.pdf"],
+        browser_config={"type": "BrowserConfig", "params": {}},
+        crawler_config=_crawler_config_payload(with_pdf_strategy=True),
+        config=CONFIG,
+    )
+
+    assert response["success"] is True
+    assert isinstance(used["crawler_strategy"], PDFCrawlerStrategy)
+    pool_mock.assert_not_awaited()
+    # The dedicated PDF crawler is not pooled, so the handler must close it.
+    used["crawler"].close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_pdf_strategy_with_hooks_rejected(api, pool_mock):
+    from fastapi import HTTPException
+
+    # A VALID hook action: without the guard this reaches set_hook and blows up
+    # with AttributeError (PDFCrawlerStrategy has no set_hook) -> 500. An invalid
+    # action would 400 via HookValidationError even without the guard, proving nothing.
+    hooks = {"hooks": [{"action": "block_resources", "params": {"resource_types": ["image"]}}]}
+    with pytest.raises(HTTPException) as exc_info:
+        await api.handle_crawl_request(
+            urls=["https://example.com/document.pdf"],
+            browser_config={"type": "BrowserConfig", "params": {}},
+            crawler_config=_crawler_config_payload(with_pdf_strategy=True),
+            config=CONFIG,
+            hooks_config=hooks,
+        )
+
+    assert exc_info.value.status_code == 400
+    assert "PDFContentScrapingStrategy" in exc_info.value.detail
+    pool_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_default_strategy_still_uses_pool(api, pool_mock):
+    response = await api.handle_crawl_request(
+        urls=["https://example.com/"],
+        browser_config={"type": "BrowserConfig", "params": {}},
+        crawler_config=_crawler_config_payload(with_pdf_strategy=False),
+        config=CONFIG,
+    )
+
+    assert response["success"] is True
+    pool_mock.assert_awaited_once()

--- a/tests/test_issue_2127_docker_pdf.py
+++ b/tests/test_issue_2127_docker_pdf.py
@@ -31,16 +31,16 @@ async def test_stream_handler_preserves_requested_scraping_strategy(monkeypatch)
     monkeypatch.syspath_prepend(str(docker_dir))
 
     api = importlib.import_module("api")
-    crawler_pool = importlib.import_module("crawler_pool")
     egress_broker = importlib.import_module("egress_broker")
     governor = importlib.import_module("governor")
 
     crawler = MagicMock()
     crawler.arun_many = AsyncMock(return_value=MagicMock())
+    crawler.start = AsyncMock()
     monkeypatch.setattr(api, "_normalize_and_validate_seeds", lambda urls: urls)
     monkeypatch.setattr(egress_broker, "enforce_egress", lambda _: None)
     monkeypatch.setattr(governor, "clamp_deep_crawl", lambda _: None)
-    monkeypatch.setattr(crawler_pool, "get_crawler", AsyncMock(return_value=crawler))
+    monkeypatch.setattr(api, "AsyncWebCrawler", MagicMock(return_value=crawler))
 
     crawler_config = {
         "type": "CrawlerRunConfig",


### PR DESCRIPTION
## Summary

**Depends on #2130** - needs pypdf in the image and the client's `scraping_strategy` honored on `/crawl/stream`.

Fixes the remaining blocker for PDF scraping through the Docker API (#2127). Even with PR: #2130, every PDF crawl still failed at browser navigation with `Page.goto: Download is starting`, because the server always used the pooled Playwright crawler and headless Chromium can't render PDFs inline.

When a request's `scraping_strategy` is `PDFContentScrapingStrategy`, both crawl handlers now build a per-request `AsyncWebCrawler(crawler_strategy=PDFCrawlerStrategy())` - the exact pairing the library documents - instead of borrowing a pooled browser. `PDFCrawlerStrategy` starts no browser (it returns a placeholder and the scraping strategy downloads/parses the PDF itself), so a per-request instance is cheap and is closed after use.

This is gated on the scraping strategy, mirroring the library, rather than sniffing the URL or Content-Type.

### Also included

- **Hooks guard:** a hooks block combined with the PDF strategy now returns a clean `400` instead of `AttributeError: 'PDFCrawlerStrategy' object has no attribute 'set_hook'` → `500`.
- **Datetime serialization:** PDF metadata datetimes are stringified so `JSONResponse` can serialize `/crawl` results (gated to PDF requests, so normal crawls pay no cost).
- **SSRF protection:** `PDFContentScrapingStrategy` downloads the PDF itself via `requests`, which previously followed redirects blindly. It now follows redirects manually (cap 10) and, when the server passes its `validate_url_destination` in as a `url_validator`, vets the download URL and every redirect hop **before** it is fetched — closing a redirect-to-internal-address (e.g. cloud metadata) SSRF vector. The `url_validator` param defaults to `None`, so library users are unaffected.

## List of files changed and why
- `deploy/docker/api.py` — route PDF-strategy requests to `PDFCrawlerStrategy`, guard hooks, close the per-request crawler, sanitize datetimes, wire the SSRF validator.
- `crawl4ai/processors/pdf/__init__.py` — optional `url_validator` hook and manual per-hop redirect handling in `PDFContentScrapingStrategy._get_pdf_path`; `MAX_PDF_DOWNLOAD_REDIRECTS` constant.
- `tests/test_docker_pdf_crawler_pairing.py` — handler-level routing/hooks/pool tests and library-level redirect/validator tests.

## How Has This Been Tested?
Image built from `develop` + #2130 + this branch:

- **PDF works on both endpoints:** arxiv, pdf.js, pdfobject on `/crawl` and `/crawl/stream`.
- **SSRF blocked:** a redirect to `169.254.169.254` is vetted and rejected before fetch (verified with the real `validate_url_destination` + the redirect loop); a direct internal seed is still `400` at the seed layer.
- **No regression:** plain HTML, explicit `LXMLWebScrapingStrategy`, multi-URL, streaming, screenshot, `/md`, and hooks-on-HTML all behave as before; repeated PDF crawls leave no lingering crawlers in the pool.
- `tests/test_docker_pdf_crawler_pairing.py` (6 tests) pass; each fix verified to fail with its change reverted.
- Full regression suite: `293 passed` (one pre-existing unrelated `transformers`-missing failure).

## Note for after #2130 merges

Its `test_stream_handler_preserves_requested_scraping_strategy` mocks `crawler_pool.get_crawler`, which PDF requests no longer call (they build a `PDFCrawlerStrategy` crawler directly). The test uses a PDF strategy, so after this merge the mock is never hit and its `arun_many` assertion fails on `await_args is None`. The fix is small — spy on `api.AsyncWebCrawler` (or otherwise intercept the PDF-branch crawler) instead of mocking the pool. Happy to include the adjustment on rebase.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added/updated unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
