### PR TITLE
Emit --disable-features once instead of letting a later one discard it

### DIFF
--- a/crawl4ai/browser_manager.py
+++ b/crawl4ai/browser_manager.py
@@ -27,7 +27,10 @@ BROWSER_DISABLE_OPTIONS = [
     "--disable-component-extensions-with-background-pages",
     "--disable-default-apps",
     "--disable-extensions",
-    "--disable-features=TranslateUI",
+    # "TranslateUI" is not a feature name in current Chromium - the literal is
+    # absent from the shipped binary, so the switch matched nothing and the
+    # translate UI was never actually disabled. The feature is "Translate".
+    "--disable-features=Translate",
     "--disable-hang-monitor",
     "--disable-ipc-flooding-protection",
     "--disable-popup-blocking",
@@ -39,6 +42,53 @@ BROWSER_DISABLE_OPTIONS = [
     "--password-store=basic",
     "--use-mock-keychain",
 ]
+
+# Chromium switches whose value is a comma-separated feature list. Chrome parses
+# them last-wins: given the switch twice it keeps the last value and silently
+# drops every earlier one, whole. Any code path that appends one of these rather
+# than merging into the existing value therefore throws away what was declared
+# before it, with no warning and no way to notice from the options object.
+_FEATURE_LIST_SWITCHES = ("--disable-features=", "--enable-features=")
+
+
+def merge_feature_switches(flags: List[str]) -> List[str]:
+    """Collapse repeated ``--disable-features`` / ``--enable-features`` switches.
+
+    Each switch is emitted once, at the position of its first occurrence, so the
+    surrounding flag order is untouched. Feature names keep first-seen order and
+    are de-duplicated.
+
+    >>> merge_feature_switches(
+    ...     ["--a", "--disable-features=X,Y", "--b", "--disable-features=Y,Z"]
+    ... )
+    ['--a', '--disable-features=X,Y,Z', '--b']
+    """
+    merged: Dict[str, List[str]] = {}
+    for flag in flags:
+        for switch in _FEATURE_LIST_SWITCHES:
+            if flag.startswith(switch):
+                names = merged.setdefault(switch, [])
+                for name in flag[len(switch) :].split(","):
+                    name = name.strip()
+                    if name and name not in names:
+                        names.append(name)
+                break
+
+    if not merged:
+        return list(flags)
+
+    out: List[str] = []
+    emitted = set()
+    for flag in flags:
+        for switch in _FEATURE_LIST_SWITCHES:
+            if flag.startswith(switch):
+                if switch not in emitted:
+                    emitted.add(switch)
+                    out.append(switch + ",".join(merged[switch]))
+                break
+        else:
+            out.append(flag)
+    return out
 
 
 class ManagedBrowser:
@@ -123,8 +173,9 @@ class ManagedBrowser:
             flags.append(f"--proxy-server={config.proxy}")
         elif config.proxy_config:
             flags.append(f"--proxy-server={config.proxy_config.server}")
-        # dedupe
-        return list(dict.fromkeys(flags))
+        # dedupe, then fold the feature lists together so a later
+        # --disable-features does not discard an earlier one
+        return merge_feature_switches(list(dict.fromkeys(flags)))
 
     browser_type: str
     user_data_dir: str
@@ -867,7 +918,8 @@ class BrowserManager:
 
             launch_kwargs = {
                 "headless": self.config.headless,
-                "args": list(dict.fromkeys(cli_args)),  # dedupe
+                # dedupe, then merge the feature lists
+                "args": merge_feature_switches(list(dict.fromkeys(cli_args))),
                 "viewport": {
                     "width": self.config.viewport_width,
                     "height": self.config.viewport_height,
@@ -1138,9 +1190,10 @@ class BrowserManager:
         if self.config.extra_args:
             args.extend(self.config.extra_args)
 
-        # Deduplicate args
-        args = list(dict.fromkeys(args))
-        
+        # Deduplicate args, then merge the feature lists so a later
+        # --disable-features does not discard an earlier one
+        args = merge_feature_switches(list(dict.fromkeys(args)))
+
         browser_args = {"headless": self.config.headless, "args": args}
 
         # On Windows, passing channel='chromium' (the default) causes Playwright

--- a/tests/regression/test_reg_browser.py
+++ b/tests/regression/test_reg_browser.py
@@ -176,6 +176,80 @@ def test_disable_features_omits_optimization_hints():
                 )
 
 
+def _feature_switches(args):
+    """The --disable-features switches in `args`, in order."""
+    return [a for a in args if a.startswith("--disable-features=")]
+
+
+def _feature_names(args):
+    """Only the names Chrome actually applies: the value of the last switch."""
+    switches = _feature_switches(args)
+    if not switches:
+        return []
+    return [n for n in switches[-1].split("=", 1)[1].split(",") if n]
+
+
+def test_merge_feature_switches_folds_repeats():
+    """Chrome parses --disable-features last-wins: given the switch twice it
+    keeps the last value and silently drops the earlier one whole. Collapse
+    repeats into one switch, in place, so nothing declared is lost."""
+    from crawl4ai.browser_manager import merge_feature_switches
+
+    merged = merge_feature_switches(
+        ["--a", "--disable-features=X,Y", "--b", "--disable-features=Y,Z", "--c"]
+    )
+    # one switch, at the position of the first occurrence, order otherwise intact
+    assert merged == ["--a", "--disable-features=X,Y,Z", "--b", "--c"]
+
+    # --enable-features is parsed the same way and is folded separately
+    merged = merge_feature_switches(
+        ["--enable-features=A", "--disable-features=X", "--enable-features=B"]
+    )
+    assert merged == ["--enable-features=A,B", "--disable-features=X"]
+
+    # nothing to fold: the list is returned unchanged
+    assert merge_feature_switches(["--a", "--b"]) == ["--a", "--b"]
+
+
+def test_build_browser_flags_emits_one_feature_switch():
+    """ManagedBrowser.build_browser_flags must not emit --disable-features
+    twice. light_mode appends BROWSER_DISABLE_OPTIONS, whose own entry used to
+    land after the default one and take the browser with it."""
+    from crawl4ai.browser_manager import ManagedBrowser
+
+    for light_mode in (False, True):
+        config = BrowserConfig(headless=True, light_mode=light_mode)
+        flags = ManagedBrowser.build_browser_flags(config)
+        assert (
+            len(_feature_switches(flags)) == 1
+        ), f"light_mode={light_mode}: {_feature_switches(flags)}"
+        # the defaults survive light_mode instead of being displaced by it.
+        # OptimizationHints is deliberately not among them - #2239 removed it
+        # from the default list, and the test above pins that removal.
+        names = _feature_names(flags)
+        for expected in ("MediaRouter", "DialMediaRouteProvider"):
+            assert expected in names, f"light_mode={light_mode} lost {expected}"
+
+
+def test_extra_args_feature_switch_merges_with_defaults():
+    """A user --disable-features passed through extra_args used to be appended
+    after the default switch, so Chrome applied the user's names and none of
+    crawl4ai's. Both must survive."""
+    from crawl4ai.browser_manager import BrowserManager
+
+    config = BrowserConfig(
+        headless=True,
+        extra_args=["--disable-features=CalculateNativeWinOcclusion"],
+    )
+    args = BrowserManager(browser_config=config)._build_browser_args()["args"]
+
+    assert len(_feature_switches(args)) == 1, _feature_switches(args)
+    names = _feature_names(args)
+    assert "CalculateNativeWinOcclusion" in names, "user's own name dropped"
+    for expected in ("MediaRouter", "DialMediaRouteProvider"):
+        assert expected in names, f"default {expected} displaced by extra_args"
+
+
 # ---------------------------------------------------------------------------
 # Viewport configuration
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Chrome parses `--disable-features` **last-wins**: given the switch twice it keeps the
last value and silently discards every earlier one, whole. There is no warning, and
the options object still shows both, so nothing about the Python side looks wrong.

`build_browser_flags()` and `_build_browser_args()` both assemble the flag list by
appending, and two ordinary configurations put a second `--disable-features` after the
default one. In those two configurations crawl4ai's own
`OptimizationHints,MediaRouter,DialMediaRouteProvider` never reaches the browser.

Measured on `develop` @ `023c87d`, Windows 10, Playwright 1.62 / Chromium 151.0.7922.34.
The command line is read back off the running process through `Win32_Process`, because
what Playwright receives and what `CreateProcess` gets are not the same list:

| configuration | `--disable-features` switches on the command line | names Chrome actually applies |
|---|---|---|
| defaults | 2 | `OptimizationHints, MediaRouter, DialMediaRouteProvider` |
| `light_mode=True` | 3 | **`TranslateUI`** |
| `extra_args=["--disable-features=CalculateNativeWinOcclusion"]` | 3 | **`CalculateNativeWinOcclusion`** |

The two bold rows are the bug. `light_mode=True` appends `BROWSER_DISABLE_OPTIONS`,
whose own `--disable-features` entry lands last and takes the browser with it, so
turning light mode *on* is what switches the default three *off*. Same for any user who
passes their own `--disable-features` through `extra_args` - they get their names and
none of crawl4ai's, which is very likely not what they meant by "extra".

After the patch, all four configurations emit exactly one switch and nothing crawl4ai
declared is dropped:

| configuration | switches | names applied |
|---|---|---|
| defaults | 1 | `OptimizationHints, MediaRouter, DialMediaRouteProvider` |
| `light_mode=True` | 1 | `OptimizationHints, MediaRouter, DialMediaRouteProvider, Translate` |
| `extra_args=[...]` | 1 | `OptimizationHints, MediaRouter, DialMediaRouteProvider, CalculateNativeWinOcclusion` |

### The second fix: `TranslateUI` is not a feature name

`BROWSER_DISABLE_OPTIONS` carried `--disable-features=TranslateUI`. That name does not
exist in Chromium any more; the feature is `Translate`. Chrome ignores an unknown
feature name silently, so the switch has been matching nothing.

Behaviour cannot tell "the flag worked" from "the flag was ignored", so this was checked
against the binary instead - every `base::Feature` carries its name as a string literal,
and a literal that is absent cannot be matched at parse time. Counting whole-word
occurrences across `chrome.dll` and `chrome.exe` of Chromium 151.0.7922.34:

```
TranslateUI                       0  ABSENT - cannot be matched
Translate                        59  present
OptimizationHints                 5  present
MediaRouter                      48  present
DialMediaRouteProvider            2  present
NodeMavenDefinitelyNotAFeature    0  ABSENT   <- negative control
```

Absence is conclusive here; presence only says the name exists somewhere in the build.
The last row is a name nobody could have implemented, included so that "ABSENT" is
shown to be a result the test can produce rather than an artefact of how it searches.

## List of files changed and why

- **`crawl4ai/browser_manager.py`**
  - `merge_feature_switches()` - new module-level helper. Folds repeats of
    `--disable-features` and `--enable-features` into one switch each, emitted at the
    position of the **first** occurrence so the surrounding flag order is untouched.
    Names keep first-seen order and are de-duplicated.
  - `ManagedBrowser.build_browser_flags()` - merge after the existing dedupe.
  - `BrowserManager` `launch_kwargs["args"]` (the `launch_persistent_context` path) -
    same.
  - `BrowserManager._build_browser_args()` - same.
  - `BROWSER_DISABLE_OPTIONS` - `TranslateUI` -> `Translate`, with the reason in a
    comment.

  It merges rather than drops the duplicate on purpose: `build_browser_flags()` also
  feeds `ManagedBrowser._get_browser_args()`, which spawns Chrome **directly** with no
  Playwright in the picture, so there is no outer list to defer to.

- **`tests/regression/test_reg_browser.py`** - a new "Launch flags" section with three
  tests: the helper's own contract (including that `--enable-features` is folded
  separately and that a list with nothing to fold is returned unchanged),
  `build_browser_flags()` under both `light_mode` values, and `_build_browser_args()`
  with a user `--disable-features` in `extra_args`.

## How Has This Been Tested?

- `pytest tests/regression/test_reg_browser.py` - **33 passed on `develop`, 36 passed
  with this branch**, so the 33 pre-existing tests are unaffected and the 3 new ones
  are additions rather than adjustments.
- The three new tests were run against unpatched `develop` first and **all three fail**
  there, each for its own reason - `2 == 1` on the switch count for both call sites,
  `ImportError` for the helper. A regression test that passes before the fix is not
  testing the fix.
- `pytest --doctest-modules crawl4ai/browser_manager.py` - passes; the helper's
  docstring carries a worked example.
- End to end: a real `chromium.launch(args=...)` per configuration, with the resulting
  command line read back through `Win32_Process`. Both tables above come from that,
  base and patched, run in the same session on the same host so the two sides differ
  only in the patch.
- `black` on the added block only. The rest of both files is not currently
  black-clean, and reformatting it would have buried this diff.

## Two things this does *not* claim

- **No performance or bandwidth claim.** `OptimizationHints` coming back on is a
  correctness result, not a measured saving. I looked for the Optimization Guide
  model download in idle traffic and did not observe it in these runs, so there is
  nothing to quote.
- **The collision with Playwright's own list is not fixed, and cannot be fixed here.**
  Playwright emits its own `--disable-features` from `chromiumSwitches()` and then does
  `chromeArguments.push(...args)`, so crawl4ai's single switch still lands after
  Playwright's 16-name one and displaces it. Measured, patched branch, defaults:

  ```
  [14] --disable-features=AvoidUnnecessaryBeforeUnloadCheckSync,...,OptimizationHints,...   <- Playwright
  [57] --disable-features=OptimizationHints,MediaRouter,DialMediaRouteProvider              <- crawl4ai, wins
  ```

  13 of Playwright's names are dropped, `HttpsUpgrades` and `PaintHolding` among them.
  This is true of **any** library that passes `--disable-features` through Playwright,
  it is unchanged by this PR in either direction, and Playwright exposes no merge API to
  fix it from the outside. Worth knowing about; a separate problem.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation - no user-facing behaviour
      changes beyond the flags now taking effect, so there is nothing documented to update
- [x] I have added/updated unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
