### PR TITLE
docs: fix dead micronaut guide URL in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ async def main():
     
     async with AsyncWebCrawler(config=browser_config) as crawler:
         result = await crawler.arun(
-            url="https://docs.micronaut.io/4.9.9/guide/",
+            url="https://docs.micronaut.io/latest/guide/",
             config=run_config
         )
         print(len(result.markdown.raw_markdown))


### PR DESCRIPTION
The heuristic markdown generation example in README.md crawls `https://docs.micronaut.io/4.9.9/guide/`, which now returns a 404 (the Micronaut docs no longer serve that pinned version path).

Verified with `curl -sI https://docs.micronaut.io/4.9.9/guide/` (404) vs `curl -sI https://docs.micronaut.io/latest/guide/` (200), and updated the example to use the `latest` path.