### PR TITLE
feat: opt-in `block_internal_urls` egress filter for the library layer (Refs #2146)

### DIFF
--- a/crawl4ai/async_configs.py
+++ b/crawl4ai/async_configs.py
@@ -1686,6 +1686,11 @@ class CrawlerRunConfig():
         url: str = None,
         base_url: str = None,  # Base URL for markdown link resolution (used with raw: HTML)
         check_robots_txt: bool = False,
+        # SSRF protection (opt-in): block crawl targets on internal/private
+        # networks (loopback, private, link-local incl. cloud metadata, etc.).
+        # See crawl4ai/url_safety.py. Disabled by default to preserve the
+        # user-agent contract.
+        block_internal_urls: bool = False,
         user_agent: str = None,
         user_agent_mode: str = None,
         user_agent_generator_config: dict = {},
@@ -1828,6 +1833,9 @@ class CrawlerRunConfig():
 
         # Robots.txt Handling Parameters
         self.check_robots_txt = check_robots_txt
+
+        # SSRF protection (opt-in)
+        self.block_internal_urls = block_internal_urls
 
         # User Agent Parameters
         self.user_agent = user_agent
@@ -2175,6 +2183,7 @@ class CrawlerRunConfig():
             "prefetch": self.prefetch,
             "process_in_browser": self.process_in_browser,
             "check_robots_txt": self.check_robots_txt,
+            "block_internal_urls": self.block_internal_urls,
             "user_agent": self.user_agent,
             "user_agent_mode": self.user_agent_mode,
             "user_agent_generator_config": self.user_agent_generator_config,

--- a/crawl4ai/async_crawler_strategy.py
+++ b/crawl4ai/async_crawler_strategy.py
@@ -23,6 +23,7 @@ from .ssl_certificate import SSLCertificate
 from .user_agent_generator import ValidUAGenerator, UAGen
 from .browser_manager import BrowserManager
 from .browser_adapter import BrowserAdapter, PlaywrightAdapter, UndetectedAdapter
+from .url_safety import check_url_destination, BlockedURLError
 
 import aiofiles
 import aiohttp
@@ -455,6 +456,9 @@ class AsyncPlaywrightCrawlerStrategy(AsyncCrawlerStrategy):
         response_headers = {}
         status_code = 200  # Default for local/raw HTML
         screenshot_data = None
+
+        if config.block_internal_urls and url.startswith(("http://", "https://")):
+            check_url_destination(url)
 
         if url.startswith(("http://", "https://", "view-source:")):
             return await self._crawl_web(url, config)
@@ -2808,7 +2812,10 @@ class AsyncHTTPCrawlerStrategy(AsyncCrawlerStrategy):
         
         if scheme not in self.VALID_SCHEMES:
             raise ValueError(f"Unsupported URL scheme: {scheme}")
-            
+
+        if config.block_internal_urls and scheme in ("http", "https"):
+            check_url_destination(url)
+
         try:
             if scheme == 'file':
                 return await self._handle_file(parsed.path)

--- a/crawl4ai/url_safety.py
+++ b/crawl4ai/url_safety.py
@@ -1,0 +1,152 @@
+"""Opt-in SSRF protection for the library layer.
+
+This module provides ``block_internal_urls`` enforcement for the core
+``crawl4ai`` library. It is intentionally dependency-free (no FastAPI, no
+egress proxy) so it can be imported from the library without pulling in the
+Docker server stack.
+
+Design notes
+------------
+* The trust boundary for *untrusted* URL sources remains the Docker API server
+  (``deploy/docker/egress_broker.py``), which pins DNS and revalidates every
+  redirect hop through a dedicated egress proxy. That server-side enforcement
+  is authoritative for multi-tenant deployments.
+* This library-side helper is the same *destination-classification* logic,
+  exposed as an opt-in flag for callers who embed Crawl4AI in an agent where an
+  LLM / prompt-injection can steer the crawl target at internal hosts *before*
+  the embedding app validates the URL.
+* Because the library connects directly (it does not proxy through a pinning
+  egress broker), the check is a pre-connection, single-resolution check. It
+  therefore defends against the obvious cases (literal internal IPs, localhost,
+  link-local/cloud-metadata, private ranges) but does **not** guarantee
+  protection against DNS-rebinding / TOCTOU attacks. Deployments that need that
+  guarantee must still terminate egress through the Docker server.
+"""
+
+import ipaddress
+import os
+import socket
+from urllib.parse import urlparse
+
+# Same address ranges the Docker server blocks (deploy/docker/utils.py).
+_BLOCKED_NETWORKS = [
+    ipaddress.ip_network("0.0.0.0/8"),
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("100.64.0.0/10"),
+    ipaddress.ip_network("127.0.0.0/8"),
+    ipaddress.ip_network("169.254.0.0/16"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.0.0.0/24"),
+    ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("198.18.0.0/15"),
+    ipaddress.ip_network("::1/128"),
+    ipaddress.ip_network("fc00::/7"),
+    ipaddress.ip_network("fe80::/10"),
+]
+
+# Hostnames that should never be crawled regardless of resolution.
+_BLOCKED_HOSTNAMES = {
+    "localhost",
+    "metadata.google.internal",
+    "metadata",
+    "kubernetes.default",
+    "kubernetes.default.svc",
+}
+
+# Escape hatch mirroring the Docker server (deploy/docker/utils.py).
+ALLOW_INTERNAL_URLS = (
+    os.environ.get("CRAWL4AI_ALLOW_INTERNAL_URLS", "false").lower() == "true"
+)
+
+
+class BlockedURLError(ValueError):
+    """Raised when a crawl URL targets an internal/private address and
+    ``block_internal_urls`` is enabled.
+
+    The message is intentionally opaque: it never echoes the resolved IP or
+    hostname, so the error is not a DNS-oracle leak.
+    """
+
+
+def _expand_ip_candidates(ip: "ipaddress.IPv4Address | ipaddress.IPv6Address"):
+    """Return ``[ip]`` plus any IPv4 form embedded inside an IPv6 address.
+
+    SSRF guards must check the unwrapped form because ``::ffff:127.0.0.1`` and
+    ``::127.0.0.1`` route to ``127.0.0.1`` but would not match IPv4 blocklists
+    directly.
+    """
+    candidates = [ip]
+    if isinstance(ip, ipaddress.IPv6Address):
+        if ip.ipv4_mapped is not None:
+            candidates.append(ip.ipv4_mapped)
+        else:
+            as_int = int(ip)
+            if 0 < as_int < 2**32:
+                candidates.append(ipaddress.IPv4Address(as_int))
+    return candidates
+
+
+def _is_internal_ip(addr: "ipaddress.IPv4Address | ipaddress.IPv6Address") -> bool:
+    for candidate in _expand_ip_candidates(addr):
+        if any(candidate in net for net in _BLOCKED_NETWORKS):
+            return True
+        # is_global is False for loopback / private / link-local / ULA / reserved.
+        if not candidate.is_global:
+            return True
+    return False
+
+
+def is_internal_url(url: str) -> bool:
+    """Return ``True`` if ``url`` resolves to an internal/private address.
+
+    ``raw:``/``raw://`` URLs are inline HTML (no network fetch) and are never
+    considered internal. Resolution failures are treated as internal
+    (fail-closed) so an attacker cannot abuse a DNS error to bypass the check.
+    """
+    if str(url).startswith(("raw:", "raw://")):
+        return False
+    parsed = urlparse(str(url))
+    if not parsed.hostname:
+        # No host to validate (e.g. a bare path) -> nothing to block.
+        return False
+    hostname = parsed.hostname
+    if hostname in _BLOCKED_HOSTNAMES:
+        return True
+
+    # Fast path: a literal IP address.
+    try:
+        addr = ipaddress.ip_address(hostname)
+        return _is_internal_ip(addr)
+    except ValueError:
+        pass
+
+    # Hostname: resolve and inspect every A/AAAA record.
+    try:
+        infos = socket.getaddrinfo(hostname, None)
+    except (socket.gaierror, UnicodeError, OSError):
+        # Fail closed: cannot prove the target is safe.
+        return True
+
+    for family, _type, _proto, _canon, sockaddr in infos:
+        ip_text = sockaddr[0].split("%")[0]  # strip IPv6 scope id
+        try:
+            addr = ipaddress.ip_address(ip_text)
+        except ValueError:
+            # Unparseable resolved address -> fail closed.
+            return True
+        if _is_internal_ip(addr):
+            return True
+    return False
+
+
+def check_url_destination(url: str) -> None:
+    """Raise :class:`BlockedURLError` if ``url`` targets an internal address.
+
+    No-op when ``CRAWL4AI_ALLOW_INTERNAL_URLS`` is set, and for ``raw:`` URLs.
+    """
+    if ALLOW_INTERNAL_URLS:
+        return
+    if is_internal_url(url):
+        raise BlockedURLError(
+            "URL blocked by block_internal_urls: destination is internal/private"
+        )

--- a/tests/async/test_url_safety.py
+++ b/tests/async/test_url_safety.py
@@ -1,0 +1,145 @@
+import os
+import sys
+import threading
+import http.server
+import importlib
+
+import pytest
+
+# Make the local package importable when running from the repo root.
+parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if parent_dir not in sys.path:
+    sys.path.append(parent_dir)
+
+from crawl4ai.url_safety import (
+    check_url_destination,
+    is_internal_url,
+    BlockedURLError,
+)
+from crawl4ai.async_configs import CrawlerRunConfig
+from crawl4ai.async_crawler_strategy import AsyncHTTPCrawlerStrategy
+
+
+# ---------------------------------------------------------------------------
+# Pure url_safety classification (deterministic: only IP literals / no DNS)
+# ---------------------------------------------------------------------------
+
+INTERNAL_URLS = [
+    "http://127.0.0.1",
+    "http://127.0.0.1:8080",
+    "http://169.254.169.254/latest/meta-data/",
+    "http://[::1]",
+    "http://10.0.0.5",
+    "http://192.168.1.1",
+    "http://172.16.0.1",
+    "http://0.0.0.0",
+    "http://100.64.0.1",  # CGN / shared address space
+]
+
+EXTERNAL_URLS = [
+    "http://1.1.1.1",
+    "http://8.8.8.8",
+    "http://[2606:4700:4700::1111]",  # global IPv6 literal
+    "raw://<html>hi</html>",
+    "file:///etc/passwd",
+]
+
+
+@pytest.mark.parametrize("url", INTERNAL_URLS)
+def test_is_internal_url_true(url):
+    assert is_internal_url(url) is True
+
+
+@pytest.mark.parametrize("url", EXTERNAL_URLS)
+def test_is_internal_url_false(url):
+    assert is_internal_url(url) is False
+
+
+def test_check_url_destination_raises_on_internal():
+    with pytest.raises(BlockedURLError):
+        check_url_destination("http://127.0.0.1")
+
+
+def test_check_url_destination_passes_on_external():
+    # 1.1.1.1 is a global IP literal; no DNS resolution required.
+    check_url_destination("http://1.1.1.1")  # must not raise
+
+
+def test_check_url_destination_allow_env_override(monkeypatch):
+    import crawl4ai.url_safety as us
+
+    monkeypatch.setattr(us, "ALLOW_INTERNAL_URLS", True)
+    us.check_url_destination("http://127.0.0.1")  # must not raise
+    monkeypatch.setattr(us, "ALLOW_INTERNAL_URLS", False)
+
+
+# ---------------------------------------------------------------------------
+# CrawlerRunConfig field
+# ---------------------------------------------------------------------------
+
+
+def test_config_default_false():
+    assert CrawlerRunConfig().block_internal_urls is False
+
+
+def test_config_set_true():
+    assert CrawlerRunConfig(block_internal_urls=True).block_internal_urls is True
+
+
+def test_config_to_dict_roundtrip():
+    c = CrawlerRunConfig(block_internal_urls=True)
+    assert c.to_dict()["block_internal_urls"] is True
+    c2 = CrawlerRunConfig.from_kwargs(c.to_dict())
+    assert c2.block_internal_urls is True
+
+
+def test_config_clone_preserves():
+    c = CrawlerRunConfig(block_internal_urls=True)
+    assert c.clone().block_internal_urls is True
+
+
+# ---------------------------------------------------------------------------
+# Integration: the chokepoint in AsyncCrawlerStrategy.crawl() actually fires
+# ---------------------------------------------------------------------------
+
+
+def _start_local_server():
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html")
+            self.end_headers()
+            self.wfile.write(b"<html><body>LOCAL_OK</body></html>")
+
+        def log_message(self, *args):
+            pass
+
+    srv = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+    port = srv.server_address[1]
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    return srv, port
+
+
+@pytest.mark.asyncio
+async def test_http_strategy_blocks_internal():
+    srv, port = _start_local_server()
+    try:
+        strat = AsyncHTTPCrawlerStrategy()
+        cfg = CrawlerRunConfig(block_internal_urls=True)
+        with pytest.raises(BlockedURLError):
+            await strat.crawl(f"http://127.0.0.1:{port}/", config=cfg)
+    finally:
+        srv.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_http_strategy_allows_by_default():
+    srv, port = _start_local_server()
+    try:
+        strat = AsyncHTTPCrawlerStrategy()
+        cfg = CrawlerRunConfig(block_internal_urls=False)
+        resp = await strat.crawl(f"http://127.0.0.1:{port}/", config=cfg)
+        assert resp.html is not None
+        assert "LOCAL_OK" in resp.html
+    finally:
+        srv.shutdown()


### PR DESCRIPTION
## Summary

Implements the opt-in library-side egress filter discussed in #2146. It started life as a responsible-disclosure report (the library fetches any caller-supplied URL, including internal/cloud-metadata addresses), and the maintainers classified that as **intended behavior** for a user-agent invoked by a trusted caller — the SSRF trust boundary correctly lives at the Docker API server (`egress_broker.py`). The one scenario that justifies exposing the same primitives to library callers is **agentic / LLM-chosen-URL** pipelines, where a prompt-injection or malicious page can steer the crawler at internal hosts *before* the embedding app validates the URL.

This PR adds an **opt-in** `block_internal_urls` flag so those callers get server-grade destination filtering without re-implementing it.

## Design

**New module `crawl4ai/url_safety.py`** (dependency-free — no FastAPI, no egress proxy, so it imports cleanly from the library):
- Reuses the **same blocked address ranges** as `deploy/docker/utils.py` (`_BLOCKED_NETWORKS`: loopback, private, link-local incl. `169.254.0.0/16` cloud metadata, CGN `100.64/10`, `0.0.0.0/8`, IPv6 ULA/link-local/loopback) plus a `_BLOCKED_HOSTNAMES` set (`localhost`, `metadata`, `metadata.google.internal`, `kubernetes.default*`).
- `BlockedURLError(ValueError)` with an **opaque message** that never echoes the resolved IP/hostname (no DNS-oracle leak).
- Expands IPv6-embedded IPv4 forms (`::ffff:127.0.0.1`, `::127.0.0.1`) before checking, mirroring the Docker server.
- Honors a `CRAWL4AI_ALLOW_INTERNAL_URLS` escape hatch (parity with the server).
- `raw:`/`raw://` URLs (inline HTML, no network fetch) are never treated as internal.

**Config**: `CrawlerRunConfig.block_internal_urls` (default **`False`**) — preserves the user-agent contract; existing behavior is unchanged. Because `from_kwargs`/`to_dict`/`clone` are signature-driven, the field flows through serialization automatically.

**Chokepoint**: inserted in both crawl entry points right after the scheme allow-list check:
- `AsyncCrawlerStrategy.crawl()` → covers the **HTTP path** (`AsyncHTTPCrawlerStrategy._handle_http`).
- `AsyncPlaywrightCrawlerStrategy.crawl()` → covers the **browser path** (`page.goto`).

Only `http(s)://` URLs are checked; `file://` and `raw:` are local/inline content and are skipped.

## Tests

`tests/async/test_url_safety.py` (23 tests, all passing). Deterministic (IP literals, no DNS dependency):
- `is_internal_url` / `check_url_destination` classification for internal vs global addresses (incl. IPv6, CGN, metadata).
- `BlockedURLError` raised on internal, passes on global.
- `CRAWL4AI_ALLOW_INTERNAL_URLS` override.
- `CrawlerRunConfig` default / set / `to_dict` roundtrip / `clone`.
- **Integration**: a local HTTP server + `AsyncHTTPCrawlerStrategy` proves the chokepoint actually fires — `block_internal_urls=True` raises before any connection, `False` (default) fetches and returns content.

## Answers to the open questions from #2146

1. **Flag name** — went with `block_internal_urls` (matches the existing `check_robots_txt` / `prefetch` style on `CrawlerRunConfig`). Happy to rename if you prefer `deny_private_destinations` / `egress_filter`.
2. **Chokepoint** — shared logic lives in `url_safety.py`; it's called from both `crawl()` entry points so HTTP and browser paths stay in sync (no duplicated trust logic).
3. **Browser redirects** — the check covers the **initial** URL (pre-connection, single resolution). Playwright `goto` follows redirects internally and the library connects directly (no pinning proxy), so redirect *hops* are **not** revalidated in this opt-in layer. That gap is exactly why the authoritative trust boundary for untrusted multi-tenant input remains the Docker server's `egress_broker` (DNS pinning + per-hop revalidation). I noted this as a deliberate limitation rather than silently claiming full coverage — if you'd like, a follow-up could add an opt-in "disable browser redirects + manual revalidate" mode.

## Scope note

This is **not** a default-behavior change and does **not** close the original SSRF report's premise — it's the opt-in escape hatch the maintainers offered. Default `arun(url)` behavior is unchanged.

Refs #2146.
