### PR TITLE
fix(extraction): retain errors for empty LLM responses

### DIFF
--- a/crawl4ai/extraction_strategy.py
+++ b/crawl4ai/extraction_strategy.py
@@ -716,10 +716,17 @@ class LLMExtractionStrategy(ExtractionStrategy):
                 content = response.choices[0].message.content
                 blocks = None
 
-                if not content:
+                if not content or not content.strip():
                     finish_reason = getattr(response.choices[0], "finish_reason", "unknown")
-                    blocks = [{"index": 0, "error": True, "tags": ["error"],
-                               "content": f"LLM returned no content (finish_reason: {finish_reason})"}]
+                    # Do not let success normalization overwrite this error below.
+                    return [
+                        {
+                            "index": ix,
+                            "error": True,
+                            "tags": ["error"],
+                            "content": f"LLM returned no content (finish_reason: {finish_reason})",
+                        }
+                    ]
                 elif self.force_json_response:
                     blocks = json.loads(_strip_markdown_fences(content))
                     if isinstance(blocks, dict):
@@ -919,10 +926,17 @@ class LLMExtractionStrategy(ExtractionStrategy):
                 content = response.choices[0].message.content
                 blocks = None
 
-                if not content:
+                if not content or not content.strip():
                     finish_reason = getattr(response.choices[0], "finish_reason", "unknown")
-                    blocks = [{"index": 0, "error": True, "tags": ["error"],
-                               "content": f"LLM returned no content (finish_reason: {finish_reason})"}]
+                    # Do not let success normalization overwrite this error below.
+                    return [
+                        {
+                            "index": ix,
+                            "error": True,
+                            "tags": ["error"],
+                            "content": f"LLM returned no content (finish_reason: {finish_reason})",
+                        }
+                    ]
                 elif self.force_json_response:
                     blocks = json.loads(_strip_markdown_fences(content))
                     if isinstance(blocks, dict):

--- a/tests/unit/test_llm_extraction_empty_response.py
+++ b/tests/unit/test_llm_extraction_empty_response.py
@@ -1,0 +1,86 @@
+"""Empty provider responses must not be exposed as successful extracted records."""
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from litellm import ModelResponse
+
+from crawl4ai import LLMConfig, LLMExtractionStrategy
+
+
+def make_response(content, finish_reason="stop"):
+    return ModelResponse(
+        choices=[
+            {
+                "message": {"role": "assistant", "content": content},
+                "finish_reason": finish_reason,
+            }
+        ],
+        usage={"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    )
+
+
+async def extract_response(monkeypatch, response, async_mode, json_mode):
+    strategy = LLMExtractionStrategy(
+        llm_config=LLMConfig(provider="openai/test-model", api_token="test-only"),
+        force_json_response=json_mode,
+    )
+    if async_mode:
+        completion = AsyncMock(return_value=response)
+        monkeypatch.setattr(
+            "crawl4ai.utils.aperform_completion_with_backoff", completion
+        )
+        blocks = await strategy.aextract("https://example.com", 7, "page text")
+        completion.assert_awaited_once()
+    else:
+        completion = Mock(return_value=response)
+        monkeypatch.setattr(
+            "crawl4ai.extraction_strategy.perform_completion_with_backoff", completion
+        )
+        blocks = strategy.extract("https://example.com", 7, "page text")
+        completion.assert_called_once()
+    return blocks, strategy
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("async_mode", [False, True], ids=["sync", "async"])
+@pytest.mark.parametrize("json_mode", [False, True], ids=["blocks", "json"])
+@pytest.mark.parametrize("content", [None, "", " \n\t"])
+@pytest.mark.parametrize("finish_reason", ["stop", "length", "content_filter"])
+async def test_empty_response_is_an_error(
+    monkeypatch, async_mode, json_mode, content, finish_reason
+):
+    blocks, strategy = await extract_response(
+        monkeypatch, make_response(content, finish_reason), async_mode, json_mode
+    )
+
+    assert len(blocks) == 1
+    assert blocks[0]["error"] is True
+    assert blocks[0]["index"] == 7
+    assert blocks[0]["tags"] == ["error"]
+    assert finish_reason in blocks[0]["content"]
+    # A failed extraction still consumes the usage reported by the provider.
+    assert len(strategy.usages) == 1
+    assert strategy.total_usage.prompt_tokens == 10
+    assert strategy.total_usage.completion_tokens == 5
+    assert strategy.total_usage.total_tokens == 15
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("async_mode", [False, True], ids=["sync", "async"])
+@pytest.mark.parametrize("json_mode", [False, True], ids=["blocks", "json"])
+@pytest.mark.parametrize("empty_list", [False, True])
+async def test_valid_response_keeps_success_semantics(
+    monkeypatch, async_mode, json_mode, empty_list
+):
+    content = "[]" if empty_list else '[{"title": "A useful page"}]'
+    if not json_mode:
+        content = f"<blocks>{content}</blocks>"
+    blocks, strategy = await extract_response(
+        monkeypatch, make_response(content), async_mode, json_mode
+    )
+
+    assert blocks == (
+        [] if empty_list else [{"title": "A useful page", "error": False}]
+    )
+    assert strategy.total_usage.total_tokens == 15


### PR DESCRIPTION
## Summary

Keep empty LLM completions marked as extraction errors in both `LLMExtractionStrategy.extract` and `aextract`.

When a provider returns `content=None` or `""` (for example with `finish_reason="length"` or `"content_filter"`), the existing code creates an error block and then overwrites its `error` flag with `False` in the successful-block loop. Whitespace-only content instead disappears as an empty list. Downstream code filtering successful records by `error` can therefore accept diagnostics as extracted data or miss the failure entirely.

Return the empty-response diagnostic before successful-result normalization, retain the actual section index and finish reason, and treat whitespace-only content as empty. Usage accounting still runs before this return. A valid model response containing `[]` continues to mean successful extraction with no matching records.

## Files changed

- `crawl4ai/extraction_strategy.py`: the same narrow empty-content guard in sync and async extraction.
- `tests/unit/test_llm_extraction_empty_response.py`: parameterized regressions using real LiteLLM `ModelResponse` objects with mocked completion boundaries; no model API calls.

## Validation

- Before the fix: **36 regression cases fail**, while eight valid-response controls pass.
- After the fix: all **44 new cases pass**, covering sync/async, JSON/XML-block parsing, None/empty/whitespace content, stop/length/content_filter reasons, section indices, usage preservation and valid empty result lists.
- Full `tests/unit` suite: **121 passed** on Python 3.13.14 after installing the optional `pypdf` dependency needed by existing PDF tests.
- Test-file Black check (`--target-version py310`), compilation of both changed Python files, and `git diff --check` pass. The existing source file was not reformatted wholesale.

Command: `LITELLM_LOCAL_MODEL_COST_MAP=True uv run --no-sync pytest tests/unit -q`.

Based on and targeting `develop`. Found by source inspection; no existing issue is claimed as resolved. Older #1450 addressed alternative response fields rather than this error-flag overwrite.

No live browser crawl or model-provider validation is claimed.