### PR TITLE
fix: preserve scraping metadata

### DIFF
--- a/crawl4ai/async_url_seeder.py
+++ b/crawl4ai/async_url_seeder.py
@@ -225,7 +225,10 @@ def _parse_head(src: str) -> Dict[str, Any]:
                 except json.JSONDecodeError:
                     pass
         # Extract html lang attribute
-        html_elem = doc.find(".//html")
+        # ``fromstring`` returns the document's ``<html>`` element for a
+        # complete HTML document. ``.//html`` only searches descendants, so
+        # it misses that root element and drops its language declaration.
+        html_elem = doc if doc.tag.lower() == "html" else doc.find(".//html")
         if html_elem is not None:
             info["lang"] = html_elem.attrib.get("lang", "")
         return info

--- a/crawl4ai/content_scraping_strategy.py
+++ b/crawl4ai/content_scraping_strategy.py
@@ -84,8 +84,6 @@ def fetch_image_file_size(img, base_url):
             return None
     except InvalidSchema:
         return None
-    finally:
-        return
 
 
 class ContentScrapingStrategy(ABC):

--- a/tests/unit/test_content_scraping_helpers.py
+++ b/tests/unit/test_content_scraping_helpers.py
@@ -1,0 +1,11 @@
+from unittest.mock import Mock, patch
+
+from crawl4ai.content_scraping_strategy import fetch_image_file_size
+
+
+def test_fetch_image_file_size_returns_content_length():
+    image = {"src": "/image.png"}
+    response = Mock(status_code=200, headers={"Content-Length": "1024"})
+
+    with patch("crawl4ai.content_scraping_strategy.requests.head", return_value=response):
+        assert fetch_image_file_size(image, "https://example.com/page") == "1024"

--- a/tests/unit/test_sitemap_namespace_parsing.py
+++ b/tests/unit/test_sitemap_namespace_parsing.py
@@ -15,7 +15,15 @@ class _FakeBM25:
 
 sys.modules.setdefault("rank_bm25", SimpleNamespace(BM25Okapi=_FakeBM25))
 
-from crawl4ai.async_url_seeder import AsyncUrlSeeder
+from crawl4ai.async_url_seeder import AsyncUrlSeeder, _parse_head
+
+
+def test_parse_head_reads_language_from_document_root():
+    info = _parse_head(
+        '<html lang="tr"><head><title>Başlık</title></head><body></body></html>'
+    )
+
+    assert info["lang"] == "tr"
 
 
 class DummyResponse:


### PR DESCRIPTION
## Summary

Fix two small scraping metadata issues:

- Preserve the root `<html lang>` attribute when lxml parses a complete HTML document.
- Return successful image `Content-Length` values instead of discarding them.

## List of files changed and why

- `crawl4ai/async_url_seeder.py` - Preserve the language declaration on the root HTML element.
- `crawl4ai/content_scraping_strategy.py` - Remove a `finally: return` that always discarded successful image-size results.
- `tests/unit/test_sitemap_namespace_parsing.py` - Add regression coverage for root-level HTML language extraction.
- `tests/unit/test_content_scraping_helpers.py` - Add regression coverage for successful image-size extraction.

## How Has This Been Tested?

- Verified both corrected behaviors with focused local checks.
- Compiled the modified Python modules successfully.
- The full pytest suite was not run locally because the project test dependencies were unavailable in the local environment.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added/updated unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes