### PR TITLE
fix(docker): add pypdf to Docker requirements for PDF crawling

### DIFF
--- a/deploy/docker/requirements.txt
+++ b/deploy/docker/requirements.txt
@@ -14,3 +14,4 @@ PyJWT==2.10.1
 mcp>=1.18.0
 websockets>=15.0.1
 httpx[http2]>=0.27.2
+pypdf>=5.0.0


### PR DESCRIPTION
## What
Add `pypdf>=5.0.0` to Docker requirements.

## Why
PDFContentScraping requires pypdf but it was not included in the Docker requirements, causing ImportError when crawling PDFs.

Fixes #2127

## How
- Add `pypdf>=5.0.0` to `deploy/docker/requirements.txt`

## Testing
- Docker build completes successfully
- PDF crawling works without ImportError