### PR TITLE
fix: add pypdf to Docker requirements for PDFContentScrapingStrategy

### DIFF
--- a/deploy/docker/requirements.txt
+++ b/deploy/docker/requirements.txt
@@ -14,3 +14,4 @@ PyJWT==2.10.1
 mcp>=1.18.0
 websockets>=15.0.1
 httpx[http2]>=0.27.2
+pypdf>=5.0.0


### PR DESCRIPTION
## 这次改了什么

Fixes #2127

Docker image was missing `pypdf` dependency, causing `PDFContentScrapingStrategy` to fail at runtime.

**修法**: Added `pypdf>=5.0.0` to `deploy/docker/requirements.txt`.

## 怎么验证的

1. Build Docker image: `docker build -t crawl4ai .`
2. Start server: `docker run -p 8000:8000 crawl4ai`
3. Send POST request with PDF URL and `PDFContentScrapingStrategy`
4. Should return extracted PDF content instead of failing

## 风险

Low risk — adds a required dependency that was missing from the Docker image.