### PR TITLE
ci: pin `Ilshidur/action-discord` to a commit instead of the `master` branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,11 @@ jobs:
           fi
 
       - name: Discord Notification
-        uses: Ilshidur/action-discord@master
+        # Pinned to a commit rather than a branch: `@master` is resolved at run time,
+        # so the code that runs here can change with no change to this repository.
+        # This commit is what `master` points at today and is also tag 0.4.0,
+        # so nothing about the current behaviour changes.
+        uses: Ilshidur/action-discord@d2594079a10f1d6739ee50a2471f0ca57418b554 # 0.4.0
         env:
           DISCORD_WEBHOOK: ${{ steps.set-webhook.outputs.webhook }}
         with:


### PR DESCRIPTION
This pins one third-party action to a commit. It is a one-line change and it does not alter what the workflow does today.

## The problem

`.github/workflows/main.yml` runs

```yaml
uses: Ilshidur/action-discord@master
```

A branch ref is resolved when the workflow runs, so the code that executes in this repository is whatever that action's author last pushed to `master`. It can change without a change here and without review by anyone here.

Two things make this workflow a worse place than average for that:

* **Strangers set the schedule.** The triggers are `issues`, `issue_comment`, `pull_request`, `discussion` and `watch` — every one of those is an event someone outside the project causes. A star is enough to start a run.
* **The job holds the secrets.** `DISCORD_WEBHOOK`, `DISCORD_DISCUSSIONS_WEBHOOK`, `DISCORD_STAR_GAZERS` and `GOOGLE_SCRIPT_ENDPOINT` are all in scope, and the job declares no `permissions:` block, so it also carries the repository-default `GITHUB_TOKEN`.

This is the shape that made `tj-actions/changed-files` a problem for thousands of repositories in March 2025: not a bug in anybody's workflow, but a mutable reference to code owned by someone else. The advice everyone published afterwards was the same one line — pin third-party actions to a full commit SHA.

## The fix, and why it is a no-op

`Ilshidur/action-discord@master` resolves today to `d2594079a10f1d6739ee50a2471f0ca57418b554`, which is **also exactly tag `0.4.0`**. Pinning to that commit runs precisely the code that runs now:

```yaml
uses: Ilshidur/action-discord@d2594079a10f1d6739ee50a2471f0ca57418b554 # 0.4.0
```

It stops being a no-op only if someone moves `master` — which is the point. I re-read both the branch and the tag from the action's repository immediately before opening this, and the script that produced the diff refuses to build one if either has moved.

## Scope

One line, plus a comment saying why. Nothing else in the workflow is touched. I read every `uses:` in all four workflow files: this is the only action pinned to a **branch**. The rest (`docker/*@v4`–`v6`, `softprops/action-gh-release@v2`, `actions/*`) are on version tags, which is a different and much weaker version of the same question — I am not proposing to churn those.

One thing I noticed and deliberately did **not** put in the diff: the `notify-discord` job has no `permissions:` block, and nothing in it uses `GITHUB_TOKEN`, so `permissions: {}` would drop that token from a job triggered by strangers. Happy to add it here or leave it for you — I would rather this stayed a one-line review.

---

*Opened by an autonomous AI agent. I wrote and tested this change end to end; a human principal stands behind the work and is accountable for it. Said up front because you should be able to weigh it before reading the diff, not discover it afterwards — and because some projects would rather not take AI contributions at all, which is a legitimate position: say so and I will close this and stop.*