### PR TITLE
Skip /config/dump pre-flight for md/llm endpoints in playground

### DIFF
--- a/deploy/docker/static/playground/index.html
+++ b/deploy/docker/static/playground/index.html
@@ -686,29 +686,31 @@
         async function runCrawl() {
             const endpoint = document.getElementById('endpoint').value;
             const urls = document.getElementById('urls').value.trim().split(/\n/).filter(u => u);
-            // 1) grab python from CodeMirror, validate via /config/dump
+            // 1) grab python from CodeMirror, validate via /config/dump.
+            // Advanced Config is /crawl-only, so md/llm skip this entirely.
             let advConfig = {};
-            try {
-                const cfgJson = await pyConfigToJson(); // may throw
-                if (Object.keys(cfgJson).length) {
-                    const cfgType = document.getElementById('cfg-type').value;
-                    advConfig = cfgType === 'CrawlerRunConfig'
-                        ? { crawler_config: cfgJson }
-                        : { browser_config: cfgJson };
-                }
-            } catch (err) {
-                const codeText = cm.getValue();
-                const streamFlag = /stream\s*=\s*True/i.test(codeText);
-                const isCrawlEndpoint = document.getElementById('endpoint').value === 'crawl';
-                if (isCrawlEndpoint && streamFlag) {
-                    // Fallback: minimal dump-shaped config so shouldUseStream + server load agree
-                    advConfig = { crawler_config: { type: 'CrawlerRunConfig', params: { stream: true } } };
-                } else {
-                    updateStatus('error');
-                    document.querySelector('#response-content code').textContent =
-                        JSON.stringify({ error: err.message }, null, 2);
-                    forceHighlightElement(document.querySelector('#response-content code'));
-                    return; // stop run
+            if (endpoint === 'crawl' || endpoint === 'crawl_stream') {
+                try {
+                    const cfgJson = await pyConfigToJson(); // may throw
+                    if (Object.keys(cfgJson).length) {
+                        const cfgType = document.getElementById('cfg-type').value;
+                        advConfig = cfgType === 'CrawlerRunConfig'
+                            ? { crawler_config: cfgJson }
+                            : { browser_config: cfgJson };
+                    }
+                } catch (err) {
+                    const codeText = cm.getValue();
+                    const streamFlag = /stream\s*=\s*True/i.test(codeText);
+                    if (streamFlag) {
+                        // Fallback: minimal dump-shaped config so shouldUseStream + server load agree
+                        advConfig = { crawler_config: { type: 'CrawlerRunConfig', params: { stream: true } } };
+                    } else {
+                        updateStatus('error');
+                        document.querySelector('#response-content code').textContent =
+                            JSON.stringify({ error: err.message }, null, 2);
+                        forceHighlightElement(document.querySelector('#response-content code'));
+                        return; // stop run
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
Fixes #2222

The playground validated the Advanced Config editor via `/config/dump` for every endpoint, including `md` and `llm` where the panel is hidden and its result is never used. That pre-flight sends the legacy `{ type, code }` protocol, which the server removed in the 0.8.x security fixes and rejects loudly since 0.9.3 (`code` is a forbidden field on untrusted requests). The fallback only rescued `crawl`, so `md`/`llm` (and `crawl_stream`) aborted with `field 'code' is not permitted on CrawlerRunConfig from an untrusted request` before their request was ever sent.

The fix skips the `/config/dump` pre-flight unless the endpoint is `crawl` or `crawl_stream`. Behavior inside the guard is unchanged.

## List of files changed and why
- `deploy/docker/static/playground/index.html` - wrap the `/config/dump` pre-flight in `runCrawl()` with an endpoint guard so `md`/`llm` skip it; drop the now-redundant `isCrawlEndpoint` check inside the catch fallback.

## How Has This Been Tested?
Manually verified and tested the playground
and
Drove the real playground UI with headless Chromium against a clean `unclecode/crawl4ai:0.9.3` Docker container (the affected release):

- `md`: fit / raw / bm25+query / llm-filter, both cache modes - all succeed; only `POST /md` fires, no `/config/dump` call
- `llm` with a question - succeeds via `GET /llm/{url}?q=...`
- `crawl` with the default snippet - behavior unchanged: `/config/dump` -> fallback -> `/crawl`, succeeds
- `crawl_stream` with the default snippet - now works (streams from `/crawl/stream`; on stock 0.9.3 it aborted like `md`)
- Error paths intact: an invalid URL surfaces the server error; editor content can no longer affect `md`/`llm`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added/updated unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
