### PR TITLE
fix(docker): move pids_limit to deploy.resources.limits.pids for Compose v5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,6 @@ x-base-config: &base-config
     - ALL
   security_opt:
     - no-new-privileges:true
-  pids_limit: 512
   # Read-only root filesystem; only these paths are writable (tmpfs).
   read_only: true
   tmpfs:
@@ -39,6 +38,7 @@ x-base-config: &base-config
     resources:
       limits:
         memory: 4G
+        pids: 512
       reservations:
         memory: 1G
   restart: unless-stopped


### PR DESCRIPTION
## Summary

Docker Compose v5 normalizes top-level `pids_limit` into `deploy.resources.limits.pids`. When both exist (`pids_limit` + a `deploy.resources.limits` block with only `memory`), Compose v5 reports `"can't set distinct values"` and refuses to start — breaking both `docker compose up` and `docker compose down`.

## Changes

- `docker-compose.yml`: Moved PID limit from top-level `pids_limit: 512` to `deploy.resources.limits.pids: 512`.

## Test plan

- [ ] `docker compose config` validates without error on Compose v5
- [ ] `docker compose up` starts successfully
- [ ] PID limit is still enforced (512)

Fixes #2091