### PR TITLE
fix(filter): respect preserve_tags in excluded_tags removal (#2125)

### DIFF
--- a/crawl4ai/content_filter_strategy.py
+++ b/crawl4ai/content_filter_strategy.py
@@ -683,9 +683,14 @@ class PruningContentFilter(RelevantContentFilter):
             element.extract()
 
     def _remove_unwanted_tags(self, soup):
-        """Removes unwanted tags"""
+        """Removes unwanted tags, respecting preserve_tags whitelist."""
         for tag in self.excluded_tags:
             for element in soup.find_all(tag):
+                # Skip elements that match preserve_tags — they should be kept
+                # even if the tag is in excluded_tags (e.g., <aside> with
+                # preserve_tags=["aside"]).  See #2125.
+                if self.preserve_tags and tag in self.preserve_tags:
+                    continue
                 element.decompose()
 
     def _is_preserved(self, node):


### PR DESCRIPTION
## Summary

Fixes #2125 — PruningContentFilter(preserve_tags=["aside"]) was silently ignored because _remove_unwanted_tags decomposes all excluded tags (nav, footer, header, aside, ...) before _prune_tree runs.

## Root cause

_remove_unwanted_tags() decomposes every element in self.excluded_tags unconditionally. _prune_tree() respects preserve_tags via _is_preserved(), but the elements are already gone.

## Fix

Add preserve_tags check in _remove_unwanted_tags to skip elements whose tag is in the preserve whitelist.

## Files changed

- crawl4ai/content_filter_strategy.py (+6/-1)