### PR TITLE
fix: allow single-label hostnames in deep crawl URL validation

### DIFF
--- a/crawl4ai/deep_crawling/bff_strategy.py
+++ b/crawl4ai/deep_crawling/bff_strategy.py
@@ -79,8 +79,8 @@ class BestFirstCrawlingStrategy(DeepCrawlStrategy):
         """
         try:
             parsed = urlparse(url)
-            if not parsed.scheme or not parsed.netloc:
-                raise ValueError("Missing scheme or netloc")
+            if not parsed.scheme or not parsed.hostname:
+                raise ValueError("Missing scheme or hostname")
             if parsed.scheme not in ("http", "https"):
                 raise ValueError("Invalid scheme")
             # Single-label hostnames (e.g. "name" without a dot) are valid

--- a/crawl4ai/deep_crawling/bff_strategy.py
+++ b/crawl4ai/deep_crawling/bff_strategy.py
@@ -83,8 +83,8 @@ class BestFirstCrawlingStrategy(DeepCrawlStrategy):
                 raise ValueError("Missing scheme or netloc")
             if parsed.scheme not in ("http", "https"):
                 raise ValueError("Invalid scheme")
-            if "." not in parsed.netloc:
-                raise ValueError("Invalid domain")
+            # Single-label hostnames (e.g. "name" without a dot) are valid
+            # when the URL has a scheme and non-empty netloc (e.g. internal DNS).
         except Exception as e:
             self.logger.warning(f"Invalid URL: {url}, error: {e}")
             return False

--- a/crawl4ai/deep_crawling/bfs_strategy.py
+++ b/crawl4ai/deep_crawling/bfs_strategy.py
@@ -70,8 +70,8 @@ class BFSDeepCrawlStrategy(DeepCrawlStrategy):
                 raise ValueError("Missing scheme or netloc")
             if parsed.scheme not in ("http", "https"):
                 raise ValueError("Invalid scheme")
-            if "." not in parsed.netloc:
-                raise ValueError("Invalid domain")
+            # Single-label hostnames (e.g. "name" without a dot) are valid
+            # when the URL has a scheme and non-empty netloc (e.g. internal DNS).
         except Exception as e:
             self.logger.warning(f"Invalid URL: {url}, error: {e}")
             return False

--- a/crawl4ai/deep_crawling/bfs_strategy.py
+++ b/crawl4ai/deep_crawling/bfs_strategy.py
@@ -66,8 +66,8 @@ class BFSDeepCrawlStrategy(DeepCrawlStrategy):
         """
         try:
             parsed = urlparse(url)
-            if not parsed.scheme or not parsed.netloc:
-                raise ValueError("Missing scheme or netloc")
+            if not parsed.scheme or not parsed.hostname:
+                raise ValueError("Missing scheme or hostname")
             if parsed.scheme not in ("http", "https"):
                 raise ValueError("Invalid scheme")
             # Single-label hostnames (e.g. "name" without a dot) are valid

--- a/tests/deep_crawling/test_deep_crawl_url_validation.py
+++ b/tests/deep_crawling/test_deep_crawl_url_validation.py
@@ -1,0 +1,37 @@
+import pytest
+
+from crawl4ai.deep_crawling import BFSDeepCrawlStrategy, BestFirstCrawlingStrategy
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("strategy_cls", [BFSDeepCrawlStrategy, BestFirstCrawlingStrategy])
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://intranet/path",
+        "https://localhost:8443/path",
+        "http://127.0.0.1/path",
+        "http://[::1]/path",
+    ],
+)
+async def test_can_process_url_accepts_valid_single_label_and_ip_hosts(strategy_cls, url):
+    strategy = strategy_cls(max_depth=1)
+
+    assert await strategy.can_process_url(url, depth=0)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("strategy_cls", [BFSDeepCrawlStrategy, BestFirstCrawlingStrategy])
+@pytest.mark.parametrize(
+    "url",
+    [
+        "intranet/path",
+        "ftp://intranet/path",
+        "http:///path",
+        "http://:8080/path",
+    ],
+)
+async def test_can_process_url_rejects_missing_or_invalid_hosts(strategy_cls, url):
+    strategy = strategy_cls(max_depth=1)
+
+    assert not await strategy.can_process_url(url, depth=0)


### PR DESCRIPTION
## What

The previous implementation rejected URLs with single-label hostnames (e.g. `https://name/xyz/`) by checking for a dot in netloc. This is overly strict and prevents crawling internal DNS hosts or local development servers.

## Why

Fixes #2079 - BFSDeepCrawlStrategy.can_process_url() rejects valid single-label hostnames.

## Changes

- Removed the dot check in both BFS and BFF deep crawl strategies
- Single-label hostnames are now accepted when the URL has a valid scheme and non-empty netloc

## Testing

- Verified that single-label hostnames are now accepted
- Verified that invalid URLs (missing scheme, invalid scheme) are still rejected

Fixes #2079