### PR TITLE
fix: return 403 for anti-bot detection in /md endpoint

### DIFF
--- a/deploy/docker/api.py
+++ b/deploy/docker/api.py
@@ -148,8 +148,9 @@ async def handle_llm_qa(
         crawler = await get_crawler(browser_cfg)
         result = await crawler.arun(url)
         if not result.success:
+            status_code = status.HTTP_403_FORBIDDEN if "Blocked by anti-bot" in (result.error_message or "") else status.HTTP_500_INTERNAL_SERVER_ERROR
             raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                status_code=status_code,
                 detail=result.error_message
             )
         content = result.markdown.fit_markdown or result.markdown.raw_markdown


### PR DESCRIPTION
Fixes #2116. The /md and /llm endpoints return HTTP 500 when anti-bot detection blocks a crawl. This is misleading - it's not a server error, it's a client-side detection issue. Fix: return 403 Forbidden when the error is due to anti-bot protection.