### PR TITLE
fix(api): return 408 for wait_for selector timeout in /crawl

### DIFF
--- a/deploy/docker/api.py
+++ b/deploy/docker/api.py
@@ -816,6 +816,10 @@ async def handle_crawl_request(
         # Per-crawl wall-clock deadline exceeded.
         raise HTTPException(status_code=504, detail="Crawl exceeded the time limit")
 
+    except TimeoutError as e:
+        # wait_for selector / JS condition timed out — client error, not server.
+        raise HTTPException(status_code=408, detail=str(e))
+
     except HTTPException:
         # Deliberate status (e.g. 400 SSRF "URL blocked") must pass through
         # rather than be genericized to 500 by the handler below.


### PR DESCRIPTION
## Summary

When `crawler_config.wait_for` specifies a CSS selector or JS condition that never matches the page, `smart_wait()` raises `TimeoutError`. The generic `except Exception` handler turned this into an opaque HTTP 500.

This PR catches `TimeoutError` explicitly and returns **408 Request Timeout** with the original timeout message, so clients can distinguish server failures from selector-mismatch timeouts.

## Changes

- `deploy/docker/api.py`: Added `except TimeoutError` handler before the generic `except Exception` block, returning 408 instead of 500.

## Test plan

- [ ] `POST /crawl` with `wait_for: "css:.nonexistent"` → should return 408 with timeout detail
- [ ] `POST /crawl` with a genuinely broken URL → should still return 500
- [ ] `POST /crawl` with `wait_for` matching successfully → normal 200 response

Fixes #2133