### PR TITLE
fix(api): return 403 for anti-bot blocked results in /md and /llm endpoints

### DIFF
--- a/deploy/docker/api.py
+++ b/deploy/docker/api.py
@@ -148,9 +148,11 @@ async def handle_llm_qa(
         crawler = await get_crawler(browser_cfg)
         result = await crawler.arun(url)
         if not result.success:
+            err = result.error_message or "Crawl failed"
+            code = status.HTTP_403_FORBIDDEN if "blocked" in err.lower() or "anti-bot" in err.lower() else status.HTTP_500_INTERNAL_SERVER_ERROR
             raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail=result.error_message
+                status_code=code,
+                detail=err
             )
         content = result.markdown.fit_markdown or result.markdown.raw_markdown
 
@@ -390,9 +392,11 @@ async def handle_markdown_request(
         )
 
         if not result.success:
+            err = result.error_message or "Crawl failed"
+            code = status.HTTP_403_FORBIDDEN if "blocked" in err.lower() or "anti-bot" in err.lower() else status.HTTP_500_INTERNAL_SERVER_ERROR
             raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail=result.error_message
+                status_code=code,
+                detail=err
             )
 
         return (result.markdown.raw_markdown


### PR DESCRIPTION
## Summary

Both `handle_markdown_request` and `handle_llm_qa` in `deploy/docker/api.py` promoted any unsuccessful crawl into HTTP 500. Since 0.8.5, `is_blocked()` sets `success=False` with `error_message = "Blocked by anti-bot protection: <reason>"`, so Cloudflare-protected sites returned opaque 500 instead of a client-meaningful error.

This PR differentiates anti-bot failures (403) from genuine server errors (500) by inspecting the error message for `blocked` / `anti-bot` keywords.

## Changes

- `deploy/docker/api.py`: In both `handle_markdown_request` and `handle_llm_qa`, check `result.error_message` for anti-bot keywords before deciding status code.

## Test plan

- [ ] `POST /md` with a Cloudflare-protected URL → should return 403 with "Blocked by anti-bot protection" detail
- [ ] `POST /llm/{url}` with a Cloudflare-protected URL → should return 403
- [ ] `POST /md` with a genuinely broken URL → should still return 500

Fixes #2116