### PR TITLE
fix: return per-URL error results from /crawl instead of HTTP 500

### DIFF
--- a/deploy/docker/server.py
+++ b/deploy/docker/server.py
@@ -906,9 +906,8 @@ async def crawl(
         hooks_config=hooks_config,
         crawler_configs=crawl_request.crawler_configs,
     )
-    # check if all of the results are not successful
-    if all(not result["success"] for result in results["results"]):
-        raise HTTPException(500, f"Crawl request failed: {results['results'][0]['error_message']}")
+    # Return results with per-URL error information instead of raising 500.
+    # This allows clients to see which URLs failed and why.
     return JSONResponse(results)
 
 


### PR DESCRIPTION
## What

When all crawl results fail (e.g. unmatched `wait_for` selector), the `/crawl` endpoint previously raised HTTP 500 with only the first error message, discarding per-URL error details. Now it returns the full results JSON with `success=false` and `error_message` per URL.

## Why

Fixes #2133 - `/crawl` returns HTTP 500 when `wait_for` selector never matches.

## Changes

- Removed the HTTP 500 raise when all results fail
- Returns per-URL error information in the response JSON
- Matches the behavior of `/md` and `/html` endpoints

## Testing

- Verified that failed crawls now return JSON with error details instead of 500
- Verified that successful crawls still work as expected

Fixes #2133