### PR TITLE
docs: fix typos in code comments

### DIFF
--- a/crawl4ai/async_configs.py
+++ b/crawl4ai/async_configs.py
@@ -1010,7 +1010,7 @@ class BrowserConfig:
         config_dict.update(kwargs)
         return BrowserConfig.from_kwargs(config_dict)
 
-    # Create a funciton returns dict of the object
+    # Create a function returns dict of the object
     def dump(self) -> dict:
         # Serialize the object to a dictionary
         return to_serializable_dict(self)
@@ -2081,7 +2081,7 @@ class CrawlerRunConfig():
         valid = inspect.signature(CrawlerRunConfig.__init__).parameters.keys() - {"self"}
         return CrawlerRunConfig(**{k: v for k, v in kwargs.items() if k in valid})
 
-    # Create a funciton returns dict of the object
+    # Create a function returns dict of the object
     def dump(self) -> dict:
         # Serialize the object to a dictionary
         return to_serializable_dict(self)

--- a/crawl4ai/deep_crawling/crazy.py
+++ b/crawl4ai/deep_crawling/crazy.py
@@ -334,7 +334,7 @@ class BFSDeepCrawlStrategy(DeepCrawlStrategy):
         ctx.depths[start_url] = 0
 
         while not ctx.frontier.is_empty() and not self._cancel.is_set():
-            # Use the best algorith, to find top_n value
+            # Use the best algorithm to find top_n value
             top_n = calculate_quantum_batch_size(
                 depth=ctx.current_depth,
                 max_depth=self.max_depth,

--- a/crawl4ai/extraction_strategy.py
+++ b/crawl4ai/extraction_strategy.py
@@ -723,7 +723,7 @@ class LLMExtractionStrategy(ExtractionStrategy):
                 elif self.force_json_response:
                     blocks = json.loads(_strip_markdown_fences(content))
                     if isinstance(blocks, dict):
-                        # If it has only one key which calue is list then assign that to blocks, exampled: {"news": [..]}
+                        # If it has only one key which value is list then assign that to blocks, exampled: {"news": [..]}
                         if len(blocks) == 1 and isinstance(list(blocks.values())[0], list):
                             blocks = list(blocks.values())[0]
                         else:


### PR DESCRIPTION
Fixes four typos in code comments (no behavior change):

- `async_configs.py` (x2): "funciton" -> "function"
- `extraction_strategy.py`: "which calue is list" -> "which value is list"
- `deep_crawling/crazy.py`: "the best algorith, to find" -> "the best algorithm to find"

Targeting `develop` per CONTRIBUTING.md.