### PR TITLE
fix(overlay): never remove html/body elements during overlay cleanup

### DIFF
--- a/crawl4ai/js_snippet/remove_overlay_elements.js
+++ b/crawl4ai/js_snippet/remove_overlay_elements.js
@@ -1,4 +1,10 @@
 async () => {
+    // Never remove html or body — they are the document root.
+    const isProtected = (elem) => {
+        const tag = elem.tagName;
+        return tag === 'HTML' || tag === 'BODY';
+    };
+
     // Function to check if element is visible
     const isVisible = (elem) => {
         const style = window.getComputedStyle(elem);
@@ -59,6 +65,7 @@ async () => {
             const position = style.position;
 
             if (
+                !isProtected(elem) &&
                 isVisible(elem) &&
                 (zIndex > 999 || position === "fixed" || position === "absolute") &&
                 (elem.offsetWidth > window.innerWidth * 0.5 ||
@@ -74,7 +81,7 @@ async () => {
         for (const selector of commonSelectors) {
             const elements = document.querySelectorAll(selector);
             elements.forEach((elem) => {
-                if (isVisible(elem)) {
+                if (!isProtected(elem) && isVisible(elem)) {
                     elem.remove();
                 }
             });
@@ -89,7 +96,7 @@ async () => {
         const elements = document.querySelectorAll("*");
         elements.forEach((elem) => {
             const style = window.getComputedStyle(elem);
-            if ((style.position === "fixed" || style.position === "sticky") && isVisible(elem)) {
+            if (!isProtected(elem) && (style.position === "fixed" || style.position === "sticky") && isVisible(elem)) {
                 elem.remove();
             }
         });


### PR DESCRIPTION
## Summary

`remove_overlay_elements()` removes all elements matching `[class*="popup"]`, `[role="dialog"]`, fixed/absolute positioned elements, etc. If `<body>` has a class containing "popup" (e.g. WordPress theme `qode_popup_menu_push_text_right`), the entire document body gets deleted, leaving an empty page.

## Changes

- `crawl4ai/js_snippet/remove_overlay_elements.js`: Added `isProtected()` guard that skips removal for `<html>` and `<body>` tags in all three removal paths: high-z-index scan, common selector scan, and fixed/sticky position scan.

## Test plan

- [ ] Crawl a site with `<body class="qode_popup_menu_push_text_right">` → body should be preserved
- [ ] Crawl a site with normal popup overlay → overlay should still be removed
- [ ] `remove_overlay_elements=True` with a Cloudflare challenge page → body intact

Fixes #2161