### PR TITLE
fix: respect preserve_tags/preserve_classes in _remove_unwanted_tags

### DIFF
--- a/crawl4ai/content_filter_strategy.py
+++ b/crawl4ai/content_filter_strategy.py
@@ -683,10 +683,11 @@ class PruningContentFilter(RelevantContentFilter):
             element.extract()
 
     def _remove_unwanted_tags(self, soup):
-        """Removes unwanted tags"""
+        """Removes unwanted tags, but respects preserve_tags/preserve_classes whitelist."""
         for tag in self.excluded_tags:
             for element in soup.find_all(tag):
-                element.decompose()
+                if not self._is_preserved(element):
+                    element.decompose()
 
     def _is_preserved(self, node):
         """Check if a node matches the preserve whitelist."""

--- a/tests/test_pruning_preserve_whitelist_1900.py
+++ b/tests/test_pruning_preserve_whitelist_1900.py
@@ -201,14 +201,20 @@ class TestCombined:
         assert "alice" in combined
         assert "Apr 6, 2026" in combined
 
-    def test_whitelist_does_not_override_excluded_tags(self):
-        """Nav/footer/header are removed before pruning — whitelist can't save them."""
+    def test_preserve_tag_overrides_excluded_tags(self):
+        """A preserved tag remains even when it is structural boilerplate by default."""
         f = PruningContentFilter(preserve_tags=["nav"])
         result = f.filter_content(GITHUB_COMMENT_HTML)
         combined = " ".join(result)
-        # nav is in excluded_tags and removed before pruning runs
-        # preserve_tags only affects the pruning phase
-        # This is expected — excluded_tags are structural boilerplate
+        assert "Home" in combined
+        assert "About" in combined
+
+    def test_preserve_class_overrides_excluded_tags(self):
+        """A preserved class remains even when its element tag is excluded."""
+        f = PruningContentFilter(preserve_classes=["site-footer"])
+        result = f.filter_content(GITHUB_COMMENT_HTML)
+        combined = " ".join(result)
+        assert "Copyright 2026" in combined
 
 
 # ── _is_preserved method ─────────────────────────────────────────────────


### PR DESCRIPTION
## What
Previously, `_remove_unwanted_tags()` decomposed all matching elements regardless of the preserve whitelist. Now it checks `_is_preserved()` before decomposing, so elements matching `preserve_tags` or `preserve_classes` are kept even if their tag is in `excluded_tags`.

## Why
Fixes #2125 — `preserve_tags` and `preserve_classes` were no-ops when the tag was also in `excluded_tags`, because `_remove_unwanted_tags` ran after the preserve check and decomposed everything unconditionally.

## How
- In `_remove_unwanted_tags()`, add an `_is_preserved()` guard before `element.decompose()`
- Reuse the existing helper that checks both `preserve_tags` and `preserve_classes`
- Replace the stale opposite-semantics test with regression assertions for both tag- and class-based preservation

## Testing
- `python -m pytest tests/test_pruning_preserve_whitelist_1900.py -q` — 21 passed
- Verified `preserve_tags=["nav"]` keeps an otherwise excluded `<nav>`
- Verified `preserve_classes=["site-footer"]` keeps an otherwise excluded `<footer>`
- Verified non-preserved excluded tags remain removed