### PR TITLE
Fix: O(n²) parent lookup in BFS and duplicate URL enqueue in BestFirst

### DIFF
--- a/crawl4ai/deep_crawling/bff_strategy.py
+++ b/crawl4ai/deep_crawling/bff_strategy.py
@@ -216,6 +216,8 @@ class BestFirstCrawlingStrategy(DeepCrawlStrategy):
             queue_items = self._resume_state.get("queue_items", [])
             for item in queue_items:
                 await queue.put((item["score"], item["depth"], item["url"], item["parent_url"]))
+            # `queued` tracks every URL ever pushed onto the queue
+            queued: Set[str] = set(visited) | {item["url"] for item in queue_items}
             # Initialize shadow list if callback is set
             if self._on_state_change:
                 self._queue_shadow = [
@@ -227,6 +229,7 @@ class BestFirstCrawlingStrategy(DeepCrawlStrategy):
             initial_score = self.url_scorer.score(start_url) if self.url_scorer else 0
             await queue.put((-initial_score, 0, start_url, None))
             visited: Set[str] = set()
+            queued: Set[str] = {start_url}
             depths: Dict[str, int] = {start_url: 0}
             # Initialize shadow list if callback is set
             if self._on_state_change:
@@ -313,6 +316,9 @@ class BestFirstCrawlingStrategy(DeepCrawlStrategy):
                     await self.link_discovery(result, url, depth, visited, new_links, depths)
                     
                     for new_url, new_parent in new_links:
+                        # Skip URLs already sitting in the queue
+                        if new_url in queued:
+                            continue
                         new_depth = depths.get(new_url, depth + 1)
                         new_score = self.url_scorer.score(new_url) if self.url_scorer else 0
                         # Skip URLs with scores below the threshold
@@ -322,6 +328,7 @@ class BestFirstCrawlingStrategy(DeepCrawlStrategy):
                             )
                             self.stats.urls_skipped += 1
                             continue
+                        queued.add(new_url)
                         queue_item = (-new_score, new_depth, new_url, new_parent)
                         await queue.put(queue_item)
                         # Add to shadow list if tracking

--- a/crawl4ai/deep_crawling/bfs_strategy.py
+++ b/crawl4ai/deep_crawling/bfs_strategy.py
@@ -248,6 +248,7 @@ class BFSDeepCrawlStrategy(DeepCrawlStrategy):
 
             next_level: List[Tuple[str, Optional[str]]] = []
             urls = [url for url, _ in current_level]
+            parent_by_url = dict(current_level)
 
             # Clone the config to disable deep crawling recursion and enforce batch mode.
             batch_config = config.clone(deep_crawl_strategy=None, stream=False)
@@ -258,7 +259,7 @@ class BFSDeepCrawlStrategy(DeepCrawlStrategy):
                 depth = depths.get(url, 0)
                 result.metadata = result.metadata or {}
                 result.metadata["depth"] = depth
-                parent_url = next((parent for (u, parent) in current_level if u == url), None)
+                parent_url = parent_by_url.get(url)
                 result.metadata["parent_url"] = parent_url
                 results.append(result)
 
@@ -336,11 +337,12 @@ class BFSDeepCrawlStrategy(DeepCrawlStrategy):
 
             next_level: List[Tuple[str, Optional[str]]] = []
             urls = [url for url, _ in current_level]
+            parent_by_url = dict(current_level)
             visited.update(urls)
 
             stream_config = config.clone(deep_crawl_strategy=None, stream=True)
             stream_gen = await crawler.arun_many(urls=urls, config=stream_config)
-            
+
             # Keep track of processed results for this batch
             results_count = 0
             async for result in stream_gen:
@@ -348,7 +350,7 @@ class BFSDeepCrawlStrategy(DeepCrawlStrategy):
                 depth = depths.get(url, 0)
                 result.metadata = result.metadata or {}
                 result.metadata["depth"] = depth
-                parent_url = next((parent for (u, parent) in current_level if u == url), None)
+                parent_url = parent_by_url.get(url)
                 result.metadata["parent_url"] = parent_url
                 
                 # Count only successful crawls


### PR DESCRIPTION
Fixes #2242

## Summary
Fixes two related inefficiencies in the deep-crawl strategies found while
integrating `BestFirstCrawlingStrategy` for site-wide crawling:

1. `BFSDeepCrawlStrategy._arun_batch`/`_arun_stream` re-scanned the entire
   `current_level` list to find each result's parent URL - O(n²) for a level
   of size n. Replaced with a dict built once per level (`dict(current_level)`),
   O(n).
2. `BestFirstCrawlingStrategy` only tracked `visited` (updated at dequeue
   time), so a URL discovered via multiple parent pages before being crawled
   could be pushed onto the priority queue more than once - wasted scorer
   calls and queue slots. Added a `queued` set updated at enqueue time to
   prevent this.

Both are internal-only fixes - no behavior or public API change, same outputs.

## Files Changed
- `crawl4ai/deep_crawling/bfs_strategy.py` - build `parent_by_url` dict once
  per level in `_arun_batch` and `_arun_stream`, instead of a linear scan per
  result.
- `crawl4ai/deep_crawling/bff_strategy.py` - added a `queued: Set[str]` tracked
  alongside `visited`, checked/updated at the point a URL is pushed onto the
  priority queue (both fresh-start and resume-from-state paths).

## How Has This Been Tested?
- `pytest tests/deep_crawling/ tests/general/test_deep_crawl*.py`: 70 passed,
  0 regressions 
- Isolated benchmark on real production data: pulled djangoproject.com's
  actual `sitemap.xml` (1000 URLs, one legitimate request, no crawling) and
  timed the parent-lookup code directly - 11.69ms (old) → 0.08ms (new), ~145x.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added/updated unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
