### PR TITLE
fix: update docker-compose.yml for Compose v5 compatibility

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 
 # Shared configuration for all environments
 x-base-config: &base-config
@@ -24,7 +23,6 @@ x-base-config: &base-config
     - ALL
   security_opt:
     - no-new-privileges:true
-  pids_limit: 512
   # Read-only root filesystem; only these paths are writable (tmpfs).
   read_only: true
   tmpfs:
@@ -39,6 +37,7 @@ x-base-config: &base-config
     resources:
       limits:
         memory: 4G
+        pids: 512
       reservations:
         memory: 1G
   restart: unless-stopped


### PR DESCRIPTION
## What

- Remove obsolete `version: '3.8'` attribute
- Move `pids_limit` from top level to `deploy.resources.limits.pids`

## Why

Fixes #2091 - docker-compose.yml is rejected by Compose v5 with 'can't set distinct values on pids_limit'.

## Changes

- Removed `version: '3.8'` (obsolete, causes warnings)
- Moved `pids_limit: 512` to `deploy.resources.limits.pids: 512` (compose-spec-compliant)

## Testing

- Verified the compose file is valid with `docker compose config`

Fixes #2091