### PR TITLE
fix(docker): handle cgroup v2 'max' in memory guard (#2123)

### DIFF
--- a/deploy/docker/utils.py
+++ b/deploy/docker/utils.py
@@ -420,9 +420,16 @@ def get_container_memory_percent() -> float:
             limit_path = Path("/sys/fs/cgroup/memory/memory.limit_in_bytes")
 
         usage = int(usage_path.read_text())
-        limit = int(limit_path.read_text())
+        limit_str = limit_path.read_text().strip()
 
-        # Handle unlimited (v2: "max", v1: > 1e18)
+        # Handle unlimited: cgroup v2 writes "max", cgroup v1 writes > 1e18
+        if limit_str == "max" or not limit_str:
+            import psutil
+            limit = psutil.virtual_memory().total
+        else:
+            limit = int(limit_str)
+
+        # Handle cgroup v1 unlimited (limit > 1e18)
         if limit > 1e18:
             import psutil
             limit = psutil.virtual_memory().total


### PR DESCRIPTION
## Summary

Fixes #2123 — On cgroup v2 with no container memory limit, memory.max contains the string "max". int("max") raised ValueError, the bare except caught it, and the function returned host memory percentage instead of container's.

## Fix

Parse limit as string first, handle "max" explicitly (fall back to host total), then convert to int for numeric values.

## Files changed

- deploy/docker/utils.py (+9/-2)