### PR TITLE
fix(pdf): carry cookies across manual redirect hops

### DIFF
--- a/crawl4ai/processors/pdf/__init__.py
+++ b/crawl4ai/processors/pdf/__init__.py
@@ -171,11 +171,17 @@ class PDFContentScrapingStrategy(ContentScrapingStrategy):
                 # Redirects are followed manually so url_validator (when set) can vet every hop BEFORE it is fetched
                 from urllib.parse import urljoin
                 current_url = url
+                # One Session for the whole chain: a bare requests.get() per hop
+                # starts with an empty cookie jar, so a host that sets a cookie
+                # and then redirects (common for gated/CDN-signed PDFs) would
+                # get its own cookie back. allow_redirects=True used to carry
+                # them for us; following hops by hand means we carry them here.
+                session = requests.Session()
                 for _ in range(MAX_PDF_DOWNLOAD_REDIRECTS):
                     if self.url_validator:
                         self.url_validator(current_url)
-                    response = requests.get(current_url, stream=True, timeout=(20, 60 * 10),
-                                            allow_redirects=False)
+                    response = session.get(current_url, stream=True, timeout=(20, 60 * 10),
+                                           allow_redirects=False)
                     if response.is_redirect:
                         location = response.headers.get("location")
                         response.close()  # hop response holds its connection open (stream=True)

--- a/tests/test_docker_pdf_crawler_pairing.py
+++ b/tests/test_docker_pdf_crawler_pairing.py
@@ -154,6 +154,21 @@ def redirect_server():
                 self.send_response(302)
                 self.send_header("Location", "/loop")
                 self.end_headers()
+            elif self.path == "/gated":
+                # Sets a cookie, then redirects to a target that demands it.
+                self.send_response(302)
+                self.send_header("Set-Cookie", "sess=abc123; Path=/")
+                self.send_header("Location", "/gated-doc.pdf")
+                self.end_headers()
+            elif self.path == "/gated-doc.pdf":
+                if "sess=abc123" not in self.headers.get("Cookie", ""):
+                    self.send_response(403)
+                    self.end_headers()
+                    return
+                self.send_response(200)
+                self.send_header("Content-Type", "application/pdf")
+                self.end_headers()
+                self.wfile.write(pdf_bytes)
             else:
                 self.send_response(200)
                 self.send_header("Content-Type", "application/pdf")
@@ -193,6 +208,23 @@ def test_download_redirects_still_followed_without_validator(redirect_server):
     """Back-compat: with no validator, redirects are followed as before."""
     strategy = PDFContentScrapingStrategy()
     path = strategy._get_pdf_path(f"{redirect_server}/hop")
+    try:
+        assert Path(path).read_bytes().startswith(b"%PDF")
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def test_download_carries_cookies_across_redirect_hops(redirect_server):
+    """Cookies set by a redirecting host must reach the next hop.
+
+    Following redirects by hand (needed so url_validator can vet each hop)
+    means a bare requests.get() per hop starts with an empty cookie jar, so
+    a host that sets a cookie and then redirects never gets it back. That is
+    the normal shape for gated or CDN-signed PDFs, and allow_redirects=True
+    used to handle it implicitly.
+    """
+    strategy = PDFContentScrapingStrategy()
+    path = strategy._get_pdf_path(f"{redirect_server}/gated")
     try:
         assert Path(path).read_bytes().startswith(b"%PDF")
     finally:


### PR DESCRIPTION
Regression from #2150, found while verifying that PR locally. Affects the library, not just the Docker server.

## What broke

#2150 set `allow_redirects=False` and follows redirect hops by hand, so `url_validator` can vet each hop *before* it is fetched. Correct goal — but each hop calls a bare `requests.get()`, and every one of those starts with an empty cookie jar.

So a host that sets a cookie and then redirects never gets its own cookie back, and answers 403. That is the ordinary shape for gated and CDN-signed PDFs. It worked before #2150 because `allow_redirects=True` carried cookies for us.

Reproduced against a local server (302 + `Set-Cookie`, then a target that requires it):

| tree | result |
|---|---|
| `fc6ec13` (before #2150) | downloads the PDF |
| `37ee60a` (after #2150) | `RuntimeError: ... 403 Client Error: Forbidden` |

## Fix

One `requests.Session` for the chain instead of a fresh `requests.get` per hop.

The SSRF guarantee is untouched: hops are still validated before the fetch, still not auto-followed, still capped. A Session only adds a cookie jar.

## Testing

- New test in `tests/test_docker_pdf_crawler_pairing.py`, reusing the existing `redirect_server` fixture with a `/gated` route.
- Mutation check: reverting `session.get` to `requests.get` fails that test and nothing else.
- `deploy/docker/tests/test_security_*.py` (the CI suite): 319 passed, 1 xfailed.
- PDF tests: 9 passed.
- `tests/regression`: 320 passed, 1 failed — `test_soft_404_filters_probes`, which hits a live site and fails identically on `fc6ec13`, so it is unrelated.

cc @SohamKukreti