### PR TITLE
fix(docker): restrict MCP SSE route to GET, fixing client connect hangs (#2120)

### DIFF
--- a/deploy/docker/mcp_bridge.py
+++ b/deploy/docker/mcp_bridge.py
@@ -249,7 +249,13 @@ def attach_mcp(
             async with sse.connect_sse(scope, receive, send) as (read_stream, write_stream):
                 await mcp.run(read_stream, write_stream, init_opts)
 
-    app.routes.append(Route(f"{base}/sse", endpoint=_MCPSseApp()))
+    # `methods` must be explicit: for a class-based ASGI endpoint, Starlette's
+    # Route otherwise leaves `self.methods = None`, which matches *any* HTTP
+    # method. A client probing this URL with POST (e.g. an MCP client trying
+    # the Streamable HTTP transport before falling back to SSE) would then be
+    # routed into the SSE handshake instead of getting a fast 405, and hang
+    # until its own client-side timeout.
+    app.routes.append(Route(f"{base}/sse", endpoint=_MCPSseApp(), methods=["GET"]))
     app.routes.append(Mount(f"{base}/messages", app=sse.handle_post_message))
 
     # ── schema endpoint ───────────────────────────────────────

--- a/deploy/docker/tests/test_security_mcp_sse_methods.py
+++ b/deploy/docker/tests/test_security_mcp_sse_methods.py
@@ -1,0 +1,60 @@
+"""
+Regression test for issue #2120: a POST to the MCP SSE endpoint must be
+rejected fast (405), not silently upgraded into an SSE connection.
+
+`/mcp/sse` is mounted as a raw ASGI Route with a class-based endpoint
+(`_MCPSseApp`). Starlette only defaults `methods` to `["GET"]` for
+function/method endpoints; a class-based endpoint with no explicit
+`methods=` matches *every* HTTP verb. Clients that probe an MCP endpoint
+with a POST (e.g. attempting the Streamable HTTP transport before falling
+back to legacy SSE) were routed straight into the SSE handshake instead of
+getting a 405, and the request just hung until the client's own timeout —
+matching the "connect via MCP from LM Studio" timeout report.
+
+The client call runs in a daemon thread with a hard wall-clock bound: on
+the buggy code the request never returns, so awaiting it inline (or via a
+non-daemon executor, whose shutdown() joins the thread) would hang the test
+suite forever instead of failing.
+"""
+
+import threading
+
+import pytest
+
+pytestmark = pytest.mark.cve
+
+from auth import create_access_token
+
+
+def test_post_to_mcp_sse_is_rejected_fast(stock_client):
+    # Authenticate past the AuthGateMiddleware gate so the request actually
+    # reaches routing — an unauthenticated POST would get a fast 401 from the
+    # gate regardless of the route's `methods`, which would not exercise the
+    # bug this test guards against.
+    token = create_access_token({"sub": "user@x.com"}, scope="data")
+
+    result = {}
+
+    def _post():
+        result["response"] = stock_client.post(
+            "/mcp/sse",
+            json={"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    thread = threading.Thread(target=_post, daemon=True)
+    thread.start()
+    thread.join(timeout=5)
+
+    if thread.is_alive():
+        pytest.fail(
+            "POST /mcp/sse did not return within 5s — it was routed into "
+            "the SSE handshake instead of being rejected with 405, so the "
+            "connection hangs until the client's own timeout."
+        )
+
+    response = result["response"]
+    assert response.status_code == 405, (
+        f"POST /mcp/sse returned {response.status_code}; expected 405 "
+        "(only GET should reach the SSE handshake)."
+    )


### PR DESCRIPTION
## Summary

Fixes #2120 — "A timeout occurs when attempting to connect via MCP from LM Studio."

`deploy/docker/mcp_bridge.py` mounts the MCP SSE endpoint like this:

```python
app.routes.append(Route(f"{base}/sse", endpoint=_MCPSseApp()))
```

`_MCPSseApp` is a callable class (used deliberately, per the comment above it,
to get a raw ASGI app instead of Starlette's `request_response()` wrapper —
see #1594/#1850). But Starlette's `Route.__init__` only defaults `methods` to
`["GET"]` when the endpoint is a plain function/method:

```python
if inspect.isfunction(endpoint_handler) or inspect.ismethod(endpoint_handler):
    self.app = request_response(endpoint)
    if methods is None:
        methods = ["GET"]
else:
    self.app = endpoint   # <-- our case: methods stays None
...
if methods is None:
    self.methods = None   # None means "match any method"
```

With `self.methods = None`, `Route.matches()` accepts **every** HTTP verb on
`/mcp/sse`, not just GET. A client that POSTs to that URL — which is exactly
what happens when an MCP client probes for the newer Streamable HTTP
transport before falling back to the legacy two-endpoint SSE transport the
URL name implies — gets routed straight into `sse.connect_sse()`. That opens
an SSE stream and waits for a POST to the (different) `/mcp/messages/`
endpoint that will never arrive from a client that already gave up on this
URL, so the original POST just hangs. There is no error, no fast 404/405 —
the connection sits open until the client's own timeout fires, which matches
the reported symptom exactly ("no response ... times out after several tens
of seconds").

The fix is a one-line addition of the `methods=["GET"]` argument, so the
route only ever matches GET/HEAD, and any other verb gets a normal fast 405
`Allow: GET, HEAD` response instead of being silently absorbed.

I ruled out the currently-open lookalike PRs before writing this — none of
them touch `mcp_bridge.py`, the MCP transport, or Docker auth (#2113 bounds
Playwright `evaluate()`/`page.content()` calls, #2142 is an egress-proxy
feature, #1923 is a dispatcher-level `arun_many` watchdog, #2005 is a docs-only
example) — and confirmed no commit on `develop` since the issue was filed
touches this file either.

## Root cause verification

Reproduced against the actual `mcp_bridge.attach_mcp()` + `AuthGateMiddleware`
+ security-headers middleware stack (installed the pinned `mcp`, `fastapi`,
`sse-starlette` versions from `deploy/docker/requirements.txt` and booted a
minimal app):

```
POST /mcp/sse  (before fix)  -> httpx.ConnectTimeout / never returns
POST /mcp/sse  (after fix)   -> 405 Method Not Allowed, Allow: GET, HEAD, in ~70ms
GET  /mcp/sse  (before/after)-> unchanged: SSE handshake still completes normally
                                 (endpoint event -> POST initialize -> 202 -> SSE
                                 "message" event with the initialize result)
```

## List of files changed and why

- `deploy/docker/mcp_bridge.py` — pass `methods=["GET"]` explicitly to the
  `/mcp/sse` `Route()` call.
- `deploy/docker/tests/test_security_mcp_sse_methods.py` — new regression
  test (named `test_security_*` to match the existing
  `pytest deploy/docker/tests/test_security_*.py` CI glob in
  `.github/workflows/security.yml`). Boots the real app via the `stock_client`
  fixture from `conftest.py`, authenticates past `AuthGateMiddleware` with a
  real JWT (an unauthenticated request would get a fast 401 regardless of
  `methods`, which wouldn't exercise this bug), and POSTs to `/mcp/sse` from a
  daemon thread with a 5s wall-clock bound — so on the buggy code the test
  *fails* after 5s instead of hanging the whole suite forever.

## How Has This Been Tested?

Confirmed the test fails without the fix and passes with it (reverted only
the source change locally, restored afterward):

```
$ pytest deploy/docker/tests/test_security_mcp_sse_methods.py -v   # fix reverted
FAILED ... - Failed: POST /mcp/sse did not return within 5s — it was routed
into the SSE handshake instead of being rejected with 405, so the connection
hangs until the client's own timeout.
1 failed in 6.76s

$ pytest deploy/docker/tests/test_security_mcp_sse_methods.py -v   # fix restored
PASSED
1 passed in 1.63s
```

Full existing security suite, unaffected:

```
$ pytest deploy/docker/tests/test_security_*.py -q
317 passed, 1 xfailed in 2.97s
```

(Installed via `pip install -e .` + `pip install -r deploy/docker/requirements.txt
-r deploy/docker/tests/requirements.txt pytest pytest-asyncio`, matching
`.github/workflows/security.yml`.)

`ruff check` and `black --check` are clean on the new test file. (Pre-existing
`mcp_bridge.py` has long-standing, unrelated ruff findings — noted in #2113 as
well — that this PR does not touch beyond the one added line.)

## AI assistance disclosure

This PR was prepared with AI assistance (root-cause investigation, fix, and
test authored by an AI coding agent), then verified by running the actual
pinned dependency versions locally as shown above.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] I have added/updated unit tests that prove my fix is effective
- [ ] Documentation updated (no user-facing behavior/docs change needed — this
      only fixes a routing gap that made bad requests hang instead of erroring)
