### PR TITLE
fix: skip body visibility wait when ignore_body_visibility=True

### DIFF
--- a/crawl4ai/async_crawler_strategy.py
+++ b/crawl4ai/async_crawler_strategy.py
@@ -808,39 +808,41 @@ class AsyncPlaywrightCrawlerStrategy(AsyncCrawlerStrategy):
                 response_headers = {}
 
             # Wait for body element and visibility
-            try:
-                await page.wait_for_selector("body", state="attached", timeout=30000)
+            # Skip entirely when ignore_body_visibility is True (the default),
+            # avoiding a hardcoded 30s timeout on pages where body never becomes visible.
+            if not config.ignore_body_visibility:
+                try:
+                    await page.wait_for_selector("body", state="attached", timeout=30000)
 
-                # Use the new check_visibility function with csp_compliant_wait
-                is_visible = await self.csp_compliant_wait(
-                    page,
-                    """() => {
-                        const element = document.body;
-                        if (!element) return false;
-                        const style = window.getComputedStyle(element);
-                        const isVisible = style.display !== 'none' && 
-                                        style.visibility !== 'hidden' && 
-                                        style.opacity !== '0';
-                        return isVisible;
-                    }""",
-                    timeout=30000,
-                )
-
-                if not is_visible and not config.ignore_body_visibility:
-                    visibility_info = await self.check_visibility(page)
-                    raise Error(f"Body element is hidden: {visibility_info}")
-
-            except Error:
-                visibility_info = await self.check_visibility(page)
-
-                if self.browser_config.verbose:
-                    self.logger.debug(
-                        message="Body visibility info: {info}",
-                        tag="DEBUG",
-                        params={"info": visibility_info},
+                    # Use the new check_visibility function with csp_compliant_wait
+                    is_visible = await self.csp_compliant_wait(
+                        page,
+                        """() => {
+                            const element = document.body;
+                            if (!element) return false;
+                            const style = window.getComputedStyle(element);
+                            const isVisible = style.display !== 'none' && 
+                                            style.visibility !== 'hidden' && 
+                                            style.opacity !== '0';
+                            return isVisible;
+                        }""",
+                        timeout=30000,
                     )
 
-                if not config.ignore_body_visibility:
+                    if not is_visible:
+                        visibility_info = await self.check_visibility(page)
+                        raise Error(f"Body element is hidden: {visibility_info}")
+
+                except Error:
+                    visibility_info = await self.check_visibility(page)
+
+                    if self.browser_config.verbose:
+                        self.logger.debug(
+                            message="Body visibility info: {info}",
+                            tag="DEBUG",
+                            params={"info": visibility_info},
+                        )
+
                     raise Error(f"Body element is hidden: {visibility_info}")
 
             # try:


### PR DESCRIPTION
## What changed

When `ignore_body_visibility=True` (the default), the body visibility check block is now skipped entirely.

## Why

Previously, even with `ignore_body_visibility=True`, the code would still:
1. Wait for body to be attached (up to 30s)
2. Run a JavaScript visibility check (up to 30s)
3. Discard the result because `ignore_body_visibility=True`

This adds a fixed 30s overhead to every crawl on pages where the body is hidden (e.g. AngularJS `ng-cloak`, Vue `v-cloak`).

## How to verify

1. Set `ignore_body_visibility=True` (default)
2. Crawl a page with hidden body (e.g. AngularJS app with `ng-cloak`)
3. Verify crawl completes without the 30s delay
4. Set `ignore_body_visibility=False` and verify body visibility errors are still raised correctly

## Risk

Low - changes behavior only when `ignore_body_visibility=True`, which is the default. The visibility check was being discarded anyway in this case.

Fixes #2129