### PR TITLE
fix(docker): add pypdf to Docker requirements (#2127)

### DIFF
--- a/deploy/docker/requirements.txt
+++ b/deploy/docker/requirements.txt
@@ -14,3 +14,4 @@ PyJWT==2.10.1
 mcp>=1.18.0
 websockets>=15.0.1
 httpx[http2]>=0.27.2
+pypdf>=3.0.0


### PR DESCRIPTION
## Summary

Fixes #2127 — PDFContentScrapingStrategy requires pypdf, but the Docker image installs crawl4ai without the [pdf] extra, so pypdf is missing and PDF scraping fails at import time.

## Fix

Add pypdf>=3.0.0 to deploy/docker/requirements.txt.

## Files changed

- deploy/docker/requirements.txt (+1)