### PR TITLE
fix: handle cgroup v2 'max' string in memory guard

### DIFF
--- a/deploy/docker/utils.py
+++ b/deploy/docker/utils.py
@@ -419,8 +419,10 @@ def get_container_memory_percent() -> float:
             usage_path = Path("/sys/fs/cgroup/memory/memory.usage_in_bytes")
             limit_path = Path("/sys/fs/cgroup/memory/memory.limit_in_bytes")
 
-        usage = int(usage_path.read_text())
-        limit = int(limit_path.read_text())
+        usage_str = usage_path.read_text().strip()
+        usage = int(usage_str) if usage_str.isdigit() else 0
+        limit_str = limit_path.read_text().strip()
+        limit = int(limit_str) if limit_str.isdigit() else 0
 
         # Handle unlimited (v2: "max", v1: > 1e18)
         if limit > 1e18:


### PR DESCRIPTION
Fixes #2123. When cgroup v2 has no memory limit, memory.max contains 'max' string. int('max') raises ValueError, caught by bare except, returning host memory % instead of container. Fix: parse 'max' as unlimited.