### PR TITLE
Docs: Add markdown content filter example for REST API

### DIFF
--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -601,6 +601,47 @@ else:
 
 ```
 
+#### Markdown with Content Filter (Pruning / BM25)
+
+To strip navigation, ads, and other clutter from the extracted page, attach a content filter to the markdown generator. The filter **must be nested inside `markdown_generator`** — a top-level `content_filter` key in `crawler_config` is silently ignored by the server (HTTP 200 with an empty `fit_markdown`), because the untrusted config loader only accepts allowlisted fields and drops unknown ones without error.
+
+```python
+import requests
+
+crawler_config_payload = {
+    "type": "CrawlerRunConfig",
+    "params": {
+        "cache_mode": "bypass",
+        "markdown_generator": {
+            "type": "DefaultMarkdownGenerator",
+            "params": {
+                "content_filter": {
+                    "type": "PruningContentFilter",
+                    "params": {"threshold": 0.45, "threshold_type": "fixed"}
+                }
+            }
+        }
+    }
+}
+
+crawl_payload = {
+    "urls": ["https://httpbin.org/html"],
+    "crawler_config": crawler_config_payload
+}
+response = requests.post("http://localhost:11235/crawl", json=crawl_payload)
+data = response.json()
+markdown = data["results"][0]["markdown"]
+# Pruned output lives in fit_markdown (fit_html for the filtered HTML);
+# raw_markdown always contains the unfiltered page.
+print(markdown["fit_markdown"])
+```
+
+**Response fields:** with a content filter active, the result `markdown` object includes `fit_markdown` / `fit_html` alongside the unfiltered `raw_markdown`. Without a filter, `fit_markdown` is empty.
+
+**BM25 filter:** swap `PruningContentFilter` for `{"type": "BM25ContentFilter", "params": {"user_query": "your query"}}` to keep only content relevant to a query.
+
+**`/md` endpoint:** for a simpler markdown-only request, `POST /md` with `filter_type` in `fit` (default), `raw`, `bm25`, or `llm` mode applies a built-in filter without tuning knobs. See `docs/examples/docker/demo_docker_api.py` (Demo 2a-2c) for more filter configurations.
+
 #### Streaming Results
 
 ```python


### PR DESCRIPTION
## Summary

Adds a **Markdown with Content Filter (Pruning / BM25)** example to the Docker server README REST API section (`deploy/docker/README.md`), between the Simple Crawl and Streaming examples.

What it covers:

- The working payload shape for `content_filter`, nested inside `markdown_generator` with the `{"type": "ClassName", "params": {...}}` serialization
- The silent-drop pitfall: a top-level `content_filter` key in `crawler_config` is ignored by the untrusted config loader (HTTP 200, empty `fit_markdown`) — this cost real debugging time, and the failure mode is invisible unless you check `fit_markdown`
- Response fields: `fit_markdown` / `fit_html` vs the always-present `raw_markdown`
- BM25 variant (`user_query`) and a pointer to `docs/examples/docker/demo_docker_api.py` (Demo 2a–2c) for more configurations

## Verification

Payload tested live against the 0.9.2 Docker server:

- `https://httpbin.org/html`: raw 3598 → fit 3598 chars (pruning, threshold 0.45 fixed)
- `https://www.bbc.com/news`: raw ~22K → fit ~9.9K chars (nav/cookie boilerplate stripped)

> **Transparency:** Prepared with assistance from my Hermes AI agent (Muninn), based on live verification against the 0.9.2 server. The example payload in the PR is the exact payload that was tested. Happy to adjust wording or add the same note to `demo_docker_api.py` if preferred.
