### PR TITLE
fix(robots): Disallow /*? should only match URLs with query strings

### DIFF
--- a/crawl4ai/utils.py
+++ b/crawl4ai/utils.py
@@ -55,21 +55,43 @@ from urllib.robotparser import RuleLine
 import re
 
 original_applies_to = RuleLine.applies_to
+original_ruleline_init = RuleLine.__init__
+
+
+def _has_query_marker(value: str) -> bool:
+    """True if a quoted or raw robots path/URL still carries a '?' query marker."""
+    if not value:
+        return False
+    return "?" in value or "%3F" in value.upper()
+
+
+def patched_ruleline_init(self, path, allowance):
+    # urlparse/urlunparse drops an empty query, so '/*?' collapses to '/*'.
+    # Preserve a trailing '?' so query-only rules keep their meaning (#2225).
+    keep_query_marker = isinstance(path, str) and path.endswith("?")
+    original_ruleline_init(self, path, allowance)
+    if keep_query_marker and not _has_query_marker(self.path):
+        self.path += "%3F"
+
 
 def patched_applies_to(self, filename):
-   # Handle wildcards in paths
-   if '*' in self.path or '%2A' in self.path or self.path in ("*", "%2A"):
-       pattern = self.path.replace('%2A', '*')
-       pattern = re.escape(pattern).replace('\\*', '.*')
-       pattern = '^' + pattern
-       if pattern.endswith('\\$'):
-           pattern = pattern[:-2] + '$'
-       try:
-           return bool(re.match(pattern, filename))
-       except re.error:
-           return original_applies_to(self, filename)
-   return original_applies_to(self, filename)
+    # Disallow: /*? (and similar) must only match URLs that actually carry a query.
+    if _has_query_marker(self.path) and not _has_query_marker(filename):
+        return False
+    # Handle wildcards in paths
+    if '*' in self.path or '%2A' in self.path or self.path in ("*", "%2A"):
+        pattern = self.path.replace('%2A', '*')
+        pattern = re.escape(pattern).replace('\\*', '.*')
+        pattern = '^' + pattern
+        if pattern.endswith('\\$'):
+            pattern = pattern[:-2] + '$'
+        try:
+            return bool(re.match(pattern, filename))
+        except re.error:
+            return original_applies_to(self, filename)
+    return original_applies_to(self, filename)
 
+RuleLine.__init__ = patched_ruleline_init
 RuleLine.applies_to = patched_applies_to
 # Monkey patch ends
 
@@ -361,7 +383,13 @@ class RobotsParser:
         # If parser can't read rules, allow access
         if not parser.mtime():
             return True
-            
+
+        # urllib.robotparser drops an empty query component, so a URL like
+        # https://host/page? is normalized to /page. Keep a query marker so
+        # rules such as Disallow: /*? still see that the URL carries '?'.
+        if "?" in url and not parsed.query:
+            url = f"{url}="
+
         return parser.can_fetch(user_agent, url)
 
     def clear_cache(self):

--- a/crawl4ai/utils.py
+++ b/crawl4ai/utils.py
@@ -387,8 +387,13 @@ class RobotsParser:
         # urllib.robotparser drops an empty query component, so a URL like
         # https://host/page? is normalized to /page. Keep a query marker so
         # rules such as Disallow: /*? still see that the URL carries '?'.
-        if "?" in url and not parsed.query:
-            url = f"{url}="
+        # Only look at the pre-fragment part so "? in fragment" is not treated
+        # as a query, and rebuild via urlunparse so page?#frag becomes page?=#frag
+        # instead of corrupting the fragment. Bare RobotFileParser.can_fetch
+        # still allows page? — this rewrite is RobotsParser-only.
+        before_hash = url.split("#", 1)[0]
+        if "?" in before_hash and not parsed.query:
+            url = urlunparse(parsed._replace(query="="))
 
         return parser.can_fetch(user_agent, url)
 

--- a/tests/general/test_robot_parser.py
+++ b/tests/general/test_robot_parser.py
@@ -182,6 +182,8 @@ async def test_disallow_query_wildcard_only_blocks_query_urls():
         assert await parser.can_fetch("https://shop.example/?s=search", "*") is False
         # Empty-but-present query still counts as carrying a query string
         assert await parser.can_fetch("https://shop.example/page?", "*") is False
+        # page?#frag has a query marker before the fragment and must stay blocked
+        assert await parser.can_fetch("https://shop.example/page?#frag", "*") is False
         print("✓ Disallow: /*? blocks query URLs only (issue #2225)")
     finally:
         shutil.rmtree(temp_dir)

--- a/tests/general/test_robot_parser.py
+++ b/tests/general/test_robot_parser.py
@@ -1,11 +1,18 @@
 from crawl4ai.utils import RobotsParser
-            
+from urllib.robotparser import RobotFileParser
+
 import asyncio
 import aiohttp
 from aiohttp import web
 import tempfile
 import shutil
 import os, sys, time, json
+
+
+# Ecommerce-style rule: block URLs that carry a query string, not the whole site.
+DISALLOW_QUERY_WILDCARD_ROBOTS = """User-agent: *
+Disallow: /*?
+"""
 
 
 async def test_robots_parser():
@@ -148,8 +155,40 @@ Allow: /public/
         shutil.rmtree(temp_dir)
         print("\nTest cleanup completed")
 
+def test_robotfileparser_disallow_query_wildcard():
+    """RuleLine patch: Disallow: /*? only matches URLs that carry a query string."""
+    parser = RobotFileParser()
+    parser.parse(DISALLOW_QUERY_WILDCARD_ROBOTS.splitlines())
+    assert parser.can_fetch("*", "https://shop.example/page") is True
+    assert parser.can_fetch("*", "https://shop.example/") is True
+    assert parser.can_fetch("*", "https://shop.example/products/shoes") is True
+    assert parser.can_fetch("*", "https://shop.example/page?q=1") is False
+    assert parser.can_fetch("*", "https://shop.example/?s=search") is False
+
+
+async def test_disallow_query_wildcard_only_blocks_query_urls():
+    """RobotsParser.can_fetch: Disallow: /*? must not collapse to Disallow: /* (#2225)."""
+    temp_dir = tempfile.mkdtemp()
+    try:
+        parser = RobotsParser(cache_dir=temp_dir)
+        parser._cache_rules("shop.example", DISALLOW_QUERY_WILDCARD_ROBOTS)
+
+        assert await parser.can_fetch("https://shop.example/page", "*") is True
+        assert await parser.can_fetch("https://shop.example/", "*") is True
+        assert await parser.can_fetch("https://shop.example/products/shoes", "*") is True
+        assert await parser.can_fetch("https://shop.example/page?q=1", "*") is False
+        assert await parser.can_fetch("https://shop.example/?s=search", "*") is False
+        # Empty-but-present query still counts as carrying a query string
+        assert await parser.can_fetch("https://shop.example/page?", "*") is False
+        print("✓ Disallow: /*? blocks query URLs only (issue #2225)")
+    finally:
+        shutil.rmtree(temp_dir)
+
+
 async def main():
     try:
+        test_robotfileparser_disallow_query_wildcard()
+        await test_disallow_query_wildcard_only_blocks_query_urls()
         await test_robots_parser()
     except Exception as e:
         print(f"Test failed: {str(e)}")

--- a/tests/general/test_robot_parser.py
+++ b/tests/general/test_robot_parser.py
@@ -7,6 +7,7 @@ from aiohttp import web
 import tempfile
 import shutil
 import os, sys, time, json
+import pytest
 
 
 # Ecommerce-style rule: block URLs that carry a query string, not the whole site.
@@ -166,6 +167,7 @@ def test_robotfileparser_disallow_query_wildcard():
     assert parser.can_fetch("*", "https://shop.example/?s=search") is False
 
 
+@pytest.mark.asyncio
 async def test_disallow_query_wildcard_only_blocks_query_urls():
     """RobotsParser.can_fetch: Disallow: /*? must not collapse to Disallow: /* (#2225)."""
     temp_dir = tempfile.mkdtemp()


### PR DESCRIPTION
Fixes #2225.

## Summary

`urllib.robotparser.RuleLine` normalizes rule paths with `urlparse` / `urlunparse`, which **drops an empty query**. Combined with crawl4ai's wildcard monkey-patch, a common ecommerce rule:

```
Disallow: /*?
```

was collapsed to `Disallow: /*`. After the `*` / `%2A` regex rewrite that became `^/.*`, so **the entire site was disallowed** — including URLs with no query string.

The intent of `/*?` is only to block URLs that actually carry a query string (for example `/page?q=1` or `/?s=search`), not `/page` or `/`.

## Fix

- Preserve a trailing empty `?` on `RuleLine` paths as `%3F` after stdlib init.
- In `patched_applies_to`, refuse to match a query-marker rule against a filename that has no query marker.
- In `RobotsParser.can_fetch`, when the URL has `?` in the pre-fragment part but an empty query after parse, rebuild via `urlunparse` with `query=\"=\"` so `page?#frag` stays `page?=#frag` (not fragment corruption). Bare `RobotFileParser.can_fetch` still allows `page?`; this rewrite is `RobotsParser`-only.

## Tests

`tests/general/test_robot_parser.py`: non-query URLs allowed; `?q=`, `?s=`, `page?`, and `page?#frag` blocked under `Disallow: /*?`.