### PR TITLE
fix(docker): pin mcp to <2.0.0 to prevent breaking changes

### DIFF
--- a/deploy/docker/requirements.txt
+++ b/deploy/docker/requirements.txt
@@ -11,6 +11,6 @@ pydantic>=2.11
 rank-bm25==0.2.2
 anyio==4.9.0
 PyJWT==2.10.1
-mcp>=1.18.0
+mcp>=1.18.0,<2.0.0
 websockets>=15.0.1
 httpx[http2]>=0.27.2


### PR DESCRIPTION
## What
Pin mcp dependency to `>=1.18.0,<2.0.0` in Docker requirements.

## Why
mcp 2.0 introduced breaking API changes that cause the Docker server to fail on boot. This pin maintains compatibility until the codebase is updated for mcp 2.0.

Fixes #2092

## How
- Change `mcp>=1.18.0` to `mcp>=1.18.0,<2.0.0` in `deploy/docker/requirements.txt`

## Testing
- Docker build completes successfully
- Server starts without import errors