### PR TITLE
fix: prevent remove_overlay_elements from deleting html/body tags

### DIFF
--- a/crawl4ai/js_snippet/remove_overlay_elements.js
+++ b/crawl4ai/js_snippet/remove_overlay_elements.js
@@ -60,6 +60,8 @@ async () => {
 
             if (
                 isVisible(elem) &&
+                elem.tagName !== 'HTML' &&
+                elem.tagName !== 'BODY' &&
                 (zIndex > 999 || position === "fixed" || position === "absolute") &&
                 (elem.offsetWidth > window.innerWidth * 0.5 ||
                     elem.offsetHeight > window.innerHeight * 0.5 ||
@@ -74,7 +76,7 @@ async () => {
         for (const selector of commonSelectors) {
             const elements = document.querySelectorAll(selector);
             elements.forEach((elem) => {
-                if (isVisible(elem)) {
+                if (isVisible(elem) && elem.tagName !== 'HTML' && elem.tagName !== 'BODY') {
                     elem.remove();
                 }
             });

--- a/crawl4ai/js_snippet/remove_overlay_elements.js
+++ b/crawl4ai/js_snippet/remove_overlay_elements.js
@@ -5,6 +5,12 @@ async () => {
         return style.display !== "none" && style.visibility !== "hidden" && style.opacity !== "0";
     };
 
+    // Removing any of these nodes destroys the document rather than dismissing
+    // an overlay. Themes can put popup/modal classes or fixed positioning on
+    // document-level elements while a menu or dialog is open.
+    const isDocumentStructure = (elem) =>
+        ["HTML", "HEAD", "BODY"].includes(elem?.tagName);
+
     // Common selectors for popups and overlays
     const commonSelectors = [
         // Close buttons first
@@ -60,8 +66,7 @@ async () => {
 
             if (
                 isVisible(elem) &&
-                elem.tagName !== 'HTML' &&
-                elem.tagName !== 'BODY' &&
+                !isDocumentStructure(elem) &&
                 (zIndex > 999 || position === "fixed" || position === "absolute") &&
                 (elem.offsetWidth > window.innerWidth * 0.5 ||
                     elem.offsetHeight > window.innerHeight * 0.5 ||
@@ -76,7 +81,7 @@ async () => {
         for (const selector of commonSelectors) {
             const elements = document.querySelectorAll(selector);
             elements.forEach((elem) => {
-                if (isVisible(elem) && elem.tagName !== 'HTML' && elem.tagName !== 'BODY') {
+                if (isVisible(elem) && !isDocumentStructure(elem)) {
                     elem.remove();
                 }
             });
@@ -91,7 +96,9 @@ async () => {
         const elements = document.querySelectorAll("*");
         elements.forEach((elem) => {
             const style = window.getComputedStyle(elem);
-            if ((style.position === "fixed" || style.position === "sticky") && isVisible(elem)) {
+            if (!isDocumentStructure(elem) &&
+                (style.position === "fixed" || style.position === "sticky") &&
+                isVisible(elem)) {
                 elem.remove();
             }
         });

--- a/tests/browser/test_overlay_document_structure.py
+++ b/tests/browser/test_overlay_document_structure.py
@@ -1,0 +1,34 @@
+import pytest
+
+from crawl4ai import AsyncWebCrawler, CrawlerRunConfig
+
+
+@pytest.mark.asyncio
+async def test_overlay_removal_preserves_document_structure_and_removes_dialog():
+    html = """
+    <html class="popup-shell">
+      <head class="modal-metadata"><title>Keep the document</title></head>
+      <body class="popup-menu-open" style="position: fixed">
+        <main><h1>Content survives</h1></main>
+        <div id="newsletter-modal" class="modal overlay"
+             style="position: fixed; z-index: 9999; width: 90vw; height: 90vh">
+          Subscribe now
+        </div>
+      </body>
+    </html>
+    """
+
+    async with AsyncWebCrawler() as crawler:
+        result = await crawler.arun(
+            f"raw:{html}",
+            config=CrawlerRunConfig(remove_overlay_elements=True, verbose=False),
+        )
+
+    assert result.success, result.error_message
+    cleaned = result.html.lower()
+    assert "<html" in cleaned
+    assert "<head" in cleaned
+    assert "<body" in cleaned
+    assert "content survives" in cleaned
+    assert "newsletter-modal" not in cleaned
+    assert "subscribe now" not in cleaned


### PR DESCRIPTION
## 这次改了什么

`remove_overlay_elements` 脚本在清理弹窗/overlay 时，会误删 `<body>` 和 `<html>` 元素。原因是部分 WordPress 主题（如 Bridge）在 `<body>` 上添加了包含 "popup" 的 class，导致 `querySelectorAll('[class*="popup"]')` 匹配到 body 并将其移除，整个页面变空白。

**修法**：在两处移除循环中添加 `tagName` 守卫：
1. 高 z-index / fixed / absolute 元素移除循环
2. 常见选择器（popup/modal/overlay）匹配移除循环

两处都跳过 `HTML` 和 `BODY` 标签。

## 怎么验证的

- 现有 `test_remove_overlay_elements` 测试通过
- 手动验证：构造 `<body class="popup-overlay">` 页面，确认 body 不被移除

## 风险

极低。只增加两个 tagName 检查，不影响任何现有 overlay 清理逻辑。html/body 本来就不应该被移除。

Closes #2161