### PR TITLE
fix: correct nl.toknize -> nl.tokenize typo in TopicSegmentationChunking.extract_keywords

### DIFF
--- a/crawl4ai/chunking_strategy.py
+++ b/crawl4ai/chunking_strategy.py
@@ -119,7 +119,7 @@ class TopicSegmentationChunking(ChunkingStrategy):
         # Tokenize and remove stopwords and punctuation
         import nltk as nl
 
-        tokens = nl.toknize.word_tokenize(text)
+        tokens = nl.tokenize.word_tokenize(text)
         tokens = [
             token.lower()
             for token in tokens

--- a/tests/unit/test_chunking_strategy_unit.py
+++ b/tests/unit/test_chunking_strategy_unit.py
@@ -1,0 +1,31 @@
+"""Unit tests for chunking_strategy.py."""
+import sys
+import types
+from unittest.mock import patch, MagicMock
+from crawl4ai.chunking_strategy import TopicSegmentationChunking
+
+
+class TestTopicSegmentationExtractKeywords:
+
+    def test_extract_keywords_does_not_raise(self):
+        # extract_keywords previously called the non-existent `nl.toknize`
+        # instead of `nl.tokenize`, raising AttributeError on every call.
+        # __init__ is bypassed since it builds a real TextTilingTokenizer,
+        # which needs NLTK data unrelated to this bug.
+        #
+        # nltk's real `corpus`/`tokenize` modules are lazy-loaded and touch
+        # disk data on first attribute access even under mock.patch, so a
+        # bare stand-in module is swapped into sys.modules instead.
+        fake_nltk = types.ModuleType("nltk")
+        fake_nltk.tokenize = MagicMock()
+        fake_nltk.tokenize.word_tokenize.return_value = ["fast", "car", "fast", "car", "road"]
+        fake_nltk.corpus = MagicMock()
+        fake_nltk.corpus.stopwords.words.return_value = ["the", "a"]
+
+        chunker = TopicSegmentationChunking.__new__(TopicSegmentationChunking)
+        chunker.num_keywords = 2
+
+        with patch.dict(sys.modules, {"nltk": fake_nltk}):
+            keywords = chunker.extract_keywords("Fast car, fast car, on the road.")
+
+        assert keywords == ["fast", "car"]


### PR DESCRIPTION
## Root cause

`TopicSegmentationChunking.extract_keywords()` calls the non-existent `nl.toknize.word_tokenize` instead of `nl.tokenize.word_tokenize`, raising `AttributeError: module 'nltk' has no attribute 'toknize'` on every invocation.

This is the same typo class reported in #59 (2024) — but that report/fix only covered the constructor's `nl.toknize.TextTilingTokenizer()` call (fixed in f5a4e80). It missed this second, separate occurrence of the identical typo in `extract_keywords()`, which has been broken ever since and crashes both `extract_keywords()` and `chunk_with_topics()`.

Found via direct source review, not an existing issue.

## Fix

One-line fix: `nl.toknize.word_tokenize` -> `nl.tokenize.word_tokenize` (`crawl4ai/chunking_strategy.py:122`).

## Test evidence

Added `tests/unit/test_chunking_strategy_unit.py`. Verified red-before-green:
- Before the fix: test fails with `AttributeError: module 'nltk' has no attribute 'toknize'`
- After the fix: test passes

Full `tests/unit/` suite: 49 passed. `ruff check` clean on both changed files.
