### PR TITLE
fix(crawler): await inner stream aclose in arun_many (#2083)

### DIFF
--- a/crawl4ai/async_webcrawler.py
+++ b/crawl4ai/async_webcrawler.py
@@ -1107,13 +1107,18 @@ class AsyncWebCrawler:
 
         if stream:
             async def result_transformer():
+                inner = dispatcher.run_urls_stream(
+                    crawler=self, urls=urls, config=config
+                )
                 try:
-                    async for task_result in dispatcher.run_urls_stream(
-                        crawler=self, urls=urls, config=config
-                    ):
+                    async for task_result in inner:
                         yield transform_result(task_result)
                 finally:
-                    # Auto-release session after streaming completes
+                    # Ensure the inner dispatcher stream is fully closed
+                    # before releasing the session — otherwise cleanup of
+                    # active crawl tasks may overlap with session teardown.
+                    # (See #2083: arun_many stream closure leaks tasks.)
+                    await inner.aclose()
                     await maybe_release_session()
 
             return result_transformer()


### PR DESCRIPTION
## Summary

Fixes #2083 — When the outer result_transformer() generator is closed via aclose(), the inner dispatcher.run_urls_stream() generator was not explicitly closed, so its cleanup could overlap with session teardown.

## Fix

Explicitly aclose() the inner generator in the finally block before releasing the session.

## Files changed

- crawl4ai/async_webcrawler.py (+9/-4)