### PR TITLE
fix(crawler): skip body visibility check when ignore_body_visibility=True (#2129)

### DIFF
--- a/crawl4ai/async_crawler_strategy.py
+++ b/crawl4ai/async_crawler_strategy.py
@@ -808,40 +808,44 @@ class AsyncPlaywrightCrawlerStrategy(AsyncCrawlerStrategy):
                 response_headers = {}
 
             # Wait for body element and visibility
-            try:
-                await page.wait_for_selector("body", state="attached", timeout=30000)
+            # Skip entirely when ignore_body_visibility=True (the default)
+            # to avoid a hardcoded 30s penalty on pages where body is never visible
+            # (e.g., AngularJS ng-cloak, Vue v-cloak).  See #2129.
+            if not config.ignore_body_visibility:
+                try:
+                    await page.wait_for_selector("body", state="attached", timeout=30000)
 
-                # Use the new check_visibility function with csp_compliant_wait
-                is_visible = await self.csp_compliant_wait(
-                    page,
-                    """() => {
-                        const element = document.body;
-                        if (!element) return false;
-                        const style = window.getComputedStyle(element);
-                        const isVisible = style.display !== 'none' && 
-                                        style.visibility !== 'hidden' && 
-                                        style.opacity !== '0';
-                        return isVisible;
-                    }""",
-                    timeout=30000,
-                )
-
-                if not is_visible and not config.ignore_body_visibility:
-                    visibility_info = await self.check_visibility(page)
-                    raise Error(f"Body element is hidden: {visibility_info}")
-
-            except Error:
-                visibility_info = await self.check_visibility(page)
-
-                if self.browser_config.verbose:
-                    self.logger.debug(
-                        message="Body visibility info: {info}",
-                        tag="DEBUG",
-                        params={"info": visibility_info},
+                    # Use the new check_visibility function with csp_compliant_wait
+                    is_visible = await self.csp_compliant_wait(
+                        page,
+                        """() => {
+                            const element = document.body;
+                            if (!element) return false;
+                            const style = window.getComputedStyle(element);
+                            const isVisible = style.display !== 'none' &&
+                                            style.visibility !== 'hidden' &&
+                                            style.opacity !== '0';
+                            return isVisible;
+                        }"",
+                        timeout=30000,
                     )
 
-                if not config.ignore_body_visibility:
+                    if not is_visible:
+                        visibility_info = await self.check_visibility(page)
+                        raise Error(f"Body element is hidden: {visibility_info}")
+
+                except Error:
+                    visibility_info = await self.check_visibility(page)
+
+                    if self.browser_config.verbose:
+                        self.logger.debug(
+                            message="Body visibility info: {info}",
+                            tag="DEBUG",
+                            params={"info": visibility_info},
+                        )
+
                     raise Error(f"Body element is hidden: {visibility_info}")
+
 
             # try:
             #     await page.wait_for_selector("body", state="attached", timeout=30000)


### PR DESCRIPTION
## Summary

Fixes #2129 — When ignore_body_visibility=True (the default), the crawler still waited for body to become attached (30s timeout) and ran a visibility check, only to discard the result. This added a hardcoded 30s penalty on every page where body is never visible.

## Root cause

The body visibility check block (wait_for_selector + csp_compliant_wait) ran unconditionally, then the result was checked against config.ignore_body_visibility. On pages with ng-cloak/v-cloak where body never becomes visible, this wasted 30 seconds every crawl.

## Fix

Wrap the entire body visibility block in `if not config.ignore_body_visibility` so the default path skips it entirely. Remove redundant inner guards that are now unreachable.

## Files changed

- crawl4ai/async_crawler_strategy.py (+32/-28)