### PR TITLE
test(docker): cover the per-URL crawler_configs PDF SSRF guard

### DIFF
--- a/tests/test_docker_pdf_crawler_pairing.py
+++ b/tests/test_docker_pdf_crawler_pairing.py
@@ -50,6 +50,7 @@ def pool_mock(api, monkeypatch):
 
     pooled = MagicMock()
     pooled.arun = AsyncMock(return_value=[])
+    pooled.arun_many = AsyncMock(return_value=[])  # per-URL config list path
     pooled.active_requests = 1  # release_crawler decrements this int
     mock = AsyncMock(return_value=pooled)
     monkeypatch.setattr(crawler_pool, "get_crawler", mock)
@@ -125,6 +126,40 @@ async def test_default_strategy_still_uses_pool(api, pool_mock):
 
     assert response["success"] is True
     pool_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_per_url_pdf_strategy_gets_validator(api, pool_mock):
+    """SSRF: a PDF strategy sent per-URL via crawler_configs must be vetted too.
+
+    crawler_configs is a public per-URL field on /crawl, and the handler builds
+    that config list on a separate branch from the top-level config. Wiring
+    url_validator only on the top-level branch leaves the per-URL one doing an
+    unvalidated download of whatever the request names.
+    """
+    pdf_config = _crawler_config_payload(with_pdf_strategy=True)
+    plain_config = _crawler_config_payload(with_pdf_strategy=False)
+
+    response = await api.handle_crawl_request(
+        # The config list branch only engages with more than one URL.
+        urls=["https://example.com/document.pdf", "https://example.com/page.html"],
+        browser_config={"type": "BrowserConfig", "params": {}},
+        crawler_config=plain_config,  # top-level is clean; the PDF rides per-URL
+        crawler_configs=[pdf_config, plain_config],
+        config=CONFIG,
+    )
+
+    assert response["success"] is True
+    configs = pool_mock.return_value.arun_many.await_args.kwargs["config"]
+    pdf_strategies = [
+        cfg.scraping_strategy for cfg in configs
+        if isinstance(cfg.scraping_strategy, PDFContentScrapingStrategy)
+    ]
+    # Guard the guard: if deserialization ever drops the strategy, the loop
+    # below would pass vacuously and the test would protect nothing.
+    assert len(pdf_strategies) == 1
+    for strategy in pdf_strategies:
+        assert strategy.url_validator is api.validate_url_destination
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to #2150 (test only, no behaviour change).

## Why

`handle_crawl_request` builds the per-URL config list on a separate branch from the top-level config, so the `url_validator` wiring has to be repeated there. #2150 fixed that gap, but nothing in the suite exercises it — the existing pairing tests only go through the top-level path. The guard could be dropped by a future refactor and no test would go red.

`crawler_configs` is a public per-URL field on `/crawl`, so an unvetted PDF strategy sent that way would do an unvalidated download of whatever the request names.

## What

One test in `tests/test_docker_pdf_crawler_pairing.py`: sends a PDF strategy via `crawler_configs` (top-level config left clean, two URLs so the config-list branch engages) and asserts every per-URL PDF strategy reaching `arun_many` carries `validate_url_destination`.

It also asserts exactly one PDF strategy survives deserialization — without that, a future change that drops the strategy would make the loop pass vacuously and the test would protect nothing.

`pool_mock` gains an `arun_many` stub, which the config-list path needs.

## Testing

- `tests/test_docker_pdf_crawler_pairing.py` + `tests/test_issue_2127_docker_pdf.py`: 9 passed.
- Mutation check: removing the guard from `deploy/docker/api.py` fails this test and nothing else, so it is genuinely load-bearing.

cc @SohamKukreti