### PR TITLE
docs: fix dead 0.7.0 release notes link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1039,7 +1039,7 @@ from crawl4ai import CrawlerRunConfig, MatchMode, CacheMode
 
 - **⚡ Performance Boost**: Up to 3x faster with optimized resource handling and memory efficiency
 
-Read the full details in our [0.7.0 Release Notes](https://docs.crawl4ai.com/blog/release-v0.7.0) or check the [CHANGELOG](https://github.com/unclecode/crawl4ai/blob/main/CHANGELOG.md).
+Read the full details in our [0.7.0 Release Notes](https://docs.crawl4ai.com/blog/releases/0.7.0/) or check the [CHANGELOG](https://github.com/unclecode/crawl4ai/blob/main/CHANGELOG.md).
 
 </details>
 


### PR DESCRIPTION
The 0.7.0 release notes link in the README returns **HTTP 404** — the docs site moved release posts under `/blog/releases/<version>/`. Fixed to `https://docs.crawl4ai.com/blog/releases/0.7.0/` (HTTP 200, "Crawl4AI v0.7.0: The Adaptive Intelligence Update").
