### PR TITLE
fix: never remove html/body in remove_overlay_elements

### DIFF
--- a/crawl4ai/js_snippet/remove_overlay_elements.js
+++ b/crawl4ai/js_snippet/remove_overlay_elements.js
@@ -5,6 +5,10 @@ async () => {
         return style.display !== "none" && style.visibility !== "hidden" && style.opacity !== "0";
     };
 
+    // html/body must never be removed: doing so wipes the whole page and is
+    // always a worse outcome than leaving a popup in place.
+    const isProtected = (elem) => elem === document.documentElement || elem === document.body;
+
     // Common selectors for popups and overlays
     const commonSelectors = [
         // Close buttons first
@@ -59,6 +63,7 @@ async () => {
             const position = style.position;
 
             if (
+                !isProtected(elem) &&
                 isVisible(elem) &&
                 (zIndex > 999 || position === "fixed" || position === "absolute") &&
                 (elem.offsetWidth > window.innerWidth * 0.5 ||
@@ -74,7 +79,7 @@ async () => {
         for (const selector of commonSelectors) {
             const elements = document.querySelectorAll(selector);
             elements.forEach((elem) => {
-                if (isVisible(elem)) {
+                if (!isProtected(elem) && isVisible(elem)) {
                     elem.remove();
                 }
             });
@@ -89,7 +94,7 @@ async () => {
         const elements = document.querySelectorAll("*");
         elements.forEach((elem) => {
             const style = window.getComputedStyle(elem);
-            if ((style.position === "fixed" || style.position === "sticky") && isVisible(elem)) {
+            if (!isProtected(elem) && (style.position === "fixed" || style.position === "sticky") && isVisible(elem)) {
                 elem.remove();
             }
         });

--- a/tests/general/test_async_crawler_strategy.py
+++ b/tests/general/test_async_crawler_strategy.py
@@ -378,5 +378,22 @@ async def test_remove_overlay_elements(crawler_strategy):
     assert response.status_code == 200
     assert "Accept all cookies" not in response.html
 
+@pytest.mark.asyncio
+async def test_remove_overlay_elements_preserves_body_with_popup_class(crawler_strategy):
+    # Regression test: some WP themes (e.g. Bridge) put a "popup" substring in
+    # the body's own class, which matched the generic `[class*="popup" i]`
+    # overlay selector and deleted the whole body, leaving an empty page.
+    raw_html = (
+        "raw://<html><body class=\"qode_popup_menu_push_text_right\">"
+        "<main><h1>Real content</h1><p>This should survive.</p></main>"
+        "</body></html>"
+    )
+    config = CrawlerRunConfig(remove_overlay_elements=True)
+
+    response = await crawler_strategy.crawl(raw_html, config)
+
+    assert "<body" in response.html
+    assert "Real content" in response.html
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
Fixes #2161

## Problem

`remove_overlay_elements=True` uses a JS snippet
(`crawl4ai/js_snippet/remove_overlay_elements.js`) that removes any
visible element matching selectors like `[class*="popup" i]`,
`[class*="overlay" i]`, etc., plus any visible fixed/absolute element
above a size/z-index threshold.

Some WordPress themes (e.g. Bridge, reported with class
`qode_popup_menu_push_text_right`) put a class containing one of
these substrings directly on `<body>`. Since these selectors don't
exclude `html`/`body`, the body element itself gets matched and
removed, leaving an empty page (`<html><head></head></html>`).

Reported for:
- https://charlesproper.com/avilene/
- https://carandini.com/en/portfolio_page/angles-tunnel-girona-spain/

## Fix

Added an `isProtected` guard (`elem === document.documentElement ||
elem === document.body`) and applied it to all three removal sites in
the script: the z-index/position sweep, the selector-based sweep, and
the fixed/sticky sweep. `html`/`body` are now never removed by the
overlay-cleanup logic, matching the issue's suggested behavior ("html/body
should never be removed by the popup removal logic").

## Test plan

Added `test_remove_overlay_elements_preserves_body_with_popup_class`
in `tests/general/test_async_crawler_strategy.py`, using a `raw://`
page whose body carries the `qode_popup_menu_push_text_right` class
(no network dependency).

Verified the test fails without the fix and passes with it:

```
$ git checkout HEAD~2 -- crawl4ai/js_snippet/remove_overlay_elements.js
$ python -m pytest tests/general/test_async_crawler_strategy.py::test_remove_overlay_elements_preserves_body_with_popup_class -v
...
FAILED ... AssertionError: assert '<body' in '<html><head></head></html>'

$ git checkout HEAD -- crawl4ai/js_snippet/remove_overlay_elements.js
$ python -m pytest tests/general/test_async_crawler_strategy.py::test_remove_overlay_elements_preserves_body_with_popup_class -v
...
PASSED
```

Also ran the rest of the local (non-network) tests in the same file —
all pass. `test_remove_overlay_elements` (the pre-existing test that
hits `https://www2.hm.com/en_us/index.html`) fails both before and
after this change with an unrelated 403 from Akamai's edge blocking
the CI/sandbox IP, not from anything in this diff.

## AI disclosure

This change was authored with the assistance of an AI coding agent
(Claude). The diff and test evidence above were verified by running
the repository's test suite locally before submitting.
