### PR TITLE
fix: respect preserve_tags/preserve_classes in _remove_unwanted_tags

### DIFF
--- a/crawl4ai/content_filter_strategy.py
+++ b/crawl4ai/content_filter_strategy.py
@@ -683,10 +683,11 @@ class PruningContentFilter(RelevantContentFilter):
             element.extract()
 
     def _remove_unwanted_tags(self, soup):
-        """Removes unwanted tags"""
+        """Removes unwanted tags, but respects preserve_tags/preserve_classes whitelist."""
         for tag in self.excluded_tags:
             for element in soup.find_all(tag):
-                element.decompose()
+                if not self._is_preserved(element):
+                    element.decompose()
 
     def _is_preserved(self, node):
         """Check if a node matches the preserve whitelist."""


### PR DESCRIPTION
## 这次改了什么

Fixes #2125

`PruningContentFilter(preserve_tags=['aside'])` was silently ignoring the whitelist because `_remove_unwanted_tags()` decomposed excluded tags (aside, nav, footer, etc.) **before** `_prune_tree()` ever consulted `_is_preserved()`.

**修法**: `_remove_unwanted_tags()` now checks `_is_preserved()` before decomposing each element. Preserved tags survive the unwanted tag removal step.

## 怎么验证的

```python
from crawl4ai.content_filter_strategy import PruningContentFilter

html = "<html><body><article><p>Main body...</p></article><aside class='related'><p>Sidebar...</p></aside></body></html>"

# Before fix: all three print False
# After fix:
PruningContentFilter().filter_content(html)  # aside kept: False (correct)
PruningContentFilter(preserve_tags=['aside']).filter_content(html)  # aside kept: True ✓
PruningContentFilter(preserve_classes=['related']).filter_content(html)  # aside kept: True ✓
```

## 风险

Low risk — 3-line change to an existing conditional. Only affects `PruningContentFilter` when `preserve_tags` or `preserve_classes` is set.