### PR TITLE
fix: skip pruning for pre/code tags to preserve whitespace in code blocks

### DIFF
--- a/crawl4ai/content_filter_strategy.py
+++ b/crawl4ai/content_filter_strategy.py
@@ -712,6 +712,10 @@ class PruningContentFilter(RelevantContentFilter):
         if self._is_preserved(node):
             return
 
+        # Skip pruning for <pre> and <code> tags — whitespace is significant in code blocks
+        if node.name in ("pre", "code"):
+            return
+
         text_len = len(node.get_text(strip=True))
         tag_len = len(node.encode_contents().decode("utf-8"))
         link_text_len = sum(

--- a/tests/async/test_content_filter_prune.py
+++ b/tests/async/test_content_filter_prune.py
@@ -165,6 +165,17 @@ class TestPruningContentFilter:
         second_run = filter.filter_content(basic_html)
         assert first_run == second_run, "Output should be consistent"
 
+    def test_preserves_whitespace_only_nodes_inside_code_blocks(self):
+        html = """<html><body><article><pre><code>if ready:
+<span>    </span>return value</code></pre></article></body></html>"""
+        filter = PruningContentFilter(
+            threshold_type="fixed", threshold=0, min_word_threshold=2
+        )
+
+        contents = filter.filter_content(html)
+
+        assert '<span>    </span>' in "".join(contents)
+
 
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
Fixes #2110. PruningContentFilter prunes whitespace-only spans inside pre/code tags, corrupting code blocks. Fix: skip pruning for pre and code tags where whitespace is significant.