### PR TITLE
fix(crawler): clean up Playwright driver on __aenter__ failure (#2155)

### DIFF
--- a/crawl4ai/async_webcrawler.py
+++ b/crawl4ai/async_webcrawler.py
@@ -197,7 +197,17 @@ class AsyncWebCrawler:
         await self.crawler_strategy.__aexit__(None, None, None)
 
     async def __aenter__(self):
-        return await self.start()
+        try:
+            return await self.start()
+        except Exception:
+            # Ensure partially-initialised Playwright driver is cleaned up
+            # when browser launch fails inside __aenter__.  Without this,
+            # each failed attempt leaks a live `node run-driver` child. (#2155)
+            try:
+                await self.close()
+            except Exception:
+                pass
+            raise
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         await self.close()


### PR DESCRIPTION
## Summary

Fixes #2155 — When browser launch fails inside __aenter__, the exception propagated without closing the partially-initialized crawler, leaking a live 'node run-driver' child process. Each failed attempt grew the process count linearly.

## Fix

Add try/except in __aenter__ to call close() on failure before re-raising.

## Files changed

- crawl4ai/async_webcrawler.py (+11/-1)