### PR TITLE
fix: clean up Playwright process on browser startup failure

### DIFF
--- a/crawl4ai/async_webcrawler.py
+++ b/crawl4ai/async_webcrawler.py
@@ -182,7 +182,7 @@ class AsyncWebCrawler:
         """
         try:
             await self.crawler_strategy.__aenter__()
-        except Exception:
+        except BaseException:
             # Ensure partial resources are cleaned up on failure
             try:
                 await self.crawler_strategy.__aexit__(None, None, None)

--- a/crawl4ai/async_webcrawler.py
+++ b/crawl4ai/async_webcrawler.py
@@ -180,7 +180,15 @@ class AsyncWebCrawler:
         Returns:
             AsyncWebCrawler: The initialized crawler instance
         """
-        await self.crawler_strategy.__aenter__()
+        try:
+            await self.crawler_strategy.__aenter__()
+        except Exception:
+            # Ensure partial resources are cleaned up on failure
+            try:
+                await self.crawler_strategy.__aexit__(None, None, None)
+            except Exception:
+                pass
+            raise
         self.logger.info(f"Crawl4AI {crawl4ai_version}", tag="INIT")
         self.ready = True
         return self

--- a/crawl4ai/browser_manager.py
+++ b/crawl4ai/browser_manager.py
@@ -808,6 +808,21 @@ class BrowserManager:
             # Initialize playwright
             self.playwright = await async_playwright().start()
 
+        try:
+            await self._launch_browser()
+        except Exception:
+            # If browser launch fails, ensure Playwright process is cleaned up
+            # to avoid leaking the "node cli.js run-driver" subprocess.
+            if self.playwright is not None and not self._using_cached_cdp:
+                try:
+                    await self.playwright.stop()
+                except Exception:
+                    pass
+                self.playwright = None
+            raise
+
+    async def _launch_browser(self):
+        """Launch or connect to the browser after Playwright is initialized."""
         # ── Persistent context via Playwright's native API ──────────────
         # When use_persistent_context is set and we're not connecting to an
         # external CDP endpoint, use launch_persistent_context() instead of

--- a/crawl4ai/browser_manager.py
+++ b/crawl4ai/browser_manager.py
@@ -810,7 +810,7 @@ class BrowserManager:
 
         try:
             await self._launch_browser()
-        except Exception:
+        except BaseException:
             # If browser launch fails, ensure Playwright process is cleaned up
             # to avoid leaking the "node cli.js run-driver" subprocess.
             if self.playwright is not None and not self._using_cached_cdp:

--- a/tests/browser/test_startup_failure_cleanup.py
+++ b/tests/browser/test_startup_failure_cleanup.py
@@ -1,0 +1,52 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from crawl4ai import AsyncWebCrawler, BrowserConfig
+from crawl4ai.browser_manager import BrowserManager
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", [RuntimeError("launch failed"), pytest.param(None, id="cancelled")])
+async def test_browser_manager_stops_playwright_after_failed_launch(monkeypatch, failure):
+    if failure is None:
+        failure = asyncio.CancelledError()
+
+    playwright = type("FakePlaywright", (), {})()
+    playwright.stop = AsyncMock()
+    starter = type("FakeStarter", (), {})()
+    starter.start = AsyncMock(return_value=playwright)
+
+    monkeypatch.setattr("playwright.async_api.async_playwright", lambda: starter)
+
+    manager = BrowserManager(BrowserConfig(), logger=None)
+    manager._launch_browser = AsyncMock(side_effect=failure)
+
+    with pytest.raises(type(failure)):
+        await manager.start()
+
+    playwright.stop.assert_awaited_once()
+    assert manager.playwright is None
+
+
+@pytest.mark.asyncio
+async def test_async_webcrawler_rolls_back_cancelled_strategy_start(tmp_path):
+    class CancelledStrategy:
+        def __init__(self):
+            self.exit = AsyncMock()
+
+        async def __aenter__(self):
+            raise asyncio.CancelledError()
+
+        async def __aexit__(self, exc_type, exc_value, traceback):
+            await self.exit(exc_type, exc_value, traceback)
+
+    strategy = CancelledStrategy()
+    crawler = AsyncWebCrawler(crawler_strategy=strategy, base_directory=str(tmp_path))
+
+    with pytest.raises(asyncio.CancelledError):
+        await crawler.start()
+
+    strategy.exit.assert_awaited_once_with(None, None, None)
+    assert crawler.ready is False


### PR DESCRIPTION
## 这次改了什么

When Playwright starts successfully but Chromium launch fails (e.g. missing browser binary, sandbox issues), the `node cli.js run-driver` subprocess was leaked. Each failed attempt left one live child process, growing the process count linearly with retries.

**Changes:**

1. **`browser_manager.py`**: Extract browser launch logic into `_launch_browser()`, wrap the call in `start()` with `try/except` that calls `self.playwright.stop()` on failure.

2. **`async_webcrawler.py`**: Wrap `crawler_strategy.__aenter__()` in `start()` with `try/except` that calls `__aexit__()` on failure.

Both layers ensure partial resources are cleaned up before the exception propagates.

## 怎么验证的

- Python syntax check passes for both files
- Manual verification: `AsyncWebCrawler.__aenter__()` now properly cleans up when browser launch fails
- No live playwright driver processes remain after failed start attempts

## 风险

Low. Only adds cleanup on the exception path. Happy path is unchanged.

Closes #2155